### PR TITLE
Fix duplicate Guacamole connections and reconnect loop on RDP/VNC session open

### DIFF
--- a/client/src/components/RDP/RdpViewer.tsx
+++ b/client/src/components/RDP/RdpViewer.tsx
@@ -45,19 +45,32 @@ export default function RdpViewer({ connectionId, tabId, isActive = true, enable
   const lastGuacErrorRef = useRef('');
   // Cleanup function returned by the inner connect setup
   const innerCleanupRef = useRef<(() => void) | null>(null);
-  // Cancelled flag for async operations
-  const cancelledRef = useRef(false);
+  // Generation counter — each connectSession invocation gets a unique ID so stale
+  // invocations (e.g. from React Strict Mode double-mount) bail after async gaps.
+  const connectionGenRef = useRef(0);
   // Heartbeat interval ref (accessible for cleanup during reconnect)
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // ResizeObserver ref
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  // Timestamp when state 3 (CONNECTED) was reached — used to gate reconnection.
+  // Only connections stable for ≥ STABLE_THRESHOLD_MS qualify for auto-reconnect.
+  const connectedAtRef = useRef(0);
 
   const credentialsRef = useRef(credentials);
   useEffect(() => { credentialsRef.current = credentials; }, [credentials]);
 
+  // Minimum time (ms) a connection must be in state 3 (CONNECTED) before it is
+  // considered stable.  Only stable connections qualify for auto-reconnect on
+  // disconnect — brief connect/disconnect cycles during initial setup will show
+  // an error instead of spawning a reconnection loop.
+  const STABLE_THRESHOLD_MS = 5_000;
+
   // Reconnect connect function — creates a new Guacamole session
   const connectSession = useCallback(async () => {
     if (!displayRef.current) return;
+
+    // Bump generation so any in-flight stale invocation bails after its next await
+    const gen = ++connectionGenRef.current;
 
     // Clean up previous session
     if (heartbeatRef.current) {
@@ -102,10 +115,17 @@ export default function RdpViewer({ connectionId, tabId, isActive = true, enable
       ),
     });
     const { token, sessionId, dlpPolicy: resDlp } = res.data;
+
+    // Stale check — a newer connectSession has been launched (e.g. Strict Mode
+    // double-mount or rapid reconnect).  End the session we just created so it
+    // doesn't leave an orphaned recording on the server.
+    if (connectionGenRef.current !== gen) {
+      if (sessionId) api.post(`/sessions/rdp/${sessionId}/end`).catch(() => {});
+      return;
+    }
+
     sessionIdRef.current = sessionId ?? null;
     if (resDlp) { setDlpPolicy(resDlp); dlpPolicyRef.current = resDlp; }
-
-    if (cancelledRef.current) return;
 
     // Determine WebSocket URL for guacamole-lite (proxied through Vite/nginx)
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -144,11 +164,12 @@ export default function RdpViewer({ connectionId, tabId, isActive = true, enable
 
     // Handle state changes
     client.onstatechange = (state: number) => {
-      if (cancelledRef.current) return;
+      if (connectionGenRef.current !== gen) return; // stale connection
       switch (state) {
         case 3: // CONNECTED
           connected = true;
           wasConnectedRef.current = true;
+          connectedAtRef.current = Date.now();
           lastGuacErrorRef.current = '';
           setStatus('connected');
           resetReconnect();
@@ -193,19 +214,29 @@ export default function RdpViewer({ connectionId, tabId, isActive = true, enable
             // Already handled (admin termination, session expired, etc.)
             return;
           }
-          if (wasConnectedRef.current && !isGuacPermanentError(lastGuacErrorRef.current)) {
-            // Transient — attempt reconnection
-            triggerReconnect();
-          } else {
-            setStatus('error');
-            setError(lastGuacErrorRef.current || 'Disconnected from remote desktop');
+          {
+            const uptime = connectedAtRef.current ? Date.now() - connectedAtRef.current : 0;
+            connectedAtRef.current = 0;
+            if (
+              wasConnectedRef.current &&
+              uptime >= STABLE_THRESHOLD_MS &&
+              !isGuacPermanentError(lastGuacErrorRef.current)
+            ) {
+              // Stable connection lost — attempt reconnection
+              triggerReconnect();
+            } else {
+              // Never connected, or connection was too brief (initial setup
+              // churn), or permanent error — show error, don't reconnect.
+              setStatus('error');
+              setError(lastGuacErrorRef.current || 'Disconnected from remote desktop');
+            }
           }
           break;
       }
     };
 
     client.onerror = (err: { message?: string }) => {
-      if (cancelledRef.current) return;
+      if (connectionGenRef.current !== gen) return;
       const msg = err.message || 'RDP connection error';
       lastGuacErrorRef.current = msg;
       if (isGuacPermanentError(msg)) {
@@ -358,22 +389,30 @@ export default function RdpViewer({ connectionId, tabId, isActive = true, enable
   useEffect(() => {
     if (!displayRef.current) return;
 
-    cancelledRef.current = false;
     permanentErrorRef.current = false;
     wasConnectedRef.current = false;
     lastGuacErrorRef.current = '';
+    connectedAtRef.current = 0;
 
     // Capture ref value for cleanup — React refs may change by the time cleanup runs
     const displayEl = displayRef.current;
 
+    // connectSession bumps connectionGenRef synchronously on entry, so we
+    // can snapshot the generation immediately after the (sync) call start.
     connectSession().catch((err: unknown) => {
-      if (cancelledRef.current) return;
+      // If the generation was bumped by cleanup or a newer invocation,
+      // this error is stale — the new invocation's state updates take over.
+      if (connectionGenRef.current !== mountGen) return;
       setStatus('error');
       setError(extractApiError(err, err instanceof Error ? err.message : 'Failed to start RDP session'));
     });
+    // connectSession increments the ref synchronously before its first await,
+    // so this captures the generation for THIS mount's connection.
+    const mountGen = connectionGenRef.current;
 
     return () => {
-      cancelledRef.current = true;
+      // Bump generation to invalidate any in-flight connectSession from this mount
+      ++connectionGenRef.current;
       cancelReconnect();
       if (heartbeatRef.current) {
         clearInterval(heartbeatRef.current);

--- a/client/src/components/VNC/VncViewer.tsx
+++ b/client/src/components/VNC/VncViewer.tsx
@@ -39,15 +39,20 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
   const permanentErrorRef = useRef(false);
   const lastGuacErrorRef = useRef('');
   const innerCleanupRef = useRef<(() => void) | null>(null);
-  const cancelledRef = useRef(false);
+  const connectionGenRef = useRef(0);
   const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const connectedAtRef = useRef(0);
 
   const credentialsRef = useRef(credentials);
   useEffect(() => { credentialsRef.current = credentials; }, [credentials]);
 
+  const STABLE_THRESHOLD_MS = 5_000;
+
   const connectSession = useCallback(async () => {
     if (!displayRef.current) return;
+
+    const gen = ++connectionGenRef.current;
 
     // Clean up previous session
     if (heartbeatRef.current) {
@@ -84,10 +89,14 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
       }),
     });
     const { token, sessionId, dlpPolicy: resDlp } = res.data;
+
+    if (connectionGenRef.current !== gen) {
+      if (sessionId) api.post(`/sessions/vnc/${sessionId}/end`).catch(() => {});
+      return;
+    }
+
     sessionIdRef.current = sessionId ?? null;
     if (resDlp) { setDlpPolicy(resDlp); dlpPolicyRef.current = resDlp; }
-
-    if (cancelledRef.current) return;
 
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = `${wsProtocol}//${window.location.host}/guacamole/?token=${encodeURIComponent(token)}`;
@@ -121,11 +130,12 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
     (client.getDisplay() as unknown as { onresize: (() => void) | null }).onresize = handleResize;
 
     client.onstatechange = (state: number) => {
-      if (cancelledRef.current) return;
+      if (connectionGenRef.current !== gen) return;
       switch (state) {
         case 3: // CONNECTED
           connected = true;
           wasConnectedRef.current = true;
+          connectedAtRef.current = Date.now();
           lastGuacErrorRef.current = '';
           setStatus('connected');
           resetReconnect();
@@ -164,18 +174,26 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
             heartbeatRef.current = null;
           }
           if (permanentErrorRef.current) return;
-          if (wasConnectedRef.current && !isGuacPermanentError(lastGuacErrorRef.current)) {
-            triggerReconnect();
-          } else {
-            setStatus('error');
-            setError(lastGuacErrorRef.current || 'Disconnected from VNC session');
+          {
+            const uptime = connectedAtRef.current ? Date.now() - connectedAtRef.current : 0;
+            connectedAtRef.current = 0;
+            if (
+              wasConnectedRef.current &&
+              uptime >= STABLE_THRESHOLD_MS &&
+              !isGuacPermanentError(lastGuacErrorRef.current)
+            ) {
+              triggerReconnect();
+            } else {
+              setStatus('error');
+              setError(lastGuacErrorRef.current || 'Disconnected from VNC session');
+            }
           }
           break;
       }
     };
 
     client.onerror = (err: { message?: string }) => {
-      if (cancelledRef.current) return;
+      if (connectionGenRef.current !== gen) return;
       const msg = err.message || 'VNC connection error';
       lastGuacErrorRef.current = msg;
       if (isGuacPermanentError(msg)) {
@@ -319,22 +337,23 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
   useEffect(() => {
     if (!displayRef.current) return;
 
-    cancelledRef.current = false;
     permanentErrorRef.current = false;
     wasConnectedRef.current = false;
     lastGuacErrorRef.current = '';
+    connectedAtRef.current = 0;
 
     // Capture ref value for cleanup — React refs may change by the time cleanup runs
     const displayEl = displayRef.current;
 
     connectSession().catch((err: unknown) => {
-      if (cancelledRef.current) return;
+      if (connectionGenRef.current !== mountGen) return;
       setStatus('error');
       setError(extractApiError(err, err instanceof Error ? err.message : 'Failed to start VNC session'));
     });
+    const mountGen = connectionGenRef.current;
 
     return () => {
-      cancelledRef.current = true;
+      ++connectionGenRef.current;
       cancelReconnect();
       if (heartbeatRef.current) {
         clearInterval(heartbeatRef.current);
@@ -364,7 +383,7 @@ export default function VncViewer({ connectionId, tabId, isActive = true, creden
         displayEl.innerHTML = '';
       }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- credentials intentionally excluded; connect once on mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- credentials excluded; connectionGenRef write in cleanup is intentional
   }, [connectionId]);
 
   return (

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -236,7 +236,7 @@ async function main() {
             key: getGuacamoleKey(),
           },
           log: {
-            level: config.logGuacamole ? toGuacamoleLogLevel(config.logLevel) : 'QUIET',
+            level: config.logGuacamole ? toGuacamoleLogLevel(config.logLevel) : 0,
           },
         }
       );

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -58,16 +58,20 @@ export const logger = createLogger();
 export type Logger = ReturnType<typeof createLogger>;
 
 /**
- * Maps LOG_LEVEL to guacamole-lite's log level string.
- * guacamole-lite levels: QUIET, ERRORS, NORMAL, VERBOSE, DEBUG
+ * Maps LOG_LEVEL to guacamole-lite's numeric log level.
+ * guacamole-lite levels: QUIET=0, ERRORS=10, NORMAL=20, VERBOSE=30, DEBUG=40
+ *
+ * Returns numeric values directly because guacamole-lite's string→number
+ * conversion has a bug: LOGLEVEL['QUIET'] is 0 (falsy), so the string
+ * 'QUIET' is never converted and log filtering breaks.
  */
-export function toGuacamoleLogLevel(level: LogLevel): string {
+export function toGuacamoleLogLevel(level: LogLevel): number {
   switch (level) {
-    case 'error': return 'ERRORS';
-    case 'warn':  return 'ERRORS';
-    case 'info':  return 'NORMAL';
-    case 'verbose': return 'VERBOSE';
-    case 'debug': return 'DEBUG';
-    default:      return 'NORMAL';
+    case 'error': return 10;
+    case 'warn':  return 10;
+    case 'info':  return 20;
+    case 'verbose': return 30;
+    case 'debug': return 40;
+    default:      return 20;
   }
 }


### PR DESCRIPTION
## Summary

Opening a single RDP session was spawning 3–4 guacamole connections (each with its own recording) before the final one stabilized. This caused unnecessary server load and orphaned recordings.

### Root causes and fixes

**1. Race condition with `cancelledRef` (both RDP + VNC viewers)**

In React Strict Mode (or any double-mount scenario), the cleanup sets `cancelledRef.current = true`, but the remount immediately resets it to `false` — un-cancelling the first in-flight `connectSession`. Both invocations run in parallel, creating orphaned sessions and recordings on the server.

**Fix:** Replaced the shared `cancelledRef` boolean with a per-invocation **generation counter** (`connectionGenRef`). Each `connectSession` call increments the counter and captures its generation; after any `await`, it bails if a newer invocation has superseded it. The effect cleanup bumps the generation to invalidate stale work. Orphaned server sessions are explicitly ended via `POST /sessions/rdp/:id/end`.

**2. Reconnect loop on brief connections (both RDP + VNC viewers)**

When a connection briefly reaches state 3 (CONNECTED) then immediately disconnects (state 5), `wasConnectedRef` is `true` so `triggerReconnect()` fires. Meanwhile, `resetReconnect()` in state 3 resets the exponential backoff, so each cycle starts fresh at ~1s delay — creating a rapid loop of short-lived sessions.

**Fix:** Added a **stability gate** (`STABLE_THRESHOLD_MS = 5000`). Only connections that have been CONNECTED for ≥ 5 seconds qualify for auto-reconnect. Brief connect/disconnect cycles during initial setup show an error instead of spawning a reconnection loop.

**3. `LOG_GUACAMOLE=false` not working (server)**

guacamole-lite's `Server.js` has a bug: `LOGLEVEL['QUIET']` is `0` (falsy in JS), so the condition `LOGLEVEL[level]` evaluates to `false` and the string `'QUIET'` is never converted to numeric `0`. The Logger then compares `40 > 'QUIET'` (NaN), which is always `false`, so nothing gets filtered.

**Fix:** `toGuacamoleLogLevel()` now returns **numeric values** directly (0, 10, 20, 30, 40), and the disabled case passes `0` instead of the string `'QUIET'`, bypassing guacamole-lite's broken conversion.

## Files changed

| File | Change |
|------|--------|
| `client/src/components/RDP/RdpViewer.tsx` | Generation counter + stability gate |
| `client/src/components/VNC/VncViewer.tsx` | Same fixes applied |
| `server/src/utils/logger.ts` | Return numeric log levels |
| `server/src/index.ts` | Pass `0` instead of `'QUIET'` |

## Test plan

- [ ] Open a single RDP session — verify only 1 guacamole connection is created (not 3–4)
- [ ] Verify only 1 recording starts per session
- [ ] Set `LOG_GUACAMOLE=false` — verify no guacamole protocol messages in server logs
- [ ] Disconnect network briefly during an active session (>5s) — verify auto-reconnect still works
- [ ] Open a VNC session — verify same single-connection behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)