### PR TITLE
fix(ci): increase max-turns for Sonnet reader agents

### DIFF
--- a/.github/workflows/agentic-fleet.yml
+++ b/.github/workflows/agentic-fleet.yml
@@ -64,7 +64,7 @@ jobs:
     name: "Read — ${{ matrix.focus }}"
     needs: build-memory
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -131,7 +131,7 @@ jobs:
         run: |
           claude -p "${{ matrix.prompt }} Use @project-memory.md as structural context." \
             --model claude-sonnet-4-6 \
-            --max-turns 6 \
+            --max-turns 15 \
             --allowedTools "Read,Grep,Glob,Write"
 
       - name: Upload focus report

--- a/.github/workflows/agentic-task.yml
+++ b/.github/workflows/agentic-task.yml
@@ -62,7 +62,7 @@ jobs:
     name: "Read — ${{ matrix.focus }}"
     needs: build-memory
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -129,7 +129,7 @@ jobs:
         run: |
           claude -p "${{ matrix.prompt }} Use @project-memory.md as structural context." \
             --model claude-sonnet-4-6 \
-            --max-turns 6 \
+            --max-turns 15 \
             --allowedTools "Read,Grep,Glob,Write"
 
       - name: Upload focus report


### PR DESCRIPTION
## Summary
- Increase `--max-turns` from 6 to 15 for Sonnet reader agents in both pipelines
- Increase deep-read job timeout from 10 to 15 minutes
- Fixes "Reached max turns (6)" error during codebase analysis

## Test plan
- [ ] Re-run Idea Scout pipeline manually and confirm readers complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)