### PR TITLE
feat: add version indicator with update notification

### DIFF
--- a/client/src/api/version.api.ts
+++ b/client/src/api/version.api.ts
@@ -1,0 +1,71 @@
+export interface VersionInfo {
+  current: string;
+  latest?: string;
+  latestUrl?: string;
+  updateAvailable: boolean;
+}
+
+const SESSION_KEY = 'arsenale-version-check';
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+export async function checkVersion(): Promise<VersionInfo> {
+  // Get current version from server health endpoint
+  const healthRes = await fetch('/api/health');
+  const health = await healthRes.json();
+  const current: string = health.version;
+
+  // Check sessionStorage cache first
+  const cached = sessionStorage.getItem(SESSION_KEY);
+  if (cached) {
+    try {
+      const data = JSON.parse(cached) as VersionInfo;
+      // Re-evaluate against current in case health version changed
+      if (data.latest) {
+        return {
+          current,
+          latest: data.latest,
+          latestUrl: data.latestUrl,
+          updateAvailable: compareSemver(data.latest, current) > 0,
+        };
+      }
+      return { current, updateAvailable: false };
+    } catch {
+      // Ignore corrupt cache
+    }
+  }
+
+  // Fetch latest release from GitHub
+  try {
+    const ghRes = await fetch(
+      'https://api.github.com/repos/dnviti/arsenale/releases/latest',
+    );
+    if (!ghRes.ok) {
+      const result: VersionInfo = { current, updateAvailable: false };
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(result));
+      return result;
+    }
+    const release = await ghRes.json();
+    const latest: string = (release.tag_name || '').replace(/^v/, '');
+    const result: VersionInfo = {
+      current,
+      latest,
+      latestUrl: release.html_url,
+      updateAvailable: compareSemver(latest, current) > 0,
+    };
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(result));
+    return result;
+  } catch {
+    const result: VersionInfo = { current, updateAvailable: false };
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(result));
+    return result;
+  }
+}

--- a/client/src/components/Layout/MainLayout.tsx
+++ b/client/src/components/Layout/MainLayout.tsx
@@ -34,6 +34,7 @@ const GeoIpDialog = lazy(() => import('../Audit/GeoIpDialog'));
 
 import TenantSwitcher from './TenantSwitcher';
 import NotificationBell from './NotificationBell';
+import VersionIndicator from './VersionIndicator';
 import { useAuthStore } from '../../store/authStore';
 import { useVaultStore } from '../../store/vaultStore';
 import { logoutApi } from '../../api/auth.api';
@@ -303,7 +304,8 @@ export default function MainLayout() {
             minWidth: SIDEBAR_WIDTH,
             borderRight: 1,
             borderColor: 'divider',
-            overflow: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
             bgcolor: 'background.paper',
             userSelect: 'none',
           }}
@@ -324,18 +326,21 @@ export default function MainLayout() {
               </Typography>
             </Alert>
           )}
-          <ConnectionTree
-            onEditConnection={handleEditConnection}
-            onShareConnection={handleShareConnection}
-            onConnectAsConnection={setConnectAsTarget}
-            onCreateConnection={handleCreateConnection}
-            onCreateFolder={handleCreateFolder}
-            onEditFolder={handleEditFolder}
-            onShareFolder={handleShareFolder}
-            onViewAuditLog={(conn) => setConnectionAuditTarget({ id: conn.id, name: conn.name })}
-            onImport={() => setImportDialogOpen(true)}
-            onExport={() => setExportDialogOpen(true)}
-          />
+          <Box sx={{ flex: 1, overflow: 'auto' }}>
+            <ConnectionTree
+              onEditConnection={handleEditConnection}
+              onShareConnection={handleShareConnection}
+              onConnectAsConnection={setConnectAsTarget}
+              onCreateConnection={handleCreateConnection}
+              onCreateFolder={handleCreateFolder}
+              onEditFolder={handleEditFolder}
+              onShareFolder={handleShareFolder}
+              onViewAuditLog={(conn) => setConnectionAuditTarget({ id: conn.id, name: conn.name })}
+              onImport={() => setImportDialogOpen(true)}
+              onExport={() => setExportDialogOpen(true)}
+            />
+          </Box>
+          <VersionIndicator />
         </Box>
 
         {/* Main content */}

--- a/client/src/components/Layout/VersionIndicator.tsx
+++ b/client/src/components/Layout/VersionIndicator.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { Box, Chip, Link, Tooltip } from '@mui/material';
+import { NewReleases as NewReleasesIcon } from '@mui/icons-material';
+import { checkVersion, type VersionInfo } from '../../api/version.api';
+import { useAuthStore } from '../../store/authStore';
+import { isAdminOrAbove } from '../../utils/roles';
+
+export default function VersionIndicator() {
+  const [info, setInfo] = useState<VersionInfo | null>(null);
+  const tenantRole = useAuthStore((s) => s.user?.tenantRole);
+
+  useEffect(() => {
+    let cancelled = false;
+    checkVersion()
+      .then((v) => { if (!cancelled) setInfo(v); })
+      .catch(() => { /* silent */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!info) return null;
+
+  const showUpdate = info.updateAvailable && isAdminOrAbove(tenantRole);
+
+  return (
+    <Box
+      sx={{
+        px: 1.5,
+        py: 0.75,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        borderTop: 1,
+        borderColor: 'divider',
+      }}
+    >
+      <Chip
+        label={`v${info.current}`}
+        size="small"
+        variant="outlined"
+        sx={{ height: 20, fontSize: '0.7rem', '& .MuiChip-label': { px: 0.75 } }}
+      />
+      {showUpdate && info.latest && info.latestUrl && (
+        <Tooltip title={`Update available: v${info.latest}`} arrow>
+          <Link
+            href={info.latestUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            underline="none"
+            sx={{ display: 'flex', alignItems: 'center' }}
+          >
+            <Chip
+              icon={<NewReleasesIcon sx={{ fontSize: '0.85rem !important' }} />}
+              label={`v${info.latest}`}
+              size="small"
+              color="warning"
+              variant="outlined"
+              clickable
+              sx={{ height: 20, fontSize: '0.7rem', '& .MuiChip-label': { px: 0.75 } }}
+            />
+          </Link>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}

--- a/server/src/routes/health.routes.ts
+++ b/server/src/routes/health.routes.ts
@@ -7,8 +7,12 @@ import {
 
 const router = Router();
 
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { version } = require('../../../package.json') as { version: string };
+/* eslint-enable @typescript-eslint/no-require-imports */
+
 router.get('/health', (_req: Request, res: Response) => {
-  res.json({ status: 'ok' });
+  res.json({ status: 'ok', version });
 });
 
 router.get('/ready', async (_req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- Expose app version in `/api/health` endpoint
- Add version check utility that compares current vs latest GitHub release (semver comparison)
- Show version chip in MainLayout sidebar footer
- ADMIN/OWNER users see amber "update available" chip linking to GitHub release when outdated
- GitHub API response cached in sessionStorage to avoid rate limiting

## Test plan
- [ ] `/api/health` returns `{ status: 'ok', version: '1.4.1' }`
- [ ] Version chip shows in sidebar bottom
- [ ] Update hint appears when running older version (test by temporarily changing version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)