### PR TITLE
fix: move USER root before apk upgrade in guacd Dockerfile

### DIFF
--- a/docker/guacd/Dockerfile
+++ b/docker/guacd/Dockerfile
@@ -23,14 +23,14 @@ RUN npm run build && npm prune --omit=dev
 # ── guacd runtime + tunnel agent ─────────────────────────────────────────────
 FROM guacamole/guacd:1.6.0
 
+USER root
+
 RUN apk update && apk upgrade --no-cache
 
 LABEL org.opencontainers.image.title="Arsenale guacd"
 LABEL org.opencontainers.image.description="guacd with embedded zero-trust tunnel agent"
 LABEL org.opencontainers.image.source="https://github.com/dnviti/arsenale"
 LABEL org.opencontainers.image.licenses="BUSL-1.1"
-
-USER root
 
 # Install Node.js runtime (Alpine-based guacd image, so use apk)
 RUN apk add --no-cache nodejs


### PR DESCRIPTION
## Summary
- Fix guacd Docker build failure: `guacamole/guacd:1.6.0` runs as non-root by default, so `apk update && apk upgrade` needs `USER root` first

## Context
Post-tag CI monitoring for v1.5.1 found this failure in the "Guacd — Build & Scan" workflow. The `USER root` directive was already present but placed after the `apk upgrade` command.

## Test plan
- [x] Verified other Dockerfiles don't have this issue (all use root-by-default base images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)