### PR TITLE
fix: use BUILDPLATFORM for Node.js builder stages in Dockerfiles

### DIFF
--- a/docker/guacd/Dockerfile
+++ b/docker/guacd/Dockerfile
@@ -8,7 +8,7 @@
 # TUNNEL_GATEWAY_ID environment variables are set.
 
 # ── Tunnel agent build stage ─────────────────────────────────────────────────
-FROM node:22-alpine AS tunnel-builder
+FROM --platform=$BUILDPLATFORM node:22-alpine AS tunnel-builder
 
 WORKDIR /tunnel-agent
 

--- a/ssh-gateway/Dockerfile
+++ b/ssh-gateway/Dockerfile
@@ -2,7 +2,7 @@
 # This allows copying tunnel-agent sources alongside the ssh-gateway files.
 
 # ── Tunnel agent build stage ─────────────────────────────────────────────────
-FROM node:22-alpine AS tunnel-builder
+FROM --platform=$BUILDPLATFORM node:22-alpine AS tunnel-builder
 
 WORKDIR /tunnel-agent
 

--- a/tunnel-agent/Dockerfile
+++ b/tunnel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ RUN npm install --ignore-scripts
 COPY tsconfig.json ./
 COPY src/ ./src/
 
-RUN npm run build
+RUN npm run build && npm prune --omit=dev
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM node:22-alpine
@@ -23,10 +23,8 @@ LABEL org.opencontainers.image.licenses="BUSL-1.1"
 
 WORKDIR /app
 
-# Install only production dependencies
-COPY package.json ./
-RUN npm install --omit=dev --ignore-scripts
-
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 
 # Non-root user


### PR DESCRIPTION
## Summary
- Add `--platform=$BUILDPLATFORM` to Node.js builder stages in ssh-gateway, guacd, and tunnel-agent Dockerfiles
- Move `npm install` from tunnel-agent runtime stage to builder stage (avoids running npm under QEMU)

## Root Cause
Multi-platform Docker builds (linux/amd64,linux/arm64) run arm64 builds under QEMU emulation on amd64 GitHub runners. Node.js V8 JIT crashes with `qemu: uncaught target signal 4 (Illegal instruction) - core dumped` during `npm install`/`npm run build`.

Since TypeScript compilation produces architecture-independent JavaScript, the builder stage can run natively on the host platform (`$BUILDPLATFORM`) while only the runtime stage uses the target platform.

## Test plan
- [x] Fix applied to all 3 affected Dockerfiles (ssh-gateway, guacd, tunnel-agent)
- [x] guacenc left unchanged (compiles native C code, needs target platform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)