### PR TITLE
[DB-001] Add missing Prisma migration for AccessPolicy model

### DIFF
--- a/server/prisma/migrations/20260315000002_zt_113_abac_policies/migration.sql
+++ b/server/prisma/migrations/20260315000002_zt_113_abac_policies/migration.sql
@@ -1,0 +1,35 @@
+-- AlterEnum: Add SESSION_DENIED_ABAC to AuditAction
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'SESSION_DENIED_ABAC'
+                   AND enumtypid = (SELECT oid FROM pg_type WHERE typname = 'AuditAction')) THEN
+        ALTER TYPE "AuditAction" ADD VALUE 'SESSION_DENIED_ABAC';
+    END IF;
+END
+$$;
+
+-- CreateEnum: AccessPolicyTargetType
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'AccessPolicyTargetType') THEN
+        CREATE TYPE "AccessPolicyTargetType" AS ENUM ('TENANT', 'TEAM', 'FOLDER');
+    END IF;
+END
+$$;
+
+-- CreateTable: AccessPolicy
+CREATE TABLE IF NOT EXISTS "AccessPolicy" (
+    "id" TEXT NOT NULL,
+    "targetType" "AccessPolicyTargetType" NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "allowedTimeWindows" TEXT,
+    "requireTrustedDevice" BOOLEAN NOT NULL DEFAULT false,
+    "requireMfaStepUp" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AccessPolicy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "AccessPolicy_targetType_targetId_idx" ON "AccessPolicy"("targetType", "targetId");


### PR DESCRIPTION
## Summary
- Adds the missing Prisma migration for the `AccessPolicy` model, `AccessPolicyTargetType` enum, and `SESSION_DENIED_ABAC` audit action introduced by ZT-113 (ABAC)
- Without this migration, `prisma migrate deploy` detects schema drift and fails at server startup

## Changes
- New migration file `20260315000002_zt_113_abac_policies/migration.sql`
- Creates `AccessPolicyTargetType` enum (TENANT, TEAM, FOLDER)
- Creates `AccessPolicy` table with all columns and composite index
- Adds `SESSION_DENIED_ABAC` to `AuditAction` enum
- All statements use `IF NOT EXISTS` for idempotency

## Test plan
- [ ] Server starts successfully with `prisma migrate deploy`
- [ ] `AccessPolicy` table exists with correct schema
- [ ] `SESSION_DENIED_ABAC` is a valid `AuditAction` value

Refs #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)