### PR TITLE
[SEC-0009] Add custom Express 404 handler to prevent framework disclosure

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -97,6 +97,11 @@ app.use('/api/vault-providers', externalVaultRoutes);
 // Health & readiness probes
 app.use('/api', healthRoutes);
 
+// Custom 404 handler for API routes (prevents framework disclosure)
+app.use('/api', (_req, res) => {
+  res.status(404).json({ error: 'Not found' });
+});
+
 // Error handler
 app.use(errorHandler);
 


### PR DESCRIPTION
## Task SEC-0009 — Custom Express 404 handler

### Summary
- Added catch-all 404 handler for `/api` routes returning JSON instead of Express default HTML

### Related Issue
Refs #255 (SEC-0009)

---
*Generated by Claude Code via `/task-pick`*