### PR TITLE
fix(security): add non-root USER to guacenc Dockerfile (SEC-2030)

### DIFF
--- a/gateways/guacenc/Dockerfile
+++ b/gateways/guacenc/Dockerfile
@@ -40,6 +40,8 @@ RUN apk update && apk upgrade --no-cache
 
 RUN apk add --no-cache python3 ffmpeg-libs ffmpeg libpng cairo libjpeg-turbo libuuid
 
+RUN addgroup -S guacenc && adduser -S -G guacenc guacenc
+
 COPY --from=builder /usr/local/bin/guacenc /usr/local/bin/guacenc
 COPY --from=builder /tmp/guacamole-server-1.6.0/src/libguac/.libs/libguac.so* /usr/local/lib/
 RUN ldconfig /usr/local/lib
@@ -47,6 +49,10 @@ RUN ldconfig /usr/local/lib
 COPY --from=agg-builder /usr/local/bin/agg /usr/local/bin/agg
 
 COPY server.py /opt/guacenc/server.py
+
+RUN mkdir -p /recordings && chown guacenc:guacenc /recordings
+
+USER guacenc
 
 EXPOSE 3003
 


### PR DESCRIPTION
## Summary
- Adds a dedicated `guacenc` non-root user to the guacenc Dockerfile runtime stage
- Creates `/recordings/` directory with proper ownership for the non-root user
- Sets `USER guacenc` before `EXPOSE`, resolving Trivy DS-0002 (HIGH)

Refs #332

## Test plan
- [ ] Build guacenc Docker image successfully
- [ ] Verify container runs as `guacenc` user (not root)
- [ ] Verify `/health` endpoint responds correctly
- [ ] Verify recording conversion works with mounted `/recordings/` volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)