### PR TITLE
chore: sync develop into main for v1.4.0 release update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arsenale",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arsenale",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "BUSL-1.1",
       "workspaces": [
         "server",
@@ -23,7 +23,7 @@
       }
     },
     "client": {
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -12596,7 +12596,7 @@
       }
     },
     "server": {
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1004.0",


### PR DESCRIPTION
## Summary
- Syncs latest develop changes (package-lock.json version bump) into main for v1.4.0 release

## Test plan
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)