### PR TITLE
[SEC-0012] Only set CORS allow-credentials when whitelisted origin matches

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -57,7 +57,16 @@ app.use(helmet({
   referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
 }));
 if (config.trustProxy !== false) app.set('trust proxy', config.trustProxy);
-app.use(cors({ origin: [config.clientUrl], credentials: true }));
+app.use(cors({
+  origin: (origin, callback) => {
+    if (!origin || origin === config.clientUrl) {
+      callback(null, true);
+    } else {
+      callback(null, false);
+    }
+  },
+  credentials: true,
+}));
 app.use(express.json({ limit: '500kb' }));
 app.use(cookieParser());
 app.use(passport.initialize());


### PR DESCRIPTION
## Task SEC-0012 — CORS credentials fix

### Summary
- Replaced static CORS config with custom origin handler
- `Access-Control-Allow-Credentials` only sent when origin matches whitelist

### Related Issue
Refs #258 (SEC-0012)

---
*Generated by Claude Code via `/task-pick`*