### PR TITLE
[SEC-0011] Enforce tenant boundary on connection sharing recipients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -274,6 +274,10 @@ LDAP_AUTO_PROVISION=true
 # Default tenant ID to assign auto-provisioned LDAP users (optional)
 LDAP_DEFAULT_TENANT_ID=
 
+# Multi-tenancy — allow sharing connections with users outside the sharer's tenant
+# When false (default), users can only share with members of the same tenant.
+ALLOW_EXTERNAL_SHARING=false
+
 # WebAuthn / Passkey (FIDO2)
 # Relying party identifier (usually the domain name, e.g., example.com)
 WEBAUTHN_RP_ID=localhost

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -232,6 +232,8 @@ export const config = {
     autoProvision: process.env.LDAP_AUTO_PROVISION !== 'false',
     defaultTenantId: process.env.LDAP_DEFAULT_TENANT_ID || '',
   },
+  // Multi-tenancy — allow sharing connections with users outside the sharer's tenant
+  allowExternalSharing: process.env.ALLOW_EXTERNAL_SHARING === 'true',
   webauthn: {
     rpId: process.env.WEBAUTHN_RP_ID || 'localhost',
     rpOrigin: process.env.WEBAUTHN_RP_ORIGIN || 'http://localhost:3000',

--- a/server/src/services/sharing.service.ts
+++ b/server/src/services/sharing.service.ts
@@ -205,6 +205,8 @@ export async function batchShareConnections(
     throw new AppError('Cannot share with yourself', 400);
   }
 
+  await assertShareableTenantBoundary(actingUserId, targetUser.id);
+
   const results = await Promise.allSettled(
     connectionIds.map((connectionId) =>
       shareConnection(actingUserId, connectionId, { userId: targetUser.id }, permission, tenantId)

--- a/server/src/utils/tenantScope.test.ts
+++ b/server/src/utils/tenantScope.test.ts
@@ -10,6 +10,14 @@ vi.mock('../lib/prisma', () => ({
   },
 }));
 
+vi.mock('../config', () => ({
+  config: {
+    get allowExternalSharing() {
+      return process.env.ALLOW_EXTERNAL_SHARING === 'true';
+    },
+  },
+}));
+
 import {
   assertSameTenant,
   tenantScopedTeamFilter,
@@ -82,21 +90,45 @@ describe('assertShareableTenantBoundary', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('throws 400 when users have no common tenant', async () => {
+  it('throws 403 when users have no common tenant', async () => {
     mockFindMany
       .mockResolvedValueOnce([{ tenantId: 'tenant-1' }])
       .mockResolvedValueOnce([{ tenantId: 'tenant-2' }]);
     await expect(
       assertShareableTenantBoundary('user-1', 'user-2'),
     ).rejects.toThrow(AppError);
-    // Verify status code
+    // Verify status code and message
     mockFindMany
       .mockResolvedValueOnce([{ tenantId: 'tenant-1' }])
       .mockResolvedValueOnce([{ tenantId: 'tenant-2' }]);
     try {
       await assertShareableTenantBoundary('user-1', 'user-2');
     } catch (err) {
-      expect((err as AppError).statusCode).toBe(400);
+      expect((err as AppError).statusCode).toBe(403);
+      expect((err as AppError).message).toBe(
+        'Cannot share connections with users outside your tenant',
+      );
+    }
+  });
+
+  it('skips check when ALLOW_EXTERNAL_SHARING is true', async () => {
+    const origVal = process.env.ALLOW_EXTERNAL_SHARING;
+    process.env.ALLOW_EXTERNAL_SHARING = 'true';
+    try {
+      mockFindMany
+        .mockResolvedValueOnce([{ tenantId: 'tenant-1' }])
+        .mockResolvedValueOnce([{ tenantId: 'tenant-2' }]);
+      await expect(
+        assertShareableTenantBoundary('user-1', 'user-2'),
+      ).resolves.toBeUndefined();
+      // Should not have queried DB at all
+      expect(mockFindMany).not.toHaveBeenCalled();
+    } finally {
+      if (origVal === undefined) {
+        delete process.env.ALLOW_EXTERNAL_SHARING;
+      } else {
+        process.env.ALLOW_EXTERNAL_SHARING = origVal;
+      }
     }
   });
 });

--- a/server/src/utils/tenantScope.ts
+++ b/server/src/utils/tenantScope.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../middleware/error.middleware';
 import prisma from '../lib/prisma';
+import { config } from '../config';
 
 /**
  * Asserts a resource's tenant matches the user's tenant.
@@ -35,11 +36,14 @@ export function tenantScopedTeamFilter(
 /**
  * Asserts both users share at least one tenant (bidirectional check).
  * Passes if neither user belongs to any tenant (backward compat).
+ * Skipped entirely when ALLOW_EXTERNAL_SHARING is true.
  */
 export async function assertShareableTenantBoundary(
   actingUserId: string,
   targetUserId: string
 ): Promise<void> {
+  if (config.allowExternalSharing) return;
+
   const [actingMemberships, targetMemberships] = await Promise.all([
     prisma.tenantMember.findMany({
       where: { userId: actingUserId },
@@ -55,7 +59,7 @@ export async function assertShareableTenantBoundary(
   if (actingTenantIds.size > 0 || targetTenantIds.size > 0) {
     const hasCommon = [...actingTenantIds].some((id) => targetTenantIds.has(id));
     if (!hasCommon) {
-      throw new AppError('Cannot share with users outside your organization', 400);
+      throw new AppError('Cannot share connections with users outside your tenant', 403);
     }
   }
 }


### PR DESCRIPTION
## Task SEC-0011 — Enforce tenant boundary on sharing

### Summary
- Tenant boundary check now applied to batch sharing (was missing)
- Error status changed from 400 to 403 for cross-tenant sharing
- Added `ALLOW_EXTERNAL_SHARING` config flag (defaults to false)
- Updated tests for new behavior

### Related Issue
Refs #256 (SEC-0011)

---
*Generated by Claude Code via `/task-pick`*