### PR TITLE
fix(theme): fix invisible toolbar icons in light mode (THEME-2031)

### DIFF
--- a/client/src/components/Layout/MainLayout.tsx
+++ b/client/src/components/Layout/MainLayout.tsx
@@ -237,7 +237,7 @@ export default function MainLayout() {
           transition: 'filter 0.3s ease',
         }}
       >
-      <AppBar position="static" elevation={0} sx={{ zIndex: (theme) => theme.zIndex.drawer + 1, bgcolor: (theme) => theme.palette.mode === 'dark' ? alpha(theme.palette.background.default, 0.8) : alpha(theme.palette.background.default, 0.9), backdropFilter: 'blur(20px)', borderBottom: 1, borderColor: 'divider' }}>
+      <AppBar position="static" elevation={0} sx={{ zIndex: (theme) => theme.zIndex.drawer + 1, bgcolor: (theme) => theme.palette.mode === 'dark' ? alpha(theme.palette.background.default, 0.8) : alpha(theme.palette.background.default, 0.9), color: 'text.primary', backdropFilter: 'blur(20px)', borderBottom: 1, borderColor: 'divider' }}>
         <Toolbar variant="dense">
           <Typography variant="h6" sx={{ flexGrow: 0, mr: 2, fontFamily: (theme) => theme.typography.h5.fontFamily, fontSize: '1.4rem', color: 'text.primary' }}>
             Arsenale


### PR DESCRIPTION
## Summary
- Adds `color: 'text.primary'` to the AppBar `sx` prop
- Root cause: AppBar IconButtons use `color="inherit"`, inheriting MUI's default white text color from `AppBar color="primary"`. The custom `bgcolor` override changed the background but not the inherited text color, leaving icons invisible in light mode.

Refs #334

## Test plan
- [ ] Switch to any light theme — toolbar icons (keychain, theme toggle, user avatar) should be visible
- [ ] Verify icons remain visible in dark mode too

🤖 Generated with [Claude Code](https://claude.com/claude-code)