### PR TITLE
[UX-073] — Auto-Reconnect & Resiliency UI

### DIFF
--- a/client/src/components/RDP/RdpViewer.tsx
+++ b/client/src/components/RDP/RdpViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import { Box, CircularProgress, Typography, Alert } from '@mui/material';
 import { FolderOpen as FolderOpenIcon } from '@mui/icons-material';
 import * as Guacamole from '@glokon/guacamole-common-js';
@@ -8,7 +8,10 @@ import { useAuthStore } from '../../store/authStore';
 import type { CredentialOverride } from '../../store/tabsStore';
 import FileBrowser from './FileBrowser';
 import FloatingToolbar, { ToolbarAction } from '../shared/FloatingToolbar';
+import ReconnectOverlay from '../shared/ReconnectOverlay';
 import { extractApiError } from '../../utils/apiError';
+import { useAutoReconnect } from '../../hooks/useAutoReconnect';
+import { isGuacPermanentError } from '../../utils/reconnectClassifier';
 
 interface RdpViewerProps {
   connectionId: string;
@@ -25,9 +28,246 @@ export default function RdpViewer({ connectionId, tabId: _tabId, isActive = true
   const keyboardRef = useRef<Guacamole.Keyboard | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const sessionIdRef = useRef<string | null>(null);
-  const [status, setStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
+  const [status, setStatus] = useState<'connecting' | 'connected' | 'unstable' | 'error'>('connecting');
   const [error, setError] = useState('');
   const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
+
+  // Track whether we ever reached CONNECTED state (for reconnect eligibility)
+  const wasConnectedRef = useRef(false);
+  // Track permanent error flag to prevent reconnection after admin termination etc.
+  const permanentErrorRef = useRef(false);
+  // Track the last guacamole error message for classification at state 5
+  const lastGuacErrorRef = useRef('');
+  // Cleanup function returned by the inner connect setup
+  const innerCleanupRef = useRef<(() => void) | null>(null);
+  // Cancelled flag for async operations
+  const cancelledRef = useRef(false);
+  // Heartbeat interval ref (accessible for cleanup during reconnect)
+  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // ResizeObserver ref
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  const credentialsRef = useRef(credentials);
+  useEffect(() => { credentialsRef.current = credentials; }, [credentials]);
+
+  // Reconnect connect function — creates a new Guacamole session
+  const connectSession = useCallback(async () => {
+    if (!displayRef.current) return;
+
+    // Clean up previous session
+    if (heartbeatRef.current) {
+      clearInterval(heartbeatRef.current);
+      heartbeatRef.current = null;
+    }
+    if (resizeObserverRef.current) {
+      resizeObserverRef.current.disconnect();
+      resizeObserverRef.current = null;
+    }
+    if (clientRef.current) {
+      clientRef.current.onclipboard = null;
+      clientRef.current.onstatechange = null;
+      clientRef.current.onerror = null;
+      clientRef.current.disconnect();
+      clientRef.current = null;
+    }
+    innerCleanupRef.current?.();
+    innerCleanupRef.current = null;
+    // End old session on server
+    if (sessionIdRef.current) {
+      api.post(`/sessions/rdp/${sessionIdRef.current}/end`).catch(() => {});
+      sessionIdRef.current = null;
+    }
+    // Clear old display elements but keep the container
+    if (displayRef.current) {
+      displayRef.current.innerHTML = '';
+    }
+
+    const creds = credentialsRef.current;
+
+    // Get RDP token from server
+    const res = await api.post('/sessions/rdp', {
+      connectionId,
+      ...(creds?.credentialMode === 'domain'
+        ? { credentialMode: 'domain' }
+        : creds && {
+            username: creds.username,
+            password: creds.password,
+            ...(creds.domain ? { domain: creds.domain } : {}),
+          }
+      ),
+    });
+    const { token, sessionId } = res.data;
+    sessionIdRef.current = sessionId ?? null;
+
+    if (cancelledRef.current) return;
+
+    // Determine WebSocket URL for guacamole-lite (proxied through Vite/nginx)
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${wsProtocol}//${window.location.host}/guacamole/?token=${encodeURIComponent(token)}`;
+
+    const tunnel = new Guacamole.WebSocketTunnel(wsUrl);
+    const client = new Guacamole.Client(tunnel);
+    clientRef.current = client;
+
+    // Get display element
+    const display = client.getDisplay().getElement();
+    displayRef.current?.appendChild(display);
+
+    // Resize logic — only active after CONNECTED
+    let connected = false;
+
+    const handleResize = () => {
+      if (!connected || !displayRef.current) return;
+      const width = displayRef.current.clientWidth;
+      const height = displayRef.current.clientHeight;
+      if (width > 0 && height > 0) {
+        client.sendSize(width, height);
+        const guacDisplay = client.getDisplay();
+        const scale = Math.min(
+          width / guacDisplay.getWidth(),
+          height / guacDisplay.getHeight()
+        );
+        if (isFinite(scale) && scale > 0) {
+          guacDisplay.scale(scale);
+        }
+      }
+    };
+
+    // Scale display whenever Guacamole reports a new resolution
+    (client.getDisplay() as unknown as { onresize: (() => void) | null }).onresize = handleResize;
+
+    // Handle state changes
+    client.onstatechange = (state: number) => {
+      if (cancelledRef.current) return;
+      switch (state) {
+        case 3: // CONNECTED
+          connected = true;
+          wasConnectedRef.current = true;
+          lastGuacErrorRef.current = '';
+          setStatus('connected');
+          resetReconnect();
+          // Send initial display size after a short delay to let the RDP session stabilize
+          setTimeout(() => {
+            handleResize();
+            if (displayRef.current && !resizeObserverRef.current) {
+              resizeObserverRef.current = new ResizeObserver(handleResize);
+              resizeObserverRef.current.observe(displayRef.current);
+            }
+          }, 2000);
+          // Start heartbeat to keep the persistent session alive
+          if (sessionIdRef.current && !heartbeatRef.current) {
+            heartbeatRef.current = setInterval(() => {
+              if (sessionIdRef.current) {
+                api.post(`/sessions/rdp/${sessionIdRef.current}/heartbeat`).catch((err) => {
+                  if (err?.response?.status === 410) {
+                    permanentErrorRef.current = true;
+                    setStatus('error');
+                    setError('Session expired due to inactivity. Please reconnect.');
+                    client.disconnect();
+                    if (heartbeatRef.current) { clearInterval(heartbeatRef.current); heartbeatRef.current = null; }
+                  }
+                });
+              }
+            }, 10_000);
+          }
+          break;
+        case 4: // UNSTABLE
+          if (connected) {
+            setStatus('unstable');
+          }
+          break;
+        case 5: // DISCONNECTED
+          connected = false;
+          if (heartbeatRef.current) {
+            clearInterval(heartbeatRef.current);
+            heartbeatRef.current = null;
+          }
+          // Check if this is a transient or permanent disconnection
+          if (permanentErrorRef.current) {
+            // Already handled (admin termination, session expired, etc.)
+            return;
+          }
+          if (wasConnectedRef.current && !isGuacPermanentError(lastGuacErrorRef.current)) {
+            // Transient — attempt reconnection
+            triggerReconnect();
+          } else {
+            setStatus('error');
+            setError(lastGuacErrorRef.current || 'Disconnected from remote desktop');
+          }
+          break;
+      }
+    };
+
+    client.onerror = (err: { message?: string }) => {
+      if (cancelledRef.current) return;
+      const msg = err.message || 'RDP connection error';
+      lastGuacErrorRef.current = msg;
+      if (isGuacPermanentError(msg)) {
+        permanentErrorRef.current = true;
+        setStatus('error');
+        setError(msg);
+      }
+      // For non-permanent errors, let onstatechange handle the transition to state 5
+    };
+
+    // Prevent native context menu on the Guacamole display (fixes Firefox)
+    const preventContextMenu = (e: Event) => e.preventDefault();
+    display.addEventListener('contextmenu', preventContextMenu);
+
+    // Mouse events — only forward when this viewer is active
+    const mouse = new Guacamole.Mouse(display);
+    mouse.onEach(['mousedown', 'mouseup', 'mousemove'], (e) => {
+      const mouseEvent = e as Guacamole.Mouse.Event;
+      if (activeRef.current) {
+        mouseEvent.preventDefault();
+        client.sendMouseState(mouseEvent.state);
+      }
+    });
+
+    // Clipboard: remote → browser
+    client.onclipboard = (stream: Guacamole.InputStream, mimetype: string) => {
+      if (mimetype !== 'text/plain') return;
+      const reader = new Guacamole.StringReader(stream);
+      let data = '';
+      reader.ontext = (text: string) => { data += text; };
+      reader.onend = () => {
+        if (data && navigator.clipboard?.writeText) {
+          navigator.clipboard.writeText(data).catch((err) => {
+            console.warn('Failed to write to browser clipboard:', err);
+          });
+        }
+      };
+    };
+
+    // Keyboard events — only forward when this viewer is active and focused
+    // displayRef.current is guaranteed non-null here (guarded at the top)
+    const keyboard = new Guacamole.Keyboard(displayRef.current as HTMLElement);
+    keyboardRef.current = keyboard;
+    keyboard.onkeydown = (keysym: number) => {
+      if (!activeRef.current) return false;
+      client.sendKeyEvent(1, keysym);
+      return true;
+    };
+    keyboard.onkeyup = (keysym: number) => {
+      if (!activeRef.current) return;
+      client.sendKeyEvent(0, keysym);
+    };
+
+    // Connect — pass empty string so WebSocketTunnel doesn't append
+    // literal "undefined" to the URL (which corrupts the base64 token)
+    client.connect('');
+
+    innerCleanupRef.current = () => {
+      display.removeEventListener('contextmenu', preventContextMenu);
+      keyboard.onkeydown = null;
+      keyboard.onkeyup = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- credentials tracked via ref
+  }, [connectionId]);
+
+  const { reconnectState, attempt, maxRetries, triggerReconnect, cancelReconnect, resetReconnect } = useAutoReconnect(
+    connectSession,
+  );
 
   // Build toolbar actions list — extensible for future tools
   const toolbarActions = useMemo<ToolbarAction[]>(() => {
@@ -65,6 +305,8 @@ export default function RdpViewer({ connectionId, tabId: _tabId, isActive = true
 
     const handler = (data: { sessionId: string }) => {
       if (data.sessionId && data.sessionId === sessionIdRef.current) {
+        permanentErrorRef.current = true;
+        cancelReconnect();
         setStatus('error');
         setError('Session terminated by administrator');
         clientRef.current?.disconnect();
@@ -77,188 +319,46 @@ export default function RdpViewer({ connectionId, tabId: _tabId, isActive = true
       socket.off('session:terminated', handler);
       socket.disconnect();
     };
-  }, [connectionId]);
+  }, [connectionId, cancelReconnect]);
 
+  // Initial connection
   useEffect(() => {
     if (!displayRef.current) return;
 
-    let cancelled = false;
-
-    async function connect() {
-      try {
-        // Get RDP token from server
-        const res = await api.post('/sessions/rdp', {
-          connectionId,
-          ...(credentials?.credentialMode === 'domain'
-            ? { credentialMode: 'domain' }
-            : credentials && {
-                username: credentials.username,
-                password: credentials.password,
-                ...(credentials.domain ? { domain: credentials.domain } : {}),
-              }
-          ),
-        });
-        const { token, sessionId } = res.data;
-        sessionIdRef.current = sessionId ?? null;
-
-        if (cancelled) return;
-
-        // Determine WebSocket URL for guacamole-lite (proxied through Vite/nginx)
-        const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const wsUrl = `${wsProtocol}//${window.location.host}/guacamole/?token=${encodeURIComponent(token)}`;
-
-        const tunnel = new Guacamole.WebSocketTunnel(wsUrl);
-        const client = new Guacamole.Client(tunnel);
-        clientRef.current = client;
-
-        // Get display element
-        const display = client.getDisplay().getElement();
-        displayRef.current?.appendChild(display);
-
-        // Resize logic — only active after CONNECTED
-        let connected = false;
-        let resizeObserver: ResizeObserver | null = null;
-        let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-
-        const handleResize = () => {
-          if (!connected || !displayRef.current) return;
-          const width = displayRef.current.clientWidth;
-          const height = displayRef.current.clientHeight;
-          if (width > 0 && height > 0) {
-            client.sendSize(width, height);
-            const guacDisplay = client.getDisplay();
-            const scale = Math.min(
-              width / guacDisplay.getWidth(),
-              height / guacDisplay.getHeight()
-            );
-            if (isFinite(scale) && scale > 0) {
-              guacDisplay.scale(scale);
-            }
-          }
-        };
-
-        // Scale display whenever Guacamole reports a new resolution
-        (client.getDisplay() as unknown as { onresize: (() => void) | null }).onresize = handleResize;
-
-        // Handle state changes
-        client.onstatechange = (state: number) => {
-          if (cancelled) return;
-          switch (state) {
-            case 3: // CONNECTED
-              connected = true;
-              setStatus('connected');
-              // Send initial display size after a short delay to let the RDP session stabilize
-              setTimeout(() => {
-                handleResize();
-                if (displayRef.current && !resizeObserver) {
-                  resizeObserver = new ResizeObserver(handleResize);
-                  resizeObserver.observe(displayRef.current);
-                }
-              }, 2000);
-              // Start heartbeat to keep the persistent session alive
-              if (sessionIdRef.current && !heartbeatInterval) {
-                heartbeatInterval = setInterval(() => {
-                  if (sessionIdRef.current) {
-                    api.post(`/sessions/rdp/${sessionIdRef.current}/heartbeat`).catch((err) => {
-                      if (err?.response?.status === 410) {
-                        setStatus('error');
-                        setError('Session expired due to inactivity. Please reconnect.');
-                        client.disconnect();
-                        if (heartbeatInterval) { clearInterval(heartbeatInterval); heartbeatInterval = null; }
-                      }
-                    });
-                  }
-                }, 10_000);
-              }
-              break;
-            case 5: // DISCONNECTED
-              connected = false;
-              setStatus('error');
-              setError('Disconnected from remote desktop');
-              break;
-          }
-        };
-
-        client.onerror = (err: { message?: string }) => {
-          if (cancelled) return;
-          setStatus('error');
-          setError(err.message || 'RDP connection error');
-        };
-
-        // Prevent native context menu on the Guacamole display (fixes Firefox)
-        const preventContextMenu = (e: Event) => e.preventDefault();
-        display.addEventListener('contextmenu', preventContextMenu);
-
-        // Mouse events — only forward when this viewer is active
-        const mouse = new Guacamole.Mouse(display);
-        mouse.onEach(['mousedown', 'mouseup', 'mousemove'], (e) => {
-          const mouseEvent = e as Guacamole.Mouse.Event;
-          if (activeRef.current) {
-            mouseEvent.preventDefault();
-            client.sendMouseState(mouseEvent.state);
-          }
-        });
-
-        // Clipboard: remote → browser
-        client.onclipboard = (stream: Guacamole.InputStream, mimetype: string) => {
-          if (mimetype !== 'text/plain') return;
-          const reader = new Guacamole.StringReader(stream);
-          let data = '';
-          reader.ontext = (text: string) => { data += text; };
-          reader.onend = () => {
-            if (data && navigator.clipboard?.writeText) {
-              navigator.clipboard.writeText(data).catch((err) => {
-                console.warn('Failed to write to browser clipboard:', err);
-              });
-            }
-          };
-        };
-
-        // Keyboard events — only forward when this viewer is active and focused
-        // displayRef.current is guaranteed non-null here (guarded at the top of the effect)
-        const keyboard = new Guacamole.Keyboard(displayRef.current as HTMLElement);
-        keyboardRef.current = keyboard;
-        keyboard.onkeydown = (keysym: number) => {
-          if (!activeRef.current) return false;
-          client.sendKeyEvent(1, keysym);
-          return true;
-        };
-        keyboard.onkeyup = (keysym: number) => {
-          if (!activeRef.current) return;
-          client.sendKeyEvent(0, keysym);
-        };
-
-        // Connect — pass empty string so WebSocketTunnel doesn't append
-        // literal "undefined" to the URL (which corrupts the base64 token)
-        client.connect('');
-
-        return () => {
-          resizeObserver?.disconnect();
-          display.removeEventListener('contextmenu', preventContextMenu);
-          keyboard.onkeydown = null;
-          keyboard.onkeyup = null;
-          if (heartbeatInterval) clearInterval(heartbeatInterval);
-        };
-      } catch (err: unknown) {
-        if (cancelled) return;
-        setStatus('error');
-        setError(extractApiError(err, err instanceof Error ? err.message : 'Failed to start RDP session'));
-      }
-    }
-
-    connect();
+    cancelledRef.current = false;
+    permanentErrorRef.current = false;
+    wasConnectedRef.current = false;
+    lastGuacErrorRef.current = '';
 
     // Capture ref value for cleanup — React refs may change by the time cleanup runs
     const displayEl = displayRef.current;
 
+    connectSession().catch((err: unknown) => {
+      if (cancelledRef.current) return;
+      setStatus('error');
+      setError(extractApiError(err, err instanceof Error ? err.message : 'Failed to start RDP session'));
+    });
+
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
+      cancelReconnect();
+      if (heartbeatRef.current) {
+        clearInterval(heartbeatRef.current);
+        heartbeatRef.current = null;
+      }
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      }
+      innerCleanupRef.current?.();
       if (keyboardRef.current) {
         keyboardRef.current.reset();
         keyboardRef.current = null;
       }
       if (clientRef.current) {
         clientRef.current.onclipboard = null;
+        clientRef.current.onstatechange = null;
+        clientRef.current.onerror = null;
         clientRef.current.disconnect();
       }
       // Signal the server to close the persistent session (fire-and-forget)
@@ -349,10 +449,29 @@ export default function RdpViewer({ connectionId, tabId: _tabId, isActive = true
           <Typography>Connecting to remote desktop...</Typography>
         </Box>
       )}
-      {status === 'error' && (
+      {status === 'error' && reconnectState === 'idle' && (
         <Alert severity="error" sx={{ m: 1 }}>
           {error}
         </Alert>
+      )}
+      {status === 'unstable' && reconnectState === 'idle' && (
+        <ReconnectOverlay state="unstable" attempt={0} maxRetries={maxRetries} protocol="RDP" />
+      )}
+      {reconnectState === 'reconnecting' && (
+        <ReconnectOverlay state="reconnecting" attempt={attempt} maxRetries={maxRetries} protocol="RDP" />
+      )}
+      {reconnectState === 'failed' && (
+        <ReconnectOverlay
+          state="failed"
+          attempt={attempt}
+          maxRetries={maxRetries}
+          protocol="RDP"
+          onRetry={() => {
+            permanentErrorRef.current = false;
+            wasConnectedRef.current = true;
+            triggerReconnect();
+          }}
+        />
       )}
       {toolbarActions.length > 0 && status === 'connected' && (
         <FloatingToolbar actions={toolbarActions} containerRef={containerRef} />

--- a/client/src/components/Terminal/SshTerminal.tsx
+++ b/client/src/components/Terminal/SshTerminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
 import { Box, CircularProgress, Typography, Alert } from '@mui/material';
 import { FolderOpen as FolderOpenIcon } from '@mui/icons-material';
 import { Terminal } from '@xterm/xterm';
@@ -12,7 +12,10 @@ import type { SshTerminalConfig } from '../../constants/terminalThemes';
 import { mergeTerminalConfig, toXtermOptions, resolveThemeForMode, THEME_PRESETS } from '../../constants/terminalThemes';
 import { useThemeStore } from '../../store/themeStore';
 import FloatingToolbar, { ToolbarAction } from '../shared/FloatingToolbar';
+import ReconnectOverlay from '../shared/ReconnectOverlay';
 import SftpBrowser from '../SSH/SftpBrowser';
+import { useAutoReconnect } from '../../hooks/useAutoReconnect';
+import { isSshPermanentError, isTransientDisconnect } from '../../utils/reconnectClassifier';
 import '@xterm/xterm/css/xterm.css';
 
 interface SshTerminalProps {
@@ -33,6 +36,18 @@ export default function SshTerminal({ connectionId, tabId: _tabId, credentials, 
   const accessToken = useAuthStore((s) => s.accessToken);
   const userDefaults = useTerminalSettingsStore((s) => s.userDefaults);
   const webUiMode = useThemeStore((s) => s.mode);
+
+  // Reconnection state refs
+  const wasConnectedRef = useRef(false);
+  const permanentErrorRef = useRef(false);
+  const cancelledRef = useRef(false);
+  const heartbeatIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const credentialsRef = useRef(credentials);
+  useEffect(() => { credentialsRef.current = credentials; }, [credentials]);
+
+  const accessTokenRef = useRef(accessToken);
+  useEffect(() => { accessTokenRef.current = accessToken; }, [accessToken]);
 
   // Compute xterm options from merged config (applied at mount only)
   const xtermOptions = useMemo(
@@ -113,8 +128,138 @@ export default function SshTerminal({ connectionId, tabId: _tabId, credentials, 
     return () => clearTimeout(timer);
   }, [sftpOpen]);
 
+  // Connect to SSH session — creates a new socket and emits session:start
+  const connectSession = useCallback(async () => {
+    // Clean up previous socket
+    if (heartbeatIntervalRef.current) {
+      clearInterval(heartbeatIntervalRef.current);
+      heartbeatIntervalRef.current = null;
+    }
+    if (socketRef.current) {
+      socketRef.current.removeAllListeners();
+      socketRef.current.disconnect();
+      socketRef.current = null;
+    }
+
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+
+    const token = accessTokenRef.current;
+    const creds = credentialsRef.current;
+
+    const socket = io('/ssh', {
+      auth: { token },
+      transports: ['websocket'],
+      reconnection: false,
+    });
+    socketRef.current = socket;
+
+    return new Promise<void>((resolve, reject) => {
+      socket.on('connect', () => {
+        socket.emit('session:start', {
+          connectionId,
+          ...(creds?.credentialMode === 'domain'
+            ? { credentialMode: 'domain' }
+            : creds && { username: creds.username, password: creds.password }
+          ),
+        });
+      });
+
+      socket.on('session:ready', () => {
+        wasConnectedRef.current = true;
+        setStatus('connected');
+        resetReconnect();
+        // Send initial size
+        socket.emit('resize', { cols: terminal.cols, rows: terminal.rows });
+
+        // Start heartbeat interval
+        heartbeatIntervalRef.current = setInterval(() => {
+          if (socket.connected) {
+            socket.emit('session:heartbeat');
+          }
+        }, 30_000);
+
+        if (wasConnectedRef.current) {
+          terminal.write('\r\n\x1b[32m[Reconnected]\x1b[0m\r\n');
+        }
+
+        resolve();
+      });
+
+      socket.on('data', (data: string) => {
+        terminal.write(data);
+      });
+
+      socket.on('session:error', (data: { message: string }) => {
+        if (isSshPermanentError('session:error', data)) {
+          permanentErrorRef.current = true;
+          setStatus('error');
+          setError(data.message);
+          terminal.write(`\r\n\x1b[31mError: ${data.message}\x1b[0m\r\n`);
+          reject(new Error(data.message));
+        }
+      });
+
+      socket.on('session:closed', () => {
+        terminal.write('\r\n\x1b[33mConnection closed.\x1b[0m\r\n');
+      });
+
+      socket.on('session:timeout', () => {
+        permanentErrorRef.current = true;
+        terminal.write('\r\n\x1b[31mSession expired due to inactivity.\x1b[0m\r\n');
+        setStatus('error');
+        setError('Session expired due to inactivity');
+      });
+
+      socket.on('session:terminated', () => {
+        permanentErrorRef.current = true;
+        cancelReconnect();
+        terminal.write('\r\n\x1b[31mSession terminated by administrator.\x1b[0m\r\n');
+        setStatus('error');
+        setError('Session terminated by administrator');
+      });
+
+      socket.on('connect_error', (err) => {
+        if (isSshPermanentError('connect_error', { message: err.message })) {
+          permanentErrorRef.current = true;
+          setStatus('error');
+          setError(err.message);
+          reject(new Error(err.message));
+        } else {
+          reject(new Error(err.message));
+        }
+      });
+
+      socket.on('disconnect', (reason: string) => {
+        if (heartbeatIntervalRef.current) {
+          clearInterval(heartbeatIntervalRef.current);
+          heartbeatIntervalRef.current = null;
+        }
+        if (cancelledRef.current || permanentErrorRef.current) return;
+        if (wasConnectedRef.current && isTransientDisconnect(reason)) {
+          terminal.write('\r\n\x1b[33m[Reconnecting...]\x1b[0m\r\n');
+          triggerReconnect();
+        } else if (!wasConnectedRef.current) {
+          // Initial connection failed
+          setStatus('error');
+          setError('Connection lost');
+        }
+      });
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- credentials/token tracked via refs
+  }, [connectionId]);
+
+  const { reconnectState, attempt, maxRetries, triggerReconnect, cancelReconnect, resetReconnect } = useAutoReconnect(
+    connectSession,
+  );
+
+  // Main mount effect: create terminal and connect
   useEffect(() => {
     if (!termRef.current) return;
+
+    cancelledRef.current = false;
+    permanentErrorRef.current = false;
+    wasConnectedRef.current = false;
 
     const terminal = new Terminal(xtermOptionsRef.current);
 
@@ -125,14 +270,6 @@ export default function SshTerminal({ connectionId, tabId: _tabId, credentials, 
 
     terminalRef.current = terminal;
     fitAddonRef.current = fitAddon;
-
-    // Connect to SSH Socket.io namespace
-    const socket = io('/ssh', {
-      auth: { token: accessToken },
-      transports: ['websocket'],
-    });
-
-    socketRef.current = socket;
 
     // Clipboard: Ctrl+Shift+C to copy, Ctrl+Shift+V to paste
     terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
@@ -151,8 +288,8 @@ export default function SshTerminal({ connectionId, tabId: _tabId, credentials, 
       if (event.ctrlKey && event.shiftKey && event.key === 'V') {
         if (navigator.clipboard?.readText) {
           navigator.clipboard.readText().then((text) => {
-            if (text && socket.connected) {
-              socket.emit('data', text);
+            if (text && socketRef.current?.connected) {
+              socketRef.current.emit('data', text);
             }
           }).catch((err) => {
             console.warn('Failed to read clipboard:', err);
@@ -177,80 +314,42 @@ export default function SshTerminal({ connectionId, tabId: _tabId, credentials, 
       }
     });
 
-    socket.on('connect', () => {
-      socket.emit('session:start', {
-        connectionId,
-        ...(credentials?.credentialMode === 'domain'
-          ? { credentialMode: 'domain' }
-          : credentials && { username: credentials.username, password: credentials.password }
-        ),
-      });
-    });
-
-    let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-
-    socket.on('session:ready', () => {
-      setStatus('connected');
-      // Send initial size
-      socket.emit('resize', { cols: terminal.cols, rows: terminal.rows });
-
-      // Start heartbeat interval
-      heartbeatInterval = setInterval(() => {
-        if (socket.connected) {
-          socket.emit('session:heartbeat');
-        }
-      }, 30_000);
-    });
-
-    socket.on('data', (data: string) => {
-      terminal.write(data);
-    });
-
-    socket.on('session:error', (data: { message: string }) => {
-      setStatus('error');
-      setError(data.message);
-      terminal.write(`\r\n\x1b[31mError: ${data.message}\x1b[0m\r\n`);
-    });
-
-    socket.on('session:closed', () => {
-      terminal.write('\r\n\x1b[33mConnection closed.\x1b[0m\r\n');
-    });
-
-    socket.on('session:timeout', () => {
-      terminal.write('\r\n\x1b[31mSession expired due to inactivity.\x1b[0m\r\n');
-      setStatus('error');
-      setError('Session expired due to inactivity');
-    });
-
-    socket.on('session:terminated', () => {
-      terminal.write('\r\n\x1b[31mSession terminated by administrator.\x1b[0m\r\n');
-      setStatus('error');
-      setError('Session terminated by administrator');
-    });
-
-    socket.on('connect_error', (err) => {
-      setStatus('error');
-      setError(err.message);
-    });
-
     // Send terminal input to server
     terminal.onData((data) => {
-      socket.emit('data', data);
+      if (socketRef.current?.connected) {
+        socketRef.current.emit('data', data);
+      }
     });
 
     // Handle resize
     const handleResize = () => {
       fitAddon.fit();
-      socket.emit('resize', { cols: terminal.cols, rows: terminal.rows });
+      if (socketRef.current?.connected) {
+        socketRef.current.emit('resize', { cols: terminal.cols, rows: terminal.rows });
+      }
     };
 
     const resizeObserver = new ResizeObserver(handleResize);
     resizeObserver.observe(termRef.current);
 
+    // Start initial connection
+    connectSession().catch((err: unknown) => {
+      if (cancelledRef.current) return;
+      if (!permanentErrorRef.current) {
+        setStatus('error');
+        setError(err instanceof Error ? err.message : 'Failed to connect');
+      }
+    });
+
     return () => {
-      if (heartbeatInterval) clearInterval(heartbeatInterval);
+      cancelledRef.current = true;
+      cancelReconnect();
+      if (heartbeatIntervalRef.current) clearInterval(heartbeatIntervalRef.current);
       resizeObserver.disconnect();
-      socket.disconnect();
+      if (socketRef.current) {
+        socketRef.current.removeAllListeners();
+        socketRef.current.disconnect();
+      }
       terminal.dispose();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- credentials intentionally excluded; connect once on mount
@@ -258,7 +357,7 @@ export default function SshTerminal({ connectionId, tabId: _tabId, credentials, 
 
   return (
     <Box ref={containerRef} sx={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative' }}>
-      {status === 'connecting' && (
+      {status === 'connecting' && reconnectState === 'idle' && (
         <Box
           sx={{
             position: 'absolute',
@@ -277,12 +376,28 @@ export default function SshTerminal({ connectionId, tabId: _tabId, credentials, 
           <Typography>Connecting...</Typography>
         </Box>
       )}
-      {status === 'error' && (
+      {status === 'error' && reconnectState === 'idle' && (
         <Alert severity="error" sx={{ m: 1 }}>
           {error}
         </Alert>
       )}
-      {status === 'connected' && (
+      {reconnectState === 'reconnecting' && (
+        <ReconnectOverlay state="reconnecting" attempt={attempt} maxRetries={maxRetries} protocol="SSH" />
+      )}
+      {reconnectState === 'failed' && (
+        <ReconnectOverlay
+          state="failed"
+          attempt={attempt}
+          maxRetries={maxRetries}
+          protocol="SSH"
+          onRetry={() => {
+            permanentErrorRef.current = false;
+            wasConnectedRef.current = true;
+            triggerReconnect();
+          }}
+        />
+      )}
+      {status === 'connected' && reconnectState === 'idle' && (
         <FloatingToolbar actions={toolbarActions} containerRef={containerRef} />
       )}
       <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>

--- a/client/src/components/VNC/VncViewer.tsx
+++ b/client/src/components/VNC/VncViewer.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { Box, CircularProgress, Typography, Alert } from '@mui/material';
 import * as Guacamole from '@glokon/guacamole-common-js';
 import { io } from 'socket.io-client';
 import api from '../../api/client';
 import { useAuthStore } from '../../store/authStore';
 import type { CredentialOverride } from '../../store/tabsStore';
+import ReconnectOverlay from '../shared/ReconnectOverlay';
 import { extractApiError } from '../../utils/apiError';
+import { useAutoReconnect } from '../../hooks/useAutoReconnect';
+import { isGuacPermanentError } from '../../utils/reconnectClassifier';
 
 interface VncViewerProps {
   connectionId: string;
@@ -20,8 +23,211 @@ export default function VncViewer({ connectionId, tabId: _tabId, isActive = true
   const activeRef = useRef(isActive);
   const keyboardRef = useRef<Guacamole.Keyboard | null>(null);
   const sessionIdRef = useRef<string | null>(null);
-  const [status, setStatus] = useState<'connecting' | 'connected' | 'error'>('connecting');
+  const [status, setStatus] = useState<'connecting' | 'connected' | 'unstable' | 'error'>('connecting');
   const [error, setError] = useState('');
+
+  // Reconnection state refs
+  const wasConnectedRef = useRef(false);
+  const permanentErrorRef = useRef(false);
+  const lastGuacErrorRef = useRef('');
+  const innerCleanupRef = useRef<(() => void) | null>(null);
+  const cancelledRef = useRef(false);
+  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  const credentialsRef = useRef(credentials);
+  useEffect(() => { credentialsRef.current = credentials; }, [credentials]);
+
+  const connectSession = useCallback(async () => {
+    if (!displayRef.current) return;
+
+    // Clean up previous session
+    if (heartbeatRef.current) {
+      clearInterval(heartbeatRef.current);
+      heartbeatRef.current = null;
+    }
+    if (resizeObserverRef.current) {
+      resizeObserverRef.current.disconnect();
+      resizeObserverRef.current = null;
+    }
+    if (clientRef.current) {
+      clientRef.current.onclipboard = null;
+      clientRef.current.onstatechange = null;
+      clientRef.current.onerror = null;
+      clientRef.current.disconnect();
+      clientRef.current = null;
+    }
+    innerCleanupRef.current?.();
+    innerCleanupRef.current = null;
+    if (sessionIdRef.current) {
+      api.post(`/sessions/vnc/${sessionIdRef.current}/end`).catch(() => {});
+      sessionIdRef.current = null;
+    }
+    if (displayRef.current) {
+      displayRef.current.innerHTML = '';
+    }
+
+    const creds = credentialsRef.current;
+
+    const res = await api.post('/sessions/vnc', {
+      connectionId,
+      ...(creds && {
+        password: creds.password,
+      }),
+    });
+    const { token, sessionId } = res.data;
+    sessionIdRef.current = sessionId ?? null;
+
+    if (cancelledRef.current) return;
+
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${wsProtocol}//${window.location.host}/guacamole/?token=${encodeURIComponent(token)}`;
+
+    const tunnel = new Guacamole.WebSocketTunnel(wsUrl);
+    const client = new Guacamole.Client(tunnel);
+    clientRef.current = client;
+
+    const display = client.getDisplay().getElement();
+    displayRef.current?.appendChild(display);
+
+    let connected = false;
+
+    const handleResize = () => {
+      if (!connected || !displayRef.current) return;
+      const width = displayRef.current.clientWidth;
+      const height = displayRef.current.clientHeight;
+      if (width > 0 && height > 0) {
+        client.sendSize(width, height);
+        const guacDisplay = client.getDisplay();
+        const scale = Math.min(
+          width / guacDisplay.getWidth(),
+          height / guacDisplay.getHeight()
+        );
+        if (isFinite(scale) && scale > 0) {
+          guacDisplay.scale(scale);
+        }
+      }
+    };
+
+    (client.getDisplay() as unknown as { onresize: (() => void) | null }).onresize = handleResize;
+
+    client.onstatechange = (state: number) => {
+      if (cancelledRef.current) return;
+      switch (state) {
+        case 3: // CONNECTED
+          connected = true;
+          wasConnectedRef.current = true;
+          lastGuacErrorRef.current = '';
+          setStatus('connected');
+          resetReconnect();
+          setTimeout(() => {
+            handleResize();
+            if (displayRef.current && !resizeObserverRef.current) {
+              resizeObserverRef.current = new ResizeObserver(handleResize);
+              resizeObserverRef.current.observe(displayRef.current);
+            }
+          }, 2000);
+          if (sessionIdRef.current && !heartbeatRef.current) {
+            heartbeatRef.current = setInterval(() => {
+              if (sessionIdRef.current) {
+                api.post(`/sessions/vnc/${sessionIdRef.current}/heartbeat`).catch((err) => {
+                  if (err?.response?.status === 410) {
+                    permanentErrorRef.current = true;
+                    setStatus('error');
+                    setError('Session expired due to inactivity. Please reconnect.');
+                    client.disconnect();
+                    if (heartbeatRef.current) { clearInterval(heartbeatRef.current); heartbeatRef.current = null; }
+                  }
+                });
+              }
+            }, 10_000);
+          }
+          break;
+        case 4: // UNSTABLE
+          if (connected) {
+            setStatus('unstable');
+          }
+          break;
+        case 5: // DISCONNECTED
+          connected = false;
+          if (heartbeatRef.current) {
+            clearInterval(heartbeatRef.current);
+            heartbeatRef.current = null;
+          }
+          if (permanentErrorRef.current) return;
+          if (wasConnectedRef.current && !isGuacPermanentError(lastGuacErrorRef.current)) {
+            triggerReconnect();
+          } else {
+            setStatus('error');
+            setError(lastGuacErrorRef.current || 'Disconnected from VNC session');
+          }
+          break;
+      }
+    };
+
+    client.onerror = (err: { message?: string }) => {
+      if (cancelledRef.current) return;
+      const msg = err.message || 'VNC connection error';
+      lastGuacErrorRef.current = msg;
+      if (isGuacPermanentError(msg)) {
+        permanentErrorRef.current = true;
+        setStatus('error');
+        setError(msg);
+      }
+    };
+
+    const preventContextMenu = (e: Event) => e.preventDefault();
+    display.addEventListener('contextmenu', preventContextMenu);
+
+    const mouse = new Guacamole.Mouse(display);
+    mouse.onEach(['mousedown', 'mouseup', 'mousemove'], (e) => {
+      const mouseEvent = e as Guacamole.Mouse.Event;
+      if (activeRef.current) {
+        mouseEvent.preventDefault();
+        client.sendMouseState(mouseEvent.state);
+      }
+    });
+
+    // Clipboard: remote → browser
+    client.onclipboard = (stream: Guacamole.InputStream, mimetype: string) => {
+      if (mimetype !== 'text/plain') return;
+      const reader = new Guacamole.StringReader(stream);
+      let data = '';
+      reader.ontext = (text: string) => { data += text; };
+      reader.onend = () => {
+        if (data && navigator.clipboard?.writeText) {
+          navigator.clipboard.writeText(data).catch((err) => {
+            console.warn('Failed to write to browser clipboard:', err);
+          });
+        }
+      };
+    };
+
+    const keyboard = new Guacamole.Keyboard(displayRef.current as HTMLElement);
+    keyboardRef.current = keyboard;
+    keyboard.onkeydown = (keysym: number) => {
+      if (!activeRef.current) return false;
+      client.sendKeyEvent(1, keysym);
+      return true;
+    };
+    keyboard.onkeyup = (keysym: number) => {
+      if (!activeRef.current) return;
+      client.sendKeyEvent(0, keysym);
+    };
+
+    client.connect('');
+
+    innerCleanupRef.current = () => {
+      display.removeEventListener('contextmenu', preventContextMenu);
+      keyboard.onkeydown = null;
+      keyboard.onkeyup = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- credentials tracked via ref
+  }, [connectionId]);
+
+  const { reconnectState, attempt, maxRetries, triggerReconnect, cancelReconnect, resetReconnect } = useAutoReconnect(
+    connectSession,
+  );
 
   useEffect(() => {
     activeRef.current = isActive;
@@ -43,6 +249,8 @@ export default function VncViewer({ connectionId, tabId: _tabId, isActive = true
 
     const handler = (data: { sessionId: string }) => {
       if (data.sessionId && data.sessionId === sessionIdRef.current) {
+        permanentErrorRef.current = true;
+        cancelReconnect();
         setStatus('error');
         setError('Session terminated by administrator');
         clientRef.current?.disconnect();
@@ -55,170 +263,46 @@ export default function VncViewer({ connectionId, tabId: _tabId, isActive = true
       socket.off('session:terminated', handler);
       socket.disconnect();
     };
-  }, [connectionId]);
+  }, [connectionId, cancelReconnect]);
 
+  // Initial connection
   useEffect(() => {
     if (!displayRef.current) return;
 
-    let cancelled = false;
-
-    async function connect() {
-      try {
-        const res = await api.post('/sessions/vnc', {
-          connectionId,
-          ...(credentials && {
-            password: credentials.password,
-          }),
-        });
-        const { token, sessionId } = res.data;
-        sessionIdRef.current = sessionId ?? null;
-
-        if (cancelled) return;
-
-        const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const wsUrl = `${wsProtocol}//${window.location.host}/guacamole/?token=${encodeURIComponent(token)}`;
-
-        const tunnel = new Guacamole.WebSocketTunnel(wsUrl);
-        const client = new Guacamole.Client(tunnel);
-        clientRef.current = client;
-
-        const display = client.getDisplay().getElement();
-        displayRef.current?.appendChild(display);
-
-        let connected = false;
-        let resizeObserver: ResizeObserver | null = null;
-        let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-
-        const handleResize = () => {
-          if (!connected || !displayRef.current) return;
-          const width = displayRef.current.clientWidth;
-          const height = displayRef.current.clientHeight;
-          if (width > 0 && height > 0) {
-            client.sendSize(width, height);
-            const guacDisplay = client.getDisplay();
-            const scale = Math.min(
-              width / guacDisplay.getWidth(),
-              height / guacDisplay.getHeight()
-            );
-            if (isFinite(scale) && scale > 0) {
-              guacDisplay.scale(scale);
-            }
-          }
-        };
-
-        (client.getDisplay() as unknown as { onresize: (() => void) | null }).onresize = handleResize;
-
-        client.onstatechange = (state: number) => {
-          if (cancelled) return;
-          switch (state) {
-            case 3: // CONNECTED
-              connected = true;
-              setStatus('connected');
-              setTimeout(() => {
-                handleResize();
-                if (displayRef.current && !resizeObserver) {
-                  resizeObserver = new ResizeObserver(handleResize);
-                  resizeObserver.observe(displayRef.current);
-                }
-              }, 2000);
-              if (sessionIdRef.current && !heartbeatInterval) {
-                heartbeatInterval = setInterval(() => {
-                  if (sessionIdRef.current) {
-                    api.post(`/sessions/vnc/${sessionIdRef.current}/heartbeat`).catch((err) => {
-                      if (err?.response?.status === 410) {
-                        setStatus('error');
-                        setError('Session expired due to inactivity. Please reconnect.');
-                        client.disconnect();
-                        if (heartbeatInterval) { clearInterval(heartbeatInterval); heartbeatInterval = null; }
-                      }
-                    });
-                  }
-                }, 10_000);
-              }
-              break;
-            case 5: // DISCONNECTED
-              connected = false;
-              setStatus('error');
-              setError('Disconnected from VNC session');
-              break;
-          }
-        };
-
-        client.onerror = (err: { message?: string }) => {
-          if (cancelled) return;
-          setStatus('error');
-          setError(err.message || 'VNC connection error');
-        };
-
-        const preventContextMenu = (e: Event) => e.preventDefault();
-        display.addEventListener('contextmenu', preventContextMenu);
-
-        const mouse = new Guacamole.Mouse(display);
-        mouse.onEach(['mousedown', 'mouseup', 'mousemove'], (e) => {
-          const mouseEvent = e as Guacamole.Mouse.Event;
-          if (activeRef.current) {
-            mouseEvent.preventDefault();
-            client.sendMouseState(mouseEvent.state);
-          }
-        });
-
-        // Clipboard: remote → browser
-        client.onclipboard = (stream: Guacamole.InputStream, mimetype: string) => {
-          if (mimetype !== 'text/plain') return;
-          const reader = new Guacamole.StringReader(stream);
-          let data = '';
-          reader.ontext = (text: string) => { data += text; };
-          reader.onend = () => {
-            if (data && navigator.clipboard?.writeText) {
-              navigator.clipboard.writeText(data).catch((err) => {
-                console.warn('Failed to write to browser clipboard:', err);
-              });
-            }
-          };
-        };
-
-        // displayRef.current is guaranteed non-null here (guarded at the top of the effect)
-        const keyboard = new Guacamole.Keyboard(displayRef.current as HTMLElement);
-        keyboardRef.current = keyboard;
-        keyboard.onkeydown = (keysym: number) => {
-          if (!activeRef.current) return false;
-          client.sendKeyEvent(1, keysym);
-          return true;
-        };
-        keyboard.onkeyup = (keysym: number) => {
-          if (!activeRef.current) return;
-          client.sendKeyEvent(0, keysym);
-        };
-
-        client.connect('');
-
-        return () => {
-          resizeObserver?.disconnect();
-          display.removeEventListener('contextmenu', preventContextMenu);
-          keyboard.onkeydown = null;
-          keyboard.onkeyup = null;
-          if (heartbeatInterval) clearInterval(heartbeatInterval);
-        };
-      } catch (err: unknown) {
-        if (cancelled) return;
-        setStatus('error');
-        setError(extractApiError(err, err instanceof Error ? err.message : 'Failed to start VNC session'));
-      }
-    }
-
-    connect();
+    cancelledRef.current = false;
+    permanentErrorRef.current = false;
+    wasConnectedRef.current = false;
+    lastGuacErrorRef.current = '';
 
     // Capture ref value for cleanup — React refs may change by the time cleanup runs
     const displayEl = displayRef.current;
 
+    connectSession().catch((err: unknown) => {
+      if (cancelledRef.current) return;
+      setStatus('error');
+      setError(extractApiError(err, err instanceof Error ? err.message : 'Failed to start VNC session'));
+    });
+
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
+      cancelReconnect();
+      if (heartbeatRef.current) {
+        clearInterval(heartbeatRef.current);
+        heartbeatRef.current = null;
+      }
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      }
+      innerCleanupRef.current?.();
       if (keyboardRef.current) {
         keyboardRef.current.reset();
         keyboardRef.current = null;
       }
       if (clientRef.current) {
         clientRef.current.onclipboard = null;
+        clientRef.current.onstatechange = null;
+        clientRef.current.onerror = null;
         clientRef.current.disconnect();
       }
       if (sessionIdRef.current) {
@@ -304,10 +388,29 @@ export default function VncViewer({ connectionId, tabId: _tabId, isActive = true
           <Typography>Connecting to VNC session...</Typography>
         </Box>
       )}
-      {status === 'error' && (
+      {status === 'error' && reconnectState === 'idle' && (
         <Alert severity="error" sx={{ m: 1 }}>
           {error}
         </Alert>
+      )}
+      {status === 'unstable' && reconnectState === 'idle' && (
+        <ReconnectOverlay state="unstable" attempt={0} maxRetries={maxRetries} protocol="VNC" />
+      )}
+      {reconnectState === 'reconnecting' && (
+        <ReconnectOverlay state="reconnecting" attempt={attempt} maxRetries={maxRetries} protocol="VNC" />
+      )}
+      {reconnectState === 'failed' && (
+        <ReconnectOverlay
+          state="failed"
+          attempt={attempt}
+          maxRetries={maxRetries}
+          protocol="VNC"
+          onRetry={() => {
+            permanentErrorRef.current = false;
+            wasConnectedRef.current = true;
+            triggerReconnect();
+          }}
+        />
       )}
       <Box
         ref={displayRef}

--- a/client/src/components/shared/ReconnectOverlay.tsx
+++ b/client/src/components/shared/ReconnectOverlay.tsx
@@ -1,0 +1,76 @@
+import { Box, Button, Chip, CircularProgress, Typography } from '@mui/material';
+import { ErrorOutline as ErrorIcon, SignalWifiOff as UnstableIcon } from '@mui/icons-material';
+
+interface ReconnectOverlayProps {
+  state: 'reconnecting' | 'unstable' | 'failed';
+  attempt: number;
+  maxRetries: number;
+  onRetry?: () => void;
+  onClose?: () => void;
+  protocol: 'RDP' | 'VNC' | 'SSH';
+}
+
+export default function ReconnectOverlay({ state, attempt, maxRetries, onRetry, onClose, protocol }: ReconnectOverlayProps) {
+  if (state === 'unstable') {
+    return (
+      <Box sx={{ position: 'absolute', top: 8, left: '50%', transform: 'translateX(-50%)', zIndex: 2 }}>
+        <Chip
+          icon={<UnstableIcon fontSize="small" />}
+          label="Connection unstable"
+          color="warning"
+          size="small"
+          variant="filled"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1,
+        bgcolor: 'rgba(0,0,0,0.7)',
+        gap: 2,
+      }}
+    >
+      {state === 'reconnecting' && (
+        <>
+          <CircularProgress size={32} />
+          <Typography>
+            Reconnecting to {protocol} session... (attempt {attempt + 1}/{maxRetries})
+          </Typography>
+        </>
+      )}
+      {state === 'failed' && (
+        <>
+          <ErrorIcon sx={{ fontSize: 48, color: 'error.main' }} />
+          <Typography variant="h6">Reconnection failed</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Could not restore the {protocol} session after {maxRetries} attempts.
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+            {onRetry && (
+              <Button variant="contained" size="small" onClick={onRetry}>
+                Retry
+              </Button>
+            )}
+            {onClose && (
+              <Button variant="outlined" size="small" onClick={onClose}>
+                Close Tab
+              </Button>
+            )}
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/client/src/hooks/useAutoReconnect.ts
+++ b/client/src/hooks/useAutoReconnect.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseAutoReconnectOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  totalTimeoutMs?: number;
+}
+
+interface UseAutoReconnectReturn {
+  reconnectState: 'idle' | 'reconnecting' | 'failed';
+  attempt: number;
+  maxRetries: number;
+  triggerReconnect: () => void;
+  cancelReconnect: () => void;
+  resetReconnect: () => void;
+}
+
+const DEFAULTS = {
+  maxRetries: 5,
+  baseDelayMs: 1000,
+  maxDelayMs: 15000,
+  totalTimeoutMs: 60000,
+};
+
+export function useAutoReconnect(
+  connectFn: () => Promise<void>,
+  options?: UseAutoReconnectOptions,
+): UseAutoReconnectReturn {
+  const {
+    maxRetries = DEFAULTS.maxRetries,
+    baseDelayMs = DEFAULTS.baseDelayMs,
+    maxDelayMs = DEFAULTS.maxDelayMs,
+    totalTimeoutMs = DEFAULTS.totalTimeoutMs,
+  } = options ?? {};
+
+  const [state, setState] = useState<'idle' | 'reconnecting' | 'failed'>('idle');
+  const [attempt, setAttempt] = useState(0);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startTimeRef = useRef<number>(0);
+  const attemptRef = useRef(0);
+  const connectFnRef = useRef(connectFn);
+  const cancelledRef = useRef(false);
+  const scheduleRef = useRef<(currentAttempt: number) => void>(null);
+
+  // Keep connectFn ref up to date
+  useEffect(() => {
+    connectFnRef.current = connectFn;
+  }, [connectFn]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Store schedule function in a ref to allow recursive calls without useCallback circular dep
+  useEffect(() => {
+    scheduleRef.current = (currentAttempt: number) => {
+      const elapsed = Date.now() - startTimeRef.current;
+      if (currentAttempt >= maxRetries || elapsed >= totalTimeoutMs) {
+        setState('failed');
+        return;
+      }
+
+      // Exponential backoff with jitter
+      const delay = Math.min(
+        baseDelayMs * Math.pow(2, currentAttempt) + Math.random() * 500,
+        maxDelayMs,
+      );
+
+      timerRef.current = setTimeout(async () => {
+        if (cancelledRef.current) return;
+
+        attemptRef.current = currentAttempt + 1;
+        setAttempt(currentAttempt + 1);
+
+        try {
+          await connectFnRef.current();
+          // Success — caller should call resetReconnect() when connection is confirmed
+        } catch {
+          if (!cancelledRef.current) {
+            scheduleRef.current?.(currentAttempt + 1);
+          }
+        }
+      }, delay);
+    };
+  }, [maxRetries, baseDelayMs, maxDelayMs, totalTimeoutMs]);
+
+  const triggerReconnect = useCallback(() => {
+    if (state === 'reconnecting') return; // Already reconnecting
+    cancelledRef.current = false;
+    startTimeRef.current = Date.now();
+    attemptRef.current = 0;
+    setAttempt(0);
+    setState('reconnecting');
+    scheduleRef.current?.(0);
+  }, [state]);
+
+  const cancelReconnect = useCallback(() => {
+    cancelledRef.current = true;
+    clearTimer();
+    setState('idle');
+    setAttempt(0);
+    attemptRef.current = 0;
+  }, [clearTimer]);
+
+  const resetReconnect = useCallback(() => {
+    cancelledRef.current = false;
+    clearTimer();
+    setState('idle');
+    setAttempt(0);
+    attemptRef.current = 0;
+  }, [clearTimer]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true;
+      clearTimer();
+    };
+  }, [clearTimer]);
+
+  return {
+    reconnectState: state,
+    attempt,
+    maxRetries,
+    triggerReconnect,
+    cancelReconnect,
+    resetReconnect,
+  };
+}

--- a/client/src/utils/reconnectClassifier.ts
+++ b/client/src/utils/reconnectClassifier.ts
@@ -1,0 +1,64 @@
+/**
+ * Error classification utilities for auto-reconnect logic.
+ * Distinguishes transient (retryable) disconnections from permanent errors.
+ */
+
+// Guacamole status codes that indicate permanent failure (no retry)
+const GUAC_PERMANENT_CODES = new Set([
+  0x0203, // SESSION_CLOSED
+  0x0301, // UNAUTHORIZED
+  0x0308, // SESSION_TIMEOUT
+]);
+
+const PERMANENT_ERROR_PATTERNS = [
+  'terminated by administrator',
+  'session expired',
+  'session timeout',
+  'unauthorized',
+  'authentication',
+  'permission denied',
+  'access denied',
+];
+
+/**
+ * Returns true if a Guacamole error is permanent and should NOT trigger reconnection.
+ */
+export function isGuacPermanentError(errorMessage: string, statusCode?: number): boolean {
+  if (statusCode !== undefined && GUAC_PERMANENT_CODES.has(statusCode)) {
+    return true;
+  }
+  const lower = errorMessage.toLowerCase();
+  return PERMANENT_ERROR_PATTERNS.some((p) => lower.includes(p));
+}
+
+/**
+ * Returns true if an SSH Socket.IO event represents a permanent error (no retry).
+ */
+export function isSshPermanentError(eventName: string, data?: { message?: string }): boolean {
+  // These events are always permanent
+  if (eventName === 'session:timeout' || eventName === 'session:terminated') {
+    return true;
+  }
+  if (eventName === 'session:error') {
+    // SSH session errors (auth failure, invalid connection, etc.) are permanent
+    return true;
+  }
+  if (eventName === 'connect_error' && data?.message) {
+    const lower = data.message.toLowerCase();
+    if (lower.includes('invalid token') || lower.includes('authentication')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if a Socket.IO disconnect reason indicates a transient failure (retryable).
+ */
+export function isTransientDisconnect(reason: string): boolean {
+  return (
+    reason === 'transport close' ||
+    reason === 'transport error' ||
+    reason === 'ping timeout'
+  );
+}

--- a/docs/rag-summary.md
+++ b/docs/rag-summary.md
@@ -22,6 +22,8 @@ RDP remote desktop sessions are rendered through the Guacamole protocol, providi
 
 VNC connections follow the same pattern as RDP, rendered through the Guacamole protocol with configurable color depth, cursor mode, clipboard encoding, and view-only settings.
 
+All three protocols include automatic reconnection with exponential backoff for transient network interruptions (Wi-Fi switches, brief server hiccups). A visual overlay shows reconnection progress, and Guacamole-based sessions (RDP/VNC) display a connection-unstable indicator when the connection degrades. Permanent errors (admin termination, session timeout, authentication failures) are not retried.
+
 SSH gateway support enables bastion host configurations where connections are routed through intermediate jump hosts. Arsenale supports both traditional SSH bastion hosts (with user-provided credentials) and managed SSH gateways where the platform automatically provisions and manages the infrastructure, including key pairs and container instances.
 
 ## Encrypted Credential Vault


### PR DESCRIPTION
## Task UX-073 — Auto-Reconnect & Resiliency UI

### Summary
- Added `useAutoReconnect` hook with exponential backoff (5 retries, 60s max timeout)
- Added `ReconnectOverlay` component with reconnecting/unstable/failed visual states
- Added `reconnectClassifier` utility to distinguish transient vs permanent errors
- Modified RDP, VNC, and SSH viewers to auto-reconnect on transient network failures
- Added Guacamole state 4 (UNSTABLE) indicator for degraded connections
- Permanent errors (admin termination, session timeout, auth failures) are never retried

### Related Issue
Refs #153 (UX-073)

---
*Generated by Claude Code via `/task-pick`*