### PR TITLE
[SEC-0004] Enforce authentication on Socket.IO base namespace

### DIFF
--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -1,6 +1,7 @@
 import { Server as HttpServer } from 'http';
 import { Server } from 'socket.io';
 import { config } from '../config';
+import { verifyJwt } from '../utils/jwt';
 import { setupSshHandler } from './ssh.handler';
 import { setupNotificationHandler } from './notification.handler';
 import { setupGatewayMonitorHandler } from './gatewayMonitor.handler';
@@ -11,6 +12,20 @@ export function setupSocketIO(httpServer: HttpServer): Server {
       origin: [config.clientUrl],
       methods: ['GET', 'POST'],
     },
+  });
+
+  // Server-level auth middleware: reject unauthenticated connections
+  // before they reach any namespace-specific middleware
+  io.use((socket, next) => {
+    const token = socket.handshake.auth.token;
+    if (!token) return next(new Error('Authentication required'));
+
+    try {
+      verifyJwt(token);
+      next();
+    } catch {
+      next(new Error('Authentication required'));
+    }
   });
 
   setupSshHandler(io);


### PR DESCRIPTION
## Task SEC-0004 — Enforce authentication on Socket.IO base namespace

### Summary
- Added server-level `io.use()` JWT authentication middleware
- All Socket.IO connections now require valid JWT before namespace-specific middleware runs

### Related Issue
Refs #260 (SEC-0004)

---
*Generated by Claude Code via `/task-pick`*