### PR TITLE
fix: address Copilot review findings from merged PRs

### DIFF
--- a/client/src/components/VNC/VncViewer.tsx
+++ b/client/src/components/VNC/VncViewer.tsx
@@ -204,7 +204,7 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
       let data = '';
       reader.ontext = (text: string) => { data += text; };
       reader.onend = () => {
-        onRemoteClipboard(data);
+        onRemoteClipboardRef.current(data);
         if (dlpPolicyRef.current?.disableCopy) return;
         if (data && navigator.clipboard?.writeText) {
           navigator.clipboard.writeText(data).catch((err) => {
@@ -273,6 +273,9 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
     suppressBrowserKeys: true,
   });
 
+  // Ref-based bridge so connectSession (defined before the hook) always gets the latest callback
+  const onRemoteClipboardRef = useRef<(text: string) => void>(() => {});
+
   // Build toolbar actions via shared hook
   const { actions: toolbarActions, onRemoteClipboard } = useGuacToolbarActions({
     protocol: 'VNC',
@@ -282,6 +285,7 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
     isFullscreen,
     toggleFullscreen,
   });
+  useEffect(() => { onRemoteClipboardRef.current = onRemoteClipboard; }, [onRemoteClipboard]);
 
   // Listen for admin-initiated session termination
   useEffect(() => {

--- a/client/src/hooks/useKeyboardCapture.ts
+++ b/client/src/hooks/useKeyboardCapture.ts
@@ -134,11 +134,15 @@ export function useKeyboardCapture({
       onFullscreenChangeRef.current?.(nowFullscreen);
 
       // Only unlock when the document has fully exited fullscreen
+      // and this hook instance actually acquired the lock
       if (document.fullscreenElement === null) {
-        try {
-          navigator.keyboard?.unlock();
-        } catch {
-          // Keyboard Lock API not supported
+        if (lockAcquiredRef.current) {
+          try {
+            navigator.keyboard?.unlock();
+          } catch {
+            // Keyboard Lock API not supported
+          }
+          lockAcquiredRef.current = false;
         }
       }
     };

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -696,8 +696,27 @@ export async function refreshAccessToken(refreshToken: string, binding?: { ip: s
 
   // Token binding verification: reject if IP/UA changed or binding info is missing
   if (config.tokenBindingEnabled && stored.ipUaHash) {
-    const currentHash = binding ? computeBindingHash(binding.ip, binding.userAgent) : null;
-    if (!currentHash || currentHash !== stored.ipUaHash) {
+    if (!binding) {
+      // Missing binding when token has stored hash = potential hijack
+      await prisma.refreshToken.deleteMany({
+        where: { tokenFamily: stored.tokenFamily },
+      });
+      auditService.log({
+        userId: stored.userId,
+        action: 'TOKEN_HIJACK_ATTEMPT',
+        ipAddress: 'unknown',
+        details: {
+          tokenFamily: stored.tokenFamily,
+          reason: 'Refresh token presented without binding info',
+        },
+      });
+      log.warn(
+        `Token binding missing for user ${stored.userId}, family ${stored.tokenFamily}. All tokens revoked.`,
+      );
+      throw new AppError('Token binding validation failed', 401);
+    }
+    const currentHash = computeBindingHash(binding.ip, binding.userAgent);
+    if (currentHash !== stored.ipUaHash) {
       // Revoke entire token family — likely session hijacking
       await prisma.refreshToken.deleteMany({
         where: { tokenFamily: stored.tokenFamily },


### PR DESCRIPTION
## Summary
- Treat missing token binding as mismatch when stored hash exists (SEC-111 bypass fix)
- Guard keyboard unlock with lockAcquiredRef in fullscreen handler (UX-301)
- Fix onRemoteClipboard reference ordering in VncViewer (UX-337)

## Test plan
- [ ] Verify token binding rejects requests without binding when hash exists
- [ ] Verify background tabs don't steal keyboard lock on fullscreen exit
- [ ] Verify VNC clipboard works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)