### PR TITLE
fix: correct package.json path in health routes for Docker

### DIFF
--- a/server/src/routes/health.routes.ts
+++ b/server/src/routes/health.routes.ts
@@ -8,7 +8,7 @@ import {
 const router = Router();
 
 /* eslint-disable @typescript-eslint/no-require-imports */
-const { version } = require('../../../package.json') as { version: string };
+const { version } = require('../../package.json') as { version: string };
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 router.get('/health', (_req: Request, res: Response) => {


### PR DESCRIPTION
## Fix

`health.routes.ts` used `require('../../../package.json')` which works from `server/src/routes/` in dev but resolves to `/` in the Docker container (compiled output at `/app/dist/routes/`).

Changed to `../../package.json`:
- **Docker**: `/app/dist/routes/` → `/app/package.json` ✓
- **Dev**: `server/src/routes/` → `server/package.json` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)