### PR TITLE
chore: bump version to 1.5.0 in all package.json files

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "React 19 + Vite frontend for Arsenale",
   "license": "BUSL-1.1",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arsenale",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Web-based remote desktop manager for SSH and RDP connections with encrypted vault, team sharing, and multi-tenant support",
   "author": "Daniele Viti <daniele@dnviti.dev>",
   "license": "BUSL-1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Express + TypeScript backend for Arsenale",
   "license": "BUSL-1.1",
   "private": true,

--- a/tunnel-agent/package.json
+++ b/tunnel-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tunnel-agent",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Zero-trust tunnel agent — embedded in managed gateway containers",
   "license": "BUSL-1.1",
   "private": true,


### PR DESCRIPTION
## Version Bump

Updates `version` field from `1.4.1` to `1.5.0` in:
- `package.json` (root)
- `server/package.json`
- `client/package.json`
- `tunnel-agent/package.json`

This was missing from the initial v1.5.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)