### PR TITLE
Enforce restart: always policy on all containers (DOCK-212)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - pgdata_devcontainer:/var/lib/postgresql/data
     networks:
       - arsenale-devcontainer
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U arsenale"]
       interval: 5s

--- a/compose.demo.yml
+++ b/compose.demo.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/dnviti/arsenale-website
     container_name: website
     pull_policy: always
-    restart: unless-stopped
+    restart: always
     ports:
       - 8080:8080
     environment:
@@ -22,7 +22,7 @@ services:
     image: ollama/ollama
     container_name: ollama-web
     pull_policy: always
-    restart: unless-stopped
+    restart: always
     volumes:
       - ollama_models:/root/.ollama
     healthcheck:
@@ -44,7 +44,7 @@ services:
       - .env.prod
     volumes:
       - pgdata:/var/lib/postgresql/data
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test:
         [
@@ -66,7 +66,7 @@ services:
     volumes:
       - arsenale_drive:/guacd-drive
       - arsenale_recordings:/recordings
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "nc -z localhost 4822 || exit 1"]
       interval: 10s
@@ -84,7 +84,7 @@ services:
       - label:disable
     volumes:
       - arsenale_recordings:/recordings
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test:
         [
@@ -123,7 +123,7 @@ services:
       - arsenale_drive:/guacd-drive
       - arsenale_recordings:/recordings
       - /var/run/docker.sock:/var/run/docker.sock
-    restart: unless-stopped
+    restart: always
     networks:
       - arsenale-front-net
       - arsenale-back-net
@@ -166,7 +166,7 @@ services:
     depends_on:
       server:
         condition: service_healthy
-    restart: unless-stopped
+    restart: always
     networks:
       - proxy-net
       - arsenale-front-net
@@ -190,7 +190,7 @@ services:
       - .env.prod
     volumes:
       - ./config/ssh-gateway/authorized_keys:/config/authorized_keys:ro,z
-    restart: unless-stopped
+    restart: always
     networks:
       - arsenale-back-net
 
@@ -198,7 +198,7 @@ services:
     image: ollama/ollama
     container_name: ollama-backend
     pull_policy: always
-    restart: unless-stopped
+    restart: always
     volumes:
       - ollama_models:/root/.ollama
     healthcheck:

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - pgdata_dev:/var/lib/postgresql/data
     networks:
       - arsenale-dev
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U arsenale -d arsenale"]
       interval: 5s
@@ -25,7 +25,7 @@ services:
   #     - ${RECORDING_PATH:-./data/recordings}:/recordings
   #   networks:
   #     - arsenale-dev
-  #   restart: unless-stopped
+  #   restart: always
   #   healthcheck:
   #     test: ["CMD-SHELL", "nc -z localhost 4822 || exit 1"]
   #     interval: 10s
@@ -38,7 +38,7 @@ services:
       context: docker/guacenc
       dockerfile: Dockerfile
     container_name: guacenc
-    restart: unless-stopped
+    restart: always
     ports:
       - "3003:3003"
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       - .env.prod
     volumes:
       - pgdata:/var/lib/postgresql/data
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test:
         [
@@ -27,7 +27,7 @@ services:
     volumes:
       - arsenale_drive:/guacd-drive
       - arsenale_recordings:/recordings
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "nc -z localhost 4822 || exit 1"]
       interval: 10s
@@ -45,7 +45,7 @@ services:
       - label:disable
     volumes:
       - arsenale_recordings:/recordings
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test:
         [
@@ -89,7 +89,7 @@ services:
       - arsenale_drive:/guacd-drive
       - arsenale_recordings:/recordings
       - /run/user/1000/podman/podman.sock:/run/user/1000/podman/podman.sock
-    restart: unless-stopped
+    restart: always
     networks:
       - arsenale_net
 
@@ -110,7 +110,7 @@ services:
     depends_on:
       server:
         condition: service_healthy
-    restart: unless-stopped
+    restart: always
     networks:
       - arsenale_net
 
@@ -133,7 +133,7 @@ services:
       - .env.prod
     volumes:
       - ./config/ssh-gateway/authorized_keys:/config/authorized_keys:ro,z
-    restart: unless-stopped
+    restart: always
     networks:
       - arsenale_net
 

--- a/server/src/orchestrator/docker.provider.ts
+++ b/server/src/orchestrator/docker.provider.ts
@@ -67,8 +67,8 @@ export class DockerProvider implements IOrchestratorProvider {
       'on-failure': 'on-failure',
     };
     const restartPolicyName =
-      restartPolicyMap[containerConfig.restartPolicy ?? 'unless-stopped'] ??
-      'unless-stopped';
+      restartPolicyMap[containerConfig.restartPolicy ?? 'always'] ??
+      'always';
 
     const createOptions: Dockerode.ContainerCreateOptions = {
       Image: containerConfig.image,

--- a/server/src/services/managedGateway.service.ts
+++ b/server/src/services/managedGateway.service.ts
@@ -68,7 +68,7 @@ function buildContainerConfig(
         'arsenale.type': 'ssh',
       },
       ...(config.dockerNetwork ? { network: config.dockerNetwork } : {}),
-      restartPolicy: 'unless-stopped',
+      restartPolicy: 'always',
     };
   }
 
@@ -99,7 +99,7 @@ function buildContainerConfig(
       binds: [`${config.recordingVolume || config.recordingPath}:/recordings`],
       user: '0:0',
     } : {}),
-    restartPolicy: 'unless-stopped',
+    restartPolicy: 'always',
   };
 }
 


### PR DESCRIPTION
## Summary
- Changed all container restart policies from `unless-stopped` to `always` across orchestrator code and static compose files
- Ensures the platform recovers automatically after a full system reboot with zero manual intervention
- Affects: `managedGateway.service.ts`, `docker.provider.ts`, `compose.yml`, `compose.dev.yml`, `compose.demo.yml`, `.devcontainer/docker-compose.yml`

Refs #192

## Test plan
- [ ] Verify `npm run verify` passes (typecheck, lint, audit, build)
- [ ] Confirm managed gateway containers are created with `restart: always` policy
- [ ] Test full system reboot recovery — all containers should restart automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)