### PR TITLE
[ROLE-111] — Time-limited membership with automatic expiration

### DIFF
--- a/client/src/api/team.api.ts
+++ b/client/src/api/team.api.ts
@@ -17,6 +17,8 @@ export interface TeamMember {
   avatarData: string | null;
   role: string;
   joinedAt: string;
+  expiresAt: string | null;
+  expired: boolean;
 }
 
 export async function createTeam(
@@ -59,8 +61,9 @@ export async function addTeamMember(
   teamId: string,
   userId: string,
   role: 'TEAM_ADMIN' | 'TEAM_EDITOR' | 'TEAM_VIEWER',
+  expiresAt?: string,
 ): Promise<TeamMember> {
-  const { data } = await api.post(`/teams/${teamId}/members`, { userId, role });
+  const { data } = await api.post(`/teams/${teamId}/members`, { userId, role, ...(expiresAt && { expiresAt }) });
   return data;
 }
 
@@ -79,4 +82,12 @@ export async function removeTeamMember(
 ): Promise<{ removed: boolean }> {
   const { data } = await api.delete(`/teams/${teamId}/members/${userId}`);
   return data;
+}
+
+export async function updateTeamMemberExpiry(
+  teamId: string,
+  userId: string,
+  expiresAt: string | null,
+): Promise<void> {
+  await api.patch(`/teams/${teamId}/members/${userId}/expiry`, { expiresAt });
 }

--- a/client/src/api/tenant.api.ts
+++ b/client/src/api/tenant.api.ts
@@ -24,6 +24,8 @@ export interface TenantUser {
   smsMfaEnabled: boolean;
   enabled: boolean;
   createdAt: string;
+  expiresAt: string | null;
+  expired: boolean;
 }
 
 export interface TenantMembership {
@@ -41,6 +43,7 @@ export interface CreateUserData {
   password: string;
   role: TenantRole;
   sendWelcomeEmail?: boolean;
+  expiresAt?: string;
 }
 
 export interface CreateUserResult {
@@ -123,8 +126,9 @@ export async function inviteUser(
   tenantId: string,
   email: string,
   role: TenantRole,
+  expiresAt?: string,
 ): Promise<InviteResult> {
-  const { data } = await api.post(`/tenants/${tenantId}/invite`, { email, role });
+  const { data } = await api.post(`/tenants/${tenantId}/invite`, { email, role, ...(expiresAt && { expiresAt }) });
   return data;
 }
 
@@ -194,4 +198,12 @@ export async function adminChangeUserPassword(
 ): Promise<{ recoveryKey: string }> {
   const { data } = await api.put(`/tenants/${tenantId}/users/${userId}/password`, { newPassword, verificationId });
   return data;
+}
+
+export async function updateMembershipExpiry(
+  tenantId: string,
+  userId: string,
+  expiresAt: string | null,
+): Promise<void> {
+  await api.patch(`/tenants/${tenantId}/users/${userId}/expiry`, { expiresAt });
 }

--- a/client/src/components/Dialogs/CreateUserDialog.tsx
+++ b/client/src/components/Dialogs/CreateUserDialog.tsx
@@ -30,6 +30,7 @@ export default function CreateUserDialog({ open, onClose }: CreateUserDialogProp
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [role, setRole] = useState<TenantRole>('MEMBER');
+  const [expiresAt, setExpiresAt] = useState('');
   const [sendWelcomeEmail, setSendWelcomeEmail] = useState(false);
   const [emailConfigured, setEmailConfigured] = useState(false);
   const { loading, error, setError, clearError, run } = useAsyncAction();
@@ -71,6 +72,7 @@ export default function CreateUserDialog({ open, onClose }: CreateUserDialogProp
         password,
         role,
         sendWelcomeEmail: emailConfigured ? sendWelcomeEmail : false,
+        expiresAt: expiresAt ? new Date(expiresAt).toISOString() : undefined,
       });
       setResult(res);
     }, 'Failed to create user');
@@ -82,6 +84,7 @@ export default function CreateUserDialog({ open, onClose }: CreateUserDialogProp
     setPassword('');
     setConfirmPassword('');
     setRole('MEMBER');
+    setExpiresAt('');
     setSendWelcomeEmail(false);
     clearError();
     setResult(null);
@@ -206,6 +209,16 @@ export default function CreateUserDialog({ open, onClose }: CreateUserDialogProp
               ))}
             </Select>
           </FormControl>
+          <TextField
+            label="Access Expires At"
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            fullWidth
+            size="small"
+            slotProps={{ inputLabel: { shrink: true } }}
+            helperText="Leave empty for permanent access"
+          />
           {emailConfigured && (
             <FormControlLabel
               control={

--- a/client/src/components/Dialogs/InviteDialog.tsx
+++ b/client/src/components/Dialogs/InviteDialog.tsx
@@ -15,6 +15,7 @@ interface InviteDialogProps {
 export default function InviteDialog({ open, onClose }: InviteDialogProps) {
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<TenantRole>('MEMBER');
+  const [expiresAt, setExpiresAt] = useState('');
   const { loading, error, setError, run } = useAsyncAction();
   const inviteUser = useTenantStore((s) => s.inviteUser);
 
@@ -29,7 +30,7 @@ export default function InviteDialog({ open, onClose }: InviteDialogProps) {
     }
 
     const ok = await run(async () => {
-      await inviteUser(email.trim(), role);
+      await inviteUser(email.trim(), role, expiresAt ? new Date(expiresAt).toISOString() : undefined);
     }, 'Failed to invite user');
     if (ok) handleClose();
   };
@@ -37,6 +38,7 @@ export default function InviteDialog({ open, onClose }: InviteDialogProps) {
   const handleClose = () => {
     setEmail('');
     setRole('MEMBER');
+    setExpiresAt('');
     setError('');
     onClose();
   };
@@ -68,6 +70,16 @@ export default function InviteDialog({ open, onClose }: InviteDialogProps) {
               ))}
             </Select>
           </FormControl>
+          <TextField
+            label="Access Expires At"
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            fullWidth
+            size="small"
+            slotProps={{ inputLabel: { shrink: true } }}
+            helperText="Leave empty for permanent access"
+          />
         </Box>
       </DialogContent>
       <DialogActions>

--- a/client/src/components/Settings/TeamSection.tsx
+++ b/client/src/components/Settings/TeamSection.tsx
@@ -4,7 +4,7 @@ import {
   Grid, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions,
   Alert, CircularProgress, Select, MenuItem, FormControl, InputLabel,
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
-  Divider, Typography, IconButton,
+  Divider, Typography, IconButton, TextField,
 } from '@mui/material';
 import {
   Add as AddIcon, Delete as DeleteIcon, Groups as GroupsIcon,
@@ -41,6 +41,7 @@ export default function TeamSection({ onNavigateToTab }: TeamSectionProps) {
   const addMember = useTeamStore((s) => s.addMember);
   const updateMemberRole = useTeamStore((s) => s.updateMemberRole);
   const removeMember = useTeamStore((s) => s.removeMember);
+  const updateMemberExpiry = useTeamStore((s) => s.updateMemberExpiry);
 
   const [teamDialogOpen, setTeamDialogOpen] = useState(false);
   const [editingTeam, setEditingTeam] = useState<TeamData | null>(null);
@@ -50,6 +51,12 @@ export default function TeamSection({ onNavigateToTab }: TeamSectionProps) {
   const [error, setError] = useState('');
   const [addMemberRole, setAddMemberRole] = useState<'TEAM_ADMIN' | 'TEAM_EDITOR' | 'TEAM_VIEWER'>('TEAM_VIEWER');
   const [addingMember, setAddingMember] = useState(false);
+
+  // Team member expiry dialog
+  const [teamExpiryOpen, setTeamExpiryOpen] = useState(false);
+  const [teamExpiryTarget, setTeamExpiryTarget] = useState<{ teamId: string; userId: string; name: string; expiresAt: string | null } | null>(null);
+  const [teamExpiryValue, setTeamExpiryValue] = useState('');
+  const [savingTeamExpiry, setSavingTeamExpiry] = useState(false);
 
   const hasTenant = Boolean(user?.tenantId);
 
@@ -275,6 +282,7 @@ export default function TeamSection({ onNavigateToTab }: TeamSectionProps) {
                           <TableRow>
                             <TableCell>User</TableCell>
                             <TableCell>Role</TableCell>
+                            <TableCell>Expires</TableCell>
                             {isTeamAdmin && <TableCell align="right">Actions</TableCell>}
                           </TableRow>
                         </TableHead>
@@ -313,6 +321,38 @@ export default function TeamSection({ onNavigateToTab }: TeamSectionProps) {
                                   </Select>
                                 ) : (
                                   <Chip label={roleLabel(m.role)} size="small" variant="outlined" />
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                {m.expiresAt ? (
+                                  <Chip
+                                    label={m.expired ? 'Expired' : new Date(m.expiresAt).toLocaleDateString()}
+                                    color={m.expired ? 'error' : 'default'}
+                                    size="small"
+                                    variant="outlined"
+                                    {...(isTeamAdmin && m.userId !== user?.id ? {
+                                      onClick: () => {
+                                        setTeamExpiryTarget({ teamId: selectedTeam.id, userId: m.userId, name: m.username || m.email, expiresAt: m.expiresAt });
+                                        setTeamExpiryValue(m.expiresAt ? new Date(m.expiresAt).toISOString().slice(0, 16) : '');
+                                        setTeamExpiryOpen(true);
+                                      },
+                                      sx: { cursor: 'pointer' },
+                                    } : {})}
+                                  />
+                                ) : isTeamAdmin && m.userId !== user?.id ? (
+                                  <Chip
+                                    label="Set"
+                                    size="small"
+                                    variant="outlined"
+                                    sx={{ cursor: 'pointer' }}
+                                    onClick={() => {
+                                      setTeamExpiryTarget({ teamId: selectedTeam.id, userId: m.userId, name: m.username || m.email, expiresAt: null });
+                                      setTeamExpiryValue('');
+                                      setTeamExpiryOpen(true);
+                                    }}
+                                  />
+                                ) : (
+                                  <Typography variant="caption" color="text.secondary">—</Typography>
                                 )}
                               </TableCell>
                               {isTeamAdmin && (
@@ -379,6 +419,61 @@ export default function TeamSection({ onNavigateToTab }: TeamSectionProps) {
         <DialogActions>
           <Button onClick={() => setRemoveTarget(null)}>Cancel</Button>
           <Button onClick={handleRemoveMember} color="error" variant="contained">Remove</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Team member expiry dialog */}
+      <Dialog open={teamExpiryOpen} onClose={() => setTeamExpiryOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Member Expiration — {teamExpiryTarget?.name}</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+            <TextField
+              label="Expires At"
+              type="datetime-local"
+              value={teamExpiryValue}
+              onChange={(e) => setTeamExpiryValue(e.target.value)}
+              fullWidth
+              size="small"
+              slotProps={{ inputLabel: { shrink: true } }}
+              helperText="Clear to remove expiration"
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          {teamExpiryTarget?.expiresAt && (
+            <Button
+              color="warning"
+              disabled={savingTeamExpiry}
+              onClick={async () => {
+                if (!teamExpiryTarget) return;
+                setSavingTeamExpiry(true);
+                try {
+                  await updateMemberExpiry(teamExpiryTarget.teamId, teamExpiryTarget.userId, null);
+                  setTeamExpiryOpen(false);
+                } catch { /* ignore */ }
+                setSavingTeamExpiry(false);
+              }}
+            >
+              Remove Expiration
+            </Button>
+          )}
+          <Box sx={{ flex: 1 }} />
+          <Button onClick={() => setTeamExpiryOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            disabled={savingTeamExpiry || !teamExpiryValue}
+            onClick={async () => {
+              if (!teamExpiryTarget || !teamExpiryValue) return;
+              setSavingTeamExpiry(true);
+              try {
+                await updateMemberExpiry(teamExpiryTarget.teamId, teamExpiryTarget.userId, new Date(teamExpiryValue).toISOString());
+                setTeamExpiryOpen(false);
+              } catch { /* ignore */ }
+              setSavingTeamExpiry(false);
+            }}
+          >
+            {savingTeamExpiry ? 'Saving...' : 'Save'}
+          </Button>
         </DialogActions>
       </Dialog>
     </>

--- a/client/src/components/Settings/TenantSection.tsx
+++ b/client/src/components/Settings/TenantSection.tsx
@@ -36,6 +36,7 @@ export default function TenantSection({ onNavigateToTab, onViewUserProfile }: Te
   const updateUserRole = useTenantStore((s) => s.updateUserRole);
   const removeUser = useTenantStore((s) => s.removeUser);
   const toggleUserEnabled = useTenantStore((s) => s.toggleUserEnabled);
+  const updateMembershipExpiry = useTenantStore((s) => s.updateMembershipExpiry);
 
   const [editName, setEditName] = useState('');
   const [nameError, setNameError] = useState('');
@@ -90,6 +91,12 @@ export default function TenantSection({ onNavigateToTab, onViewUserProfile }: Te
   const [changePwdLoading, setChangePwdLoading] = useState(false);
   const [changePwdError, setChangePwdError] = useState('');
   const [recoveryKey, setRecoveryKey] = useState('');
+
+  // Membership expiry dialog
+  const [expiryDialogOpen, setExpiryDialogOpen] = useState(false);
+  const [expiryTarget, setExpiryTarget] = useState<{ id: string; name: string; expiresAt: string | null } | null>(null);
+  const [expiryValue, setExpiryValue] = useState('');
+  const [savingExpiry, setSavingExpiry] = useState(false);
 
   const tenantRole = user?.tenantRole;
   const isAdmin = isAdminOrAbove(tenantRole);
@@ -555,6 +562,7 @@ export default function TenantSection({ onNavigateToTab, onViewUserProfile }: Te
                     <TableCell>User</TableCell>
                     <TableCell>Role</TableCell>
                     <TableCell>MFA</TableCell>
+                    {isAdmin && <TableCell>Expires</TableCell>}
                     {isAdmin && <TableCell>Status</TableCell>}
                     {isAdmin && <TableCell align="right">Actions</TableCell>}
                   </TableRow>
@@ -606,6 +614,20 @@ export default function TenantSection({ onNavigateToTab, onViewUserProfile }: Te
                           <Chip label="None" size="small" />
                         )}
                       </TableCell>
+                      {isAdmin && (
+                        <TableCell>
+                          {u.expiresAt ? (
+                            <Chip
+                              label={u.expired ? 'Expired' : new Date(u.expiresAt).toLocaleDateString()}
+                              color={u.expired ? 'error' : 'default'}
+                              size="small"
+                              variant="outlined"
+                            />
+                          ) : (
+                            <Typography variant="caption" color="text.secondary">—</Typography>
+                          )}
+                        </TableCell>
+                      )}
                       {isAdmin && (
                         <TableCell>
                           {u.id === user?.id ? (
@@ -705,10 +727,76 @@ export default function TenantSection({ onNavigateToTab, onViewUserProfile }: Te
       >
         <MenuItem onClick={openChangeEmail}>Change Email</MenuItem>
         <MenuItem onClick={openChangePwd}>Change Password</MenuItem>
+        <MenuItem onClick={() => {
+          if (menuTargetUser) {
+            const u = users.find((usr) => usr.id === menuTargetUser.id);
+            setExpiryTarget({ id: menuTargetUser.id, name: menuTargetUser.name, expiresAt: u?.expiresAt ?? null });
+            setExpiryValue(u?.expiresAt ? new Date(u.expiresAt).toISOString().slice(0, 16) : '');
+            setExpiryDialogOpen(true);
+            closeAdminMenu();
+          }
+        }}>
+          {users.find((usr) => usr.id === menuTargetUser?.id)?.expiresAt ? 'Change Expiration' : 'Set Expiration'}
+        </MenuItem>
         <MenuItem onClick={() => { if (menuTargetUser) { setRemoveTarget({ id: menuTargetUser.id, name: menuTargetUser.name }); closeAdminMenu(); } }} sx={{ color: 'error.main' }}>
           Remove
         </MenuItem>
       </Menu>
+
+      {/* Membership expiry dialog */}
+      <Dialog open={expiryDialogOpen} onClose={() => setExpiryDialogOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Membership Expiration — {expiryTarget?.name}</DialogTitle>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+            <TextField
+              label="Expires At"
+              type="datetime-local"
+              value={expiryValue}
+              onChange={(e) => setExpiryValue(e.target.value)}
+              fullWidth
+              size="small"
+              slotProps={{ inputLabel: { shrink: true } }}
+              helperText="Clear to remove expiration"
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          {expiryTarget?.expiresAt && (
+            <Button
+              color="warning"
+              disabled={savingExpiry}
+              onClick={async () => {
+                if (!expiryTarget) return;
+                setSavingExpiry(true);
+                try {
+                  await updateMembershipExpiry(expiryTarget.id, null);
+                  setExpiryDialogOpen(false);
+                } catch { /* ignore */ }
+                setSavingExpiry(false);
+              }}
+            >
+              Remove Expiration
+            </Button>
+          )}
+          <Box sx={{ flex: 1 }} />
+          <Button onClick={() => setExpiryDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            disabled={savingExpiry || !expiryValue}
+            onClick={async () => {
+              if (!expiryTarget || !expiryValue) return;
+              setSavingExpiry(true);
+              try {
+                await updateMembershipExpiry(expiryTarget.id, new Date(expiryValue).toISOString());
+                setExpiryDialogOpen(false);
+              } catch { /* ignore */ }
+              setSavingExpiry(false);
+            }}
+          >
+            {savingExpiry ? 'Saving...' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Admin change email dialog */}
       <Dialog open={changeEmailOpen} onClose={() => setChangeEmailOpen(false)} maxWidth="sm" fullWidth>

--- a/client/src/store/teamStore.ts
+++ b/client/src/store/teamStore.ts
@@ -4,6 +4,7 @@ import {
   listTeams, createTeam as createTeamApi, getTeam, updateTeam as updateTeamApi,
   deleteTeam as deleteTeamApi, listTeamMembers, addTeamMember as addTeamMemberApi,
   updateTeamMemberRole as updateMemberRoleApi, removeTeamMember as removeMemberApi,
+  updateTeamMemberExpiry as updateMemberExpiryApi,
 } from '../api/team.api';
 
 interface TeamState {
@@ -22,9 +23,10 @@ interface TeamState {
   selectTeam: (teamId: string) => Promise<void>;
   clearSelectedTeam: () => void;
   fetchMembers: (teamId: string) => Promise<void>;
-  addMember: (teamId: string, userId: string, role: 'TEAM_ADMIN' | 'TEAM_EDITOR' | 'TEAM_VIEWER') => Promise<void>;
+  addMember: (teamId: string, userId: string, role: 'TEAM_ADMIN' | 'TEAM_EDITOR' | 'TEAM_VIEWER', expiresAt?: string) => Promise<void>;
   updateMemberRole: (teamId: string, userId: string, role: 'TEAM_ADMIN' | 'TEAM_EDITOR' | 'TEAM_VIEWER') => Promise<void>;
   removeMember: (teamId: string, userId: string) => Promise<void>;
+  updateMemberExpiry: (teamId: string, userId: string, expiresAt: string | null) => Promise<void>;
   reset: () => void;
 }
 
@@ -94,8 +96,8 @@ export const useTeamStore = create<TeamState>((set, get) => ({
     }
   },
 
-  addMember: async (teamId, userId, role) => {
-    await addTeamMemberApi(teamId, userId, role);
+  addMember: async (teamId, userId, role, expiresAt?) => {
+    await addTeamMemberApi(teamId, userId, role, expiresAt);
     await get().fetchMembers(teamId);
   },
 
@@ -106,6 +108,11 @@ export const useTeamStore = create<TeamState>((set, get) => ({
 
   removeMember: async (teamId, userId) => {
     await removeMemberApi(teamId, userId);
+    await get().fetchMembers(teamId);
+  },
+
+  updateMemberExpiry: async (teamId, userId, expiresAt) => {
+    await updateMemberExpiryApi(teamId, userId, expiresAt);
     await get().fetchMembers(teamId);
   },
 

--- a/client/src/store/tenantStore.ts
+++ b/client/src/store/tenantStore.ts
@@ -7,6 +7,7 @@ import {
   updateUserRole as updateUserRoleApi, removeUser as removeUserApi,
   createTenantUser, toggleUserEnabled as toggleUserEnabledApi,
   getMyTenants, switchTenant as switchTenantApi,
+  updateMembershipExpiry as updateMembershipExpiryApi,
 } from '../api/tenant.api';
 import { useAuthStore } from './authStore';
 import { useTabsStore } from './tabsStore';
@@ -27,11 +28,12 @@ interface TenantState {
   updateTenant: (data: { name?: string; defaultSessionTimeoutSeconds?: number; mfaRequired?: boolean; vaultAutoLockMaxMinutes?: number | null }) => Promise<void>;
   deleteTenant: () => Promise<void>;
   fetchUsers: () => Promise<void>;
-  inviteUser: (email: string, role: TenantRole) => Promise<void>;
+  inviteUser: (email: string, role: TenantRole, expiresAt?: string) => Promise<void>;
   updateUserRole: (userId: string, role: TenantRole) => Promise<void>;
   removeUser: (userId: string) => Promise<void>;
   createUser: (data: CreateUserData) => Promise<CreateUserResult>;
   toggleUserEnabled: (userId: string, enabled: boolean) => Promise<void>;
+  updateMembershipExpiry: (userId: string, expiresAt: string | null) => Promise<void>;
   reset: () => void;
 }
 
@@ -111,10 +113,10 @@ export const useTenantStore = create<TenantState>((set, get) => ({
     }
   },
 
-  inviteUser: async (email, role) => {
+  inviteUser: async (email, role, expiresAt?) => {
     const { tenant } = get();
     if (!tenant) return;
-    await inviteUserApi(tenant.id, email, role);
+    await inviteUserApi(tenant.id, email, role, expiresAt);
     await get().fetchUsers();
   },
 
@@ -144,6 +146,13 @@ export const useTenantStore = create<TenantState>((set, get) => ({
     const { tenant } = get();
     if (!tenant) return;
     await toggleUserEnabledApi(tenant.id, userId, enabled);
+    await get().fetchUsers();
+  },
+
+  updateMembershipExpiry: async (userId, expiresAt) => {
+    const { tenant } = get();
+    if (!tenant) return;
+    await updateMembershipExpiryApi(tenant.id, userId, expiresAt);
     await get().fetchUsers();
   },
 

--- a/docs/rag-summary.md
+++ b/docs/rag-summary.md
@@ -52,6 +52,8 @@ Tenant roles provide a seven-level hierarchical access control: Owner > Admin > 
 
 Tenant-level policies allow administrators to enforce mandatory multi-factor authentication for all members, set maximum vault auto-lock durations to prevent users from keeping vaults unlocked indefinitely, and configure default session inactivity timeouts. User accounts can be enabled or disabled by administrators, and admins can perform identity-verified operations like changing user emails or resetting passwords.
 
+Time-limited memberships allow administrators to set an optional expiration date on tenant and team memberships. Expired memberships are automatically filtered out at token issuance time (defense in depth) and cleaned up by a batch scheduler running every 5 minutes. When a tenant membership expires, the user is removed from all teams in that tenant and their refresh tokens are revoked for immediate lockout. Owner memberships cannot expire. Administrators can set, change, or remove expiration dates from the organization settings UI.
+
 ## Security
 
 Arsenale supports multiple MFA methods: TOTP authenticator apps, SMS one-time passwords (via Twilio, AWS SNS, or Vonage), and WebAuthn/FIDO2 passkeys for hardware security key and biometric authentication. Users can register multiple methods simultaneously. Identity verification is required for sensitive operations like email changes or password resets, using the same MFA infrastructure.

--- a/server/prisma/migrations/20260312100000_role_111_membership_expiry/migration.sql
+++ b/server/prisma/migrations/20260312100000_role_111_membership_expiry/migration.sql
@@ -1,0 +1,17 @@
+-- AlterEnum
+ALTER TYPE "AuditAction" ADD VALUE 'TENANT_MEMBERSHIP_EXPIRED';
+ALTER TYPE "AuditAction" ADD VALUE 'TEAM_MEMBERSHIP_EXPIRED';
+ALTER TYPE "AuditAction" ADD VALUE 'TENANT_MEMBERSHIP_EXPIRY_UPDATE';
+ALTER TYPE "AuditAction" ADD VALUE 'TEAM_MEMBERSHIP_EXPIRY_UPDATE';
+
+-- AlterTable
+ALTER TABLE "TeamMember" ADD COLUMN "expiresAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "TenantMember" ADD COLUMN "expiresAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "TeamMember_expiresAt_idx" ON "TeamMember"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "TenantMember_expiresAt_idx" ON "TenantMember"("expiresAt");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -73,11 +73,13 @@ model TeamMember {
   teamVaultKeyIV        String?
   teamVaultKeyTag       String?
   joinedAt              DateTime @default(now())
+  expiresAt             DateTime?
 
   team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([teamId, userId])
+  @@index([expiresAt])
 }
 
 model User {
@@ -584,6 +586,10 @@ enum AuditAction {
   SYNC_COMPLETE
   SYNC_ERROR
   IMPOSSIBLE_TRAVEL_DETECTED
+  TENANT_MEMBERSHIP_EXPIRED
+  TEAM_MEMBERSHIP_EXPIRED
+  TENANT_MEMBERSHIP_EXPIRY_UPDATE
+  TEAM_MEMBERSHIP_EXPIRY_UPDATE
 }
 
 model AuditLog {
@@ -759,6 +765,7 @@ model TenantMember {
   isActive  Boolean    @default(false)
   joinedAt  DateTime   @default(now())
   updatedAt DateTime   @updatedAt
+  expiresAt DateTime?
 
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -766,6 +773,7 @@ model TenantMember {
   @@unique([tenantId, userId])
   @@index([userId, isActive])
   @@index([tenantId, isActive])
+  @@index([expiresAt])
 }
 
 model TenantVaultMember {

--- a/server/src/controllers/team.controller.ts
+++ b/server/src/controllers/team.controller.ts
@@ -3,7 +3,7 @@ import { AuthRequest, assertAuthenticated, assertTenantAuthenticated } from '../
 import * as teamService from '../services/team.service';
 import * as auditService from '../services/audit.service';
 import { getClientIp } from '../utils/ip';
-import type { CreateTeamInput, UpdateTeamInput, AddMemberInput, UpdateMemberRoleInput } from '../schemas/team.schemas';
+import type { CreateTeamInput, UpdateTeamInput, AddMemberInput, UpdateMemberRoleInput, UpdateMemberExpiryInput } from '../schemas/team.schemas';
 
 export async function createTeam(req: AuthRequest, res: Response) {
   assertTenantAuthenticated(req);
@@ -68,13 +68,13 @@ export async function listMembers(req: AuthRequest, res: Response) {
 
 export async function addMember(req: AuthRequest, res: Response) {
   assertAuthenticated(req);
-  const { userId, role } = req.body as AddMemberInput;
+  const { userId, role, expiresAt } = req.body as AddMemberInput;
   const teamId = req.params.id as string;
-  const result = await teamService.addMember(teamId, userId, role, req.user.userId);
+  const result = await teamService.addMember(teamId, userId, role, req.user.userId, expiresAt ? new Date(expiresAt) : undefined);
   auditService.log({
     userId: req.user.userId, action: 'TEAM_ADD_MEMBER',
     targetType: 'TeamMember', targetId: userId,
-    details: { teamId, role },
+    details: { teamId, role, expiresAt: expiresAt ?? null },
     ipAddress: getClientIp(req),
   });
   res.status(201).json(result);
@@ -104,6 +104,23 @@ export async function removeMember(req: AuthRequest, res: Response) {
     userId: req.user.userId, action: 'TEAM_REMOVE_MEMBER',
     targetType: 'TeamMember', targetId: targetUserId,
     details: { teamId },
+    ipAddress: getClientIp(req),
+  });
+  res.json(result);
+}
+
+export async function updateMemberExpiry(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const { expiresAt } = req.body as UpdateMemberExpiryInput;
+  const teamId = req.params.id as string;
+  const targetUserId = req.params.userId as string;
+  const result = await teamService.updateMemberExpiry(teamId, targetUserId, expiresAt ? new Date(expiresAt) : null);
+  auditService.log({
+    userId: req.user.userId,
+    action: 'TEAM_MEMBERSHIP_EXPIRY_UPDATE',
+    targetType: 'TeamMember',
+    targetId: targetUserId,
+    details: { teamId, expiresAt: expiresAt ?? null },
     ipAddress: getClientIp(req),
   });
   res.json(result);

--- a/server/src/controllers/tenant.controller.ts
+++ b/server/src/controllers/tenant.controller.ts
@@ -7,7 +7,7 @@ import prisma from '../lib/prisma';
 import { setRefreshTokenCookie, setCsrfCookie } from '../utils/cookie';
 import { logger } from '../utils/logger';
 import { getClientIp } from '../utils/ip';
-import type { CreateTenantInput, UpdateTenantInput, InviteUserInput, UpdateRoleInput, CreateUserInput, ToggleUserEnabledInput, AdminChangeEmailInput, AdminChangePasswordInput } from '../schemas/tenant.schemas';
+import type { CreateTenantInput, UpdateTenantInput, InviteUserInput, UpdateRoleInput, CreateUserInput, ToggleUserEnabledInput, AdminChangeEmailInput, AdminChangePasswordInput, UpdateMembershipExpiryInput } from '../schemas/tenant.schemas';
 
 export async function createTenant(req: AuthRequest, res: Response) {
   assertAuthenticated(req);
@@ -95,13 +95,13 @@ export async function getUserProfile(req: AuthRequest, res: Response) {
 
 export async function inviteUser(req: AuthRequest, res: Response) {
   assertAuthenticated(req);
-  const { email, role } = req.body as InviteUserInput;
+  const { email, role, expiresAt } = req.body as InviteUserInput;
   const tenantId = req.params.id as string;
-  const result = await tenantService.inviteUser(tenantId, email, role);
+  const result = await tenantService.inviteUser(tenantId, email, role, expiresAt ? new Date(expiresAt) : undefined);
   auditService.log({
     userId: req.user.userId, action: 'TENANT_INVITE_USER',
     targetType: 'Tenant', targetId: tenantId,
-    details: { invitedEmail: email, role },
+    details: { invitedEmail: email, role, expiresAt: expiresAt ?? null },
     ipAddress: getClientIp(req),
   });
   res.status(201).json(result);
@@ -148,7 +148,7 @@ export async function createUser(req: AuthRequest, res: Response) {
   const tenantId = req.params.id as string;
   const result = await tenantService.createUser(
     tenantId,
-    { email: data.email, username: data.username, password: data.password, role: data.role },
+    { email: data.email, username: data.username, password: data.password, role: data.role, expiresAt: data.expiresAt ?? undefined },
     req.user.userId,
   );
 
@@ -216,5 +216,24 @@ export async function adminChangeUserPassword(req: AuthRequest, res: Response) {
   const result = await tenantService.adminChangeUserPassword(
     tenantId, req.user.userId, targetUserId, newPassword, verificationId,
   );
+  res.json(result);
+}
+
+export async function updateMembershipExpiry(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const { expiresAt } = req.body as UpdateMembershipExpiryInput;
+  const tenantId = req.params.id as string;
+  const targetUserId = req.params.userId as string;
+  const result = await tenantService.updateMembershipExpiry(
+    tenantId, targetUserId, expiresAt ? new Date(expiresAt) : null,
+  );
+  auditService.log({
+    userId: req.user.userId,
+    action: 'TENANT_MEMBERSHIP_EXPIRY_UPDATE',
+    targetType: 'TenantMember',
+    targetId: targetUserId,
+    details: { tenantId, expiresAt: expiresAt ?? null },
+    ipAddress: getClientIp(req),
+  });
   res.json(result);
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,7 +8,7 @@ import { initializePassport } from './config/passport';
 import { setupSocketIO } from './socket';
 import { logger, toGuacamoleLogLevel } from './utils/logger';
 import prisma from './lib/prisma';
-import { startKeyRotationJob, startLdapSyncJob, stopAllJobs } from './services/scheduler.service';
+import { startKeyRotationJob, startLdapSyncJob, startMembershipExpiryJob, stopAllJobs } from './services/scheduler.service';
 import { startAllSyncJobs, stopAllSyncJobs } from './services/syncScheduler.service';
 import { startAllMonitors, stopAllMonitors } from './services/gatewayMonitor.service';
 import { cleanupExpiredShares } from './services/externalShare.service';
@@ -100,6 +100,7 @@ async function main() {
   // Start scheduled jobs
   startKeyRotationJob();
   startLdapSyncJob();
+  startMembershipExpiryJob();
   startAllSyncJobs().catch((err) => {
     logger.error('Failed to start sync jobs:', err);
   });

--- a/server/src/routes/team.routes.ts
+++ b/server/src/routes/team.routes.ts
@@ -3,7 +3,7 @@ import { authenticate } from '../middleware/auth.middleware';
 import { requireTenant } from '../middleware/tenant.middleware';
 import { requireTeamMember, requireTeamRole } from '../middleware/team.middleware';
 import { validate, validateUuidParam } from '../middleware/validate.middleware';
-import { createTeamSchema, updateTeamSchema, addMemberSchema, updateMemberRoleSchema } from '../schemas/team.schemas';
+import { createTeamSchema, updateTeamSchema, addMemberSchema, updateMemberRoleSchema, updateMemberExpirySchema } from '../schemas/team.schemas';
 import * as teamController from '../controllers/team.controller';
 import { asyncHandler } from '../middleware/asyncHandler';
 
@@ -24,5 +24,6 @@ router.get('/:id/members', validateUuidParam(), requireTeamMember, asyncHandler(
 router.post('/:id/members', validateUuidParam(), requireTeamMember, requireTeamRole('TEAM_ADMIN'), validate(addMemberSchema), asyncHandler(teamController.addMember));
 router.put('/:id/members/:userId', validateUuidParam(), requireTeamMember, requireTeamRole('TEAM_ADMIN'), validateUuidParam('userId'), validate(updateMemberRoleSchema), asyncHandler(teamController.updateMemberRole));
 router.delete('/:id/members/:userId', validateUuidParam(), requireTeamMember, requireTeamRole('TEAM_ADMIN', { allowTenantAdmin: true }), validateUuidParam('userId'), asyncHandler(teamController.removeMember));
+router.patch('/:id/members/:userId/expiry', validateUuidParam(), requireTeamMember, requireTeamRole('TEAM_ADMIN'), validateUuidParam('userId'), validate(updateMemberExpirySchema), asyncHandler(teamController.updateMemberExpiry));
 
 export default router;

--- a/server/src/routes/tenant.routes.ts
+++ b/server/src/routes/tenant.routes.ts
@@ -5,6 +5,7 @@ import { validate, validateUuidParam } from '../middleware/validate.middleware';
 import {
   createTenantSchema, updateTenantSchema, inviteUserSchema, updateRoleSchema,
   createUserSchema, toggleUserEnabledSchema, adminChangeEmailSchema, adminChangePasswordSchema,
+  updateMembershipExpirySchema,
 } from '../schemas/tenant.schemas';
 import * as tenantController from '../controllers/tenant.controller';
 import { asyncHandler } from '../middleware/asyncHandler';
@@ -38,6 +39,7 @@ router.put('/:id/users/:userId', validateUuidParam(), requireTenant, requireOwnT
 router.delete('/:id/users/:userId', validateUuidParam(), requireTenant, requireOwnTenant, requireTenantRole('ADMIN'), validateUuidParam('userId'), asyncHandler(tenantController.removeUser));
 router.post('/:id/users', validateUuidParam(), requireTenant, requireOwnTenant, requireTenantRole('ADMIN'), validate(createUserSchema), asyncHandler(tenantController.createUser));
 router.patch('/:id/users/:userId/enabled', validateUuidParam(), requireTenant, requireOwnTenant, requireTenantRole('ADMIN'), validateUuidParam('userId'), validate(toggleUserEnabledSchema), asyncHandler(tenantController.toggleUserEnabled));
+router.patch('/:id/users/:userId/expiry', validateUuidParam(), requireTenant, requireOwnTenant, requireTenantRole('ADMIN'), validateUuidParam('userId'), validate(updateMembershipExpirySchema), asyncHandler(tenantController.updateMembershipExpiry));
 
 // Admin identity-verified operations on users
 router.put('/:id/users/:userId/email', validateUuidParam(), requireTenant, requireOwnTenant, requireTenantRole('ADMIN'), validateUuidParam('userId'), validate(adminChangeEmailSchema), asyncHandler(tenantController.adminChangeUserEmail));

--- a/server/src/schemas/team.schemas.ts
+++ b/server/src/schemas/team.schemas.ts
@@ -15,6 +15,7 @@ export type UpdateTeamInput = z.infer<typeof updateTeamSchema>;
 export const addMemberSchema = z.object({
   userId: z.string().uuid(),
   role: z.enum(['TEAM_ADMIN', 'TEAM_EDITOR', 'TEAM_VIEWER']),
+  expiresAt: z.string().datetime().optional().nullable(),
 });
 export type AddMemberInput = z.infer<typeof addMemberSchema>;
 
@@ -22,3 +23,8 @@ export const updateMemberRoleSchema = z.object({
   role: z.enum(['TEAM_ADMIN', 'TEAM_EDITOR', 'TEAM_VIEWER']),
 });
 export type UpdateMemberRoleInput = z.infer<typeof updateMemberRoleSchema>;
+
+export const updateMemberExpirySchema = z.object({
+  expiresAt: z.string().datetime().nullable(),
+});
+export type UpdateMemberExpiryInput = z.infer<typeof updateMemberExpirySchema>;

--- a/server/src/schemas/tenant.schemas.ts
+++ b/server/src/schemas/tenant.schemas.ts
@@ -17,6 +17,7 @@ export type UpdateTenantInput = z.infer<typeof updateTenantSchema>;
 export const inviteUserSchema = z.object({
   email: z.string().email(),
   role: z.enum(['ADMIN', 'OPERATOR', 'MEMBER', 'CONSULTANT', 'AUDITOR', 'GUEST']),
+  expiresAt: z.string().datetime().optional().nullable(),
 });
 export type InviteUserInput = z.infer<typeof inviteUserSchema>;
 
@@ -31,6 +32,7 @@ export const createUserSchema = z.object({
   password: passwordSchema,
   role: z.enum(['ADMIN', 'OPERATOR', 'MEMBER', 'CONSULTANT', 'AUDITOR', 'GUEST']),
   sendWelcomeEmail: z.boolean().optional().default(false),
+  expiresAt: z.string().datetime().optional().nullable(),
 });
 export type CreateUserInput = z.infer<typeof createUserSchema>;
 
@@ -50,3 +52,8 @@ export const adminChangePasswordSchema = z.object({
   verificationId: z.string().uuid(),
 });
 export type AdminChangePasswordInput = z.infer<typeof adminChangePasswordSchema>;
+
+export const updateMembershipExpirySchema = z.object({
+  expiresAt: z.string().datetime().nullable(),
+});
+export type UpdateMembershipExpiryInput = z.infer<typeof updateMembershipExpirySchema>;

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -124,14 +124,20 @@ export async function issueTokens(user: {
     orderBy: { joinedAt: 'asc' },
   });
 
+  // Filter out expired memberships
+  const now = new Date();
+  const validMemberships = allMemberships.filter(
+    (m) => !m.expiresAt || m.expiresAt > now,
+  );
+
   // Resolve active membership, auto-activating if exactly one exists
-  let activeMembership = allMemberships.find((m) => m.isActive);
-  if (!activeMembership && allMemberships.length === 1) {
+  let activeMembership = validMemberships.find((m) => m.isActive);
+  if (!activeMembership && validMemberships.length === 1) {
     await prisma.tenantMember.update({
-      where: { id: allMemberships[0].id },
+      where: { id: validMemberships[0].id },
       data: { isActive: true },
     });
-    activeMembership = { ...allMemberships[0], isActive: true };
+    activeMembership = { ...validMemberships[0], isActive: true };
   }
 
   const payload: AuthPayload = {
@@ -167,7 +173,7 @@ export async function issueTokens(user: {
       tenantId: activeMembership?.tenantId,
       tenantRole: activeMembership?.role,
     },
-    tenantMemberships: allMemberships.map((m) => ({
+    tenantMemberships: validMemberships.map((m) => ({
       tenantId: m.tenant.id,
       name: m.tenant.name,
       slug: m.tenant.slug,
@@ -184,6 +190,9 @@ export async function switchTenant(userId: string, targetTenantId: string) {
   });
   if (!membership) {
     throw new AppError('You are not a member of this organization', 403);
+  }
+  if (membership.expiresAt && membership.expiresAt <= new Date()) {
+    throw new AppError('Your membership in this organization has expired', 403);
   }
 
   // Transactionally deactivate all memberships and activate the target

--- a/server/src/services/scheduler.service.ts
+++ b/server/src/services/scheduler.service.ts
@@ -8,6 +8,7 @@ import * as auditService from './audit.service';
 
 let rotationTask: ScheduledTask | null = null;
 let ldapSyncTask: ScheduledTask | null = null;
+let membershipExpiryTask: ScheduledTask | null = null;
 
 export function startKeyRotationJob(): void {
   const cronExpr = config.keyRotationCron;
@@ -161,6 +162,131 @@ export function startLdapSyncJob(): void {
   logger.info(`[scheduler] LDAP sync job scheduled: "${cronExpr}" (UTC)`);
 }
 
+const MEMBERSHIP_EXPIRY_CRON = '*/5 * * * *';
+
+export function startMembershipExpiryJob(): void {
+  membershipExpiryTask = cron.schedule(
+    MEMBERSHIP_EXPIRY_CRON,
+    () => {
+      processExpiredMemberships().catch((err) => {
+        logger.error('[scheduler] Unhandled error in processExpiredMemberships:', err);
+      });
+    },
+    { timezone: 'UTC' },
+  );
+
+  logger.info(
+    `[scheduler] Membership expiry job scheduled: "${MEMBERSHIP_EXPIRY_CRON}" (UTC)`,
+  );
+}
+
+export async function processExpiredMemberships(): Promise<void> {
+  const now = new Date();
+  logger.info(`[scheduler] Starting membership expiry check at ${now.toISOString()}`);
+
+  // --- Expired TenantMembers (exclude OWNER) ---
+  const expiredTenantMembers = await prisma.tenantMember.findMany({
+    where: {
+      expiresAt: { not: null, lte: now },
+      role: { not: 'OWNER' },
+    },
+    include: {
+      user: { select: { id: true, email: true } },
+      tenant: { select: { id: true, name: true } },
+    },
+  });
+
+  for (const m of expiredTenantMembers) {
+    try {
+      await prisma.$transaction([
+        // Remove from all teams in this tenant
+        prisma.teamMember.deleteMany({
+          where: {
+            userId: m.userId,
+            team: { tenantId: m.tenantId },
+          },
+        }),
+        // Delete the tenant membership
+        prisma.tenantMember.delete({
+          where: { id: m.id },
+        }),
+        // Revoke refresh tokens to force re-auth
+        prisma.refreshToken.deleteMany({
+          where: { userId: m.userId },
+        }),
+      ]);
+
+      auditService.log({
+        userId: m.userId,
+        action: 'TENANT_MEMBERSHIP_EXPIRED',
+        targetType: 'TenantMember',
+        targetId: m.id,
+        details: {
+          tenantId: m.tenantId,
+          tenantName: m.tenant.name,
+          email: m.user.email,
+          expiresAt: m.expiresAt?.toISOString(),
+        },
+      });
+
+      logger.info(
+        `[scheduler] Expired tenant membership: user "${m.user.email}" from tenant "${m.tenant.name}"`,
+      );
+    } catch (err) {
+      logger.error(
+        `[scheduler] Failed to expire tenant membership ${m.id}:`,
+        (err as Error).message,
+      );
+    }
+  }
+
+  // --- Expired TeamMembers ---
+  const expiredTeamMembers = await prisma.teamMember.findMany({
+    where: {
+      expiresAt: { not: null, lte: now },
+    },
+    include: {
+      user: { select: { id: true, email: true } },
+      team: { select: { id: true, name: true } },
+    },
+  });
+
+  for (const m of expiredTeamMembers) {
+    try {
+      await prisma.teamMember.delete({
+        where: { id: m.id },
+      });
+
+      auditService.log({
+        userId: m.userId,
+        action: 'TEAM_MEMBERSHIP_EXPIRED',
+        targetType: 'TeamMember',
+        targetId: m.id,
+        details: {
+          teamId: m.teamId,
+          teamName: m.team.name,
+          email: m.user.email,
+          expiresAt: m.expiresAt?.toISOString(),
+        },
+      });
+
+      logger.info(
+        `[scheduler] Expired team membership: user "${m.user.email}" from team "${m.team.name}"`,
+      );
+    } catch (err) {
+      logger.error(
+        `[scheduler] Failed to expire team membership ${m.id}:`,
+        (err as Error).message,
+      );
+    }
+  }
+
+  const total = expiredTenantMembers.length + expiredTeamMembers.length;
+  if (total > 0) {
+    logger.info(`[scheduler] Membership expiry check complete. Expired: ${total}`);
+  }
+}
+
 export function stopAllJobs(): void {
   if (rotationTask) {
     rotationTask.stop();
@@ -169,6 +295,10 @@ export function stopAllJobs(): void {
   if (ldapSyncTask) {
     ldapSyncTask.stop();
     ldapSyncTask = null;
+  }
+  if (membershipExpiryTask) {
+    membershipExpiryTask.stop();
+    membershipExpiryTask = null;
   }
   logger.info('[scheduler] All scheduled jobs stopped.');
 }

--- a/server/src/services/team.service.ts
+++ b/server/src/services/team.service.ts
@@ -186,6 +186,8 @@ export async function listMembers(teamId: string) {
     avatarData: m.user.avatarData,
     role: m.role,
     joinedAt: m.joinedAt,
+    expiresAt: m.expiresAt?.toISOString() ?? null,
+    expired: m.expiresAt ? m.expiresAt <= new Date() : false,
   }));
 }
 
@@ -193,7 +195,8 @@ export async function addMember(
   teamId: string,
   targetUserId: string,
   role: 'TEAM_ADMIN' | 'TEAM_EDITOR' | 'TEAM_VIEWER',
-  addedByUserId: string
+  addedByUserId: string,
+  expiresAt?: Date,
 ) {
   // Load team to check tenant
   const team = await prisma.team.findUnique({
@@ -257,6 +260,7 @@ export async function addMember(
       encryptedTeamVaultKey: encKey.ciphertext,
       teamVaultKeyIV: encKey.iv,
       teamVaultKeyTag: encKey.tag,
+      ...(expiresAt && { expiresAt }),
     },
   });
 
@@ -326,6 +330,23 @@ export async function updateMemberRole(
   });
 
   return { userId: targetUserId, role: updated.role };
+}
+
+export async function updateMemberExpiry(
+  teamId: string,
+  targetUserId: string,
+  expiresAt: Date | null,
+) {
+  const membership = await prisma.teamMember.findUnique({
+    where: { teamId_userId: { teamId, userId: targetUserId } },
+  });
+  if (!membership) {
+    throw new AppError('Member not found', 404);
+  }
+  return prisma.teamMember.update({
+    where: { teamId_userId: { teamId, userId: targetUserId } },
+    data: { expiresAt },
+  });
 }
 
 export async function resolveTeamKey(teamId: string, userId: string): Promise<Buffer> {

--- a/server/src/services/tenant.service.ts
+++ b/server/src/services/tenant.service.ts
@@ -226,6 +226,8 @@ export async function listTenantUsers(tenantId: string) {
       smsMfaEnabled: m.user.smsMfaEnabled,
       enabled: m.user.enabled,
       createdAt: m.user.createdAt,
+      expiresAt: m.expiresAt?.toISOString() ?? null,
+      expired: m.expiresAt ? m.expiresAt <= new Date() : false,
     }))
     .sort((a, b) => {
       const aOrder = roleOrder[a.role] ?? 3;
@@ -303,7 +305,7 @@ export async function getUserProfile(
   return profile;
 }
 
-export async function inviteUser(tenantId: string, email: string, role: TenantRoleType) {
+export async function inviteUser(tenantId: string, email: string, role: TenantRoleType, expiresAt?: Date) {
   const targetUser = await prisma.user.findUnique({ where: { email } });
   if (!targetUser) {
     throw new AppError('User not found. They must register first.', 404);
@@ -318,7 +320,7 @@ export async function inviteUser(tenantId: string, email: string, role: TenantRo
 
   const [membership, tenant] = await Promise.all([
     prisma.tenantMember.create({
-      data: { tenantId, userId: targetUser.id, role: role as TenantRole, isActive: false },
+      data: { tenantId, userId: targetUser.id, role: role as TenantRole, isActive: false, ...(expiresAt && { expiresAt }) },
     }),
     prisma.tenant.findUnique({ where: { id: tenantId }, select: { name: true } }),
   ]);
@@ -435,7 +437,7 @@ export async function removeUser(tenantId: string, targetUserId: string, actingU
 
 export async function createUser(
   tenantId: string,
-  data: { email: string; username?: string; password: string; role: TenantRoleType },
+  data: { email: string; username?: string; password: string; role: TenantRoleType; expiresAt?: string },
   _actingUserId: string,
 ) {
   // Check for existing user
@@ -488,7 +490,7 @@ export async function createUser(
     });
 
     const membership = await tx.tenantMember.create({
-      data: { tenantId, userId: user.id, role: data.role as TenantRole, isActive: false },
+      data: { tenantId, userId: user.id, role: data.role as TenantRole, isActive: false, ...(data.expiresAt && { expiresAt: new Date(data.expiresAt) }) },
     });
 
     return { ...user, role: membership.role };
@@ -547,6 +549,26 @@ export async function toggleUserEnabled(
   }
 
   return { ...updated, role: membership.role };
+}
+
+export async function updateMembershipExpiry(
+  tenantId: string,
+  targetUserId: string,
+  expiresAt: Date | null,
+) {
+  const membership = await prisma.tenantMember.findUnique({
+    where: { tenantId_userId: { tenantId, userId: targetUserId } },
+  });
+  if (!membership) {
+    throw new AppError('User not found in this organization', 404);
+  }
+  if (membership.role === 'OWNER') {
+    throw new AppError('Cannot set expiration on owner membership', 400);
+  }
+  return prisma.tenantMember.update({
+    where: { tenantId_userId: { tenantId, userId: targetUserId } },
+    data: { expiresAt },
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Task ROLE-111 — Time-limited membership with automatic expiration

### Summary
- Added optional `expiresAt` field to `TenantMember` and `TeamMember` models with DB indexes
- Auth-layer defense: `issueTokens()` filters expired memberships, `switchTenant()` rejects expired
- Batch scheduler (`*/5 * * * *`) auto-removes expired memberships with cascade (tenant→team) and audit trail
- New audit actions: `TENANT_MEMBERSHIP_EXPIRED`, `TEAM_MEMBERSHIP_EXPIRED`, `TENANT_MEMBERSHIP_EXPIRY_UPDATE`, `TEAM_MEMBERSHIP_EXPIRY_UPDATE`
- Server: Zod schemas, controllers, routes (`PATCH .../expiry`) for tenant and team membership expiry management
- Client: expiry datetime picker in Invite/CreateUser dialogs, expiry column with chips in TenantSection/TeamSection, inline expiry editing dialogs
- OWNER role protected from expiration at all layers

### Related Issue
Refs #147 (ROLE-111)

---
*Generated by Claude Code via `/task-pick`*