### PR TITLE
fix(ci): run CodeQL analysis on workflow_call events

### DIFF
--- a/.github/workflows/security-server.yml
+++ b/.github/workflows/security-server.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   codeql-analysis:
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     permissions:
       security-events: write


### PR DESCRIPTION
CodeQL job was skipped during Docker pipeline runs because the `if` condition only matched `pull_request` and `schedule` events, not `workflow_call`.