### PR TITLE
feat: Pwned Password Check for Vault Secrets (SEC-112)

### DIFF
--- a/client/src/api/secrets.api.ts
+++ b/client/src/api/secrets.api.ts
@@ -69,6 +69,7 @@ export interface SecretListItem {
   metadata: Record<string, unknown> | null;
   tags: string[];
   isFavorite: boolean;
+  pwnedCount: number;
   expiresAt: string | null;
   currentVersion: number;
   createdAt: string;
@@ -234,6 +235,30 @@ export async function distributeTenantKey(targetUserId: string): Promise<{ distr
 
 export async function getTenantVaultStatus(): Promise<TenantVaultStatus> {
   const { data } = await api.get('/secrets/tenant-vault/status');
+  return data;
+}
+
+// --- Breach check types ---
+
+export interface BreachCheckResult {
+  pwnedCount: number;
+}
+
+export interface BatchBreachCheckResult {
+  checked: number;
+  pwned: number;
+  results: Array<{ id: string; name: string; pwnedCount: number }>;
+}
+
+// --- Breach check API ---
+
+export async function checkSecretBreach(secretId: string): Promise<BreachCheckResult> {
+  const { data } = await api.post(`/secrets/${secretId}/breach-check`);
+  return data;
+}
+
+export async function checkAllSecretBreaches(): Promise<BatchBreachCheckResult> {
+  const { data } = await api.post('/secrets/breach-check');
   return data;
 }
 

--- a/client/src/components/Dialogs/KeychainDialog.tsx
+++ b/client/src/components/Dialogs/KeychainDialog.tsx
@@ -50,6 +50,7 @@ export default function KeychainDialog({ open, onClose }: KeychainDialogProps) {
   const tenantVaultStatus = useSecretStore((s) => s.tenantVaultStatus);
   const fetchTenantVaultStatus = useSecretStore((s) => s.fetchTenantVaultStatus);
   const initTenantVault = useSecretStore((s) => s.initTenantVault);
+  const checkSecretBreach = useSecretStore((s) => s.checkSecretBreach);
   const user = useAuthStore((s) => s.user);
 
   const treeOpen = useUiPreferencesStore((s) => s.keychainTreeOpen);
@@ -296,6 +297,7 @@ export default function KeychainDialog({ open, onClose }: KeychainDialogProps) {
               onDelete={() => setDeleteTarget(selectedSecret)}
               onToggleFavorite={() => toggleFavorite(selectedSecret.id)}
               onRestore={handleRestore}
+              onCheckBreach={checkSecretBreach}
             />
           ) : (
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>

--- a/client/src/components/Keychain/SecretDetailView.tsx
+++ b/client/src/components/Keychain/SecretDetailView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import {
   Box, Typography, Chip, IconButton, Accordion, AccordionSummary,
-  AccordionDetails, Divider, Tooltip, Alert,
+  AccordionDetails, Divider, Tooltip, Alert, Button, CircularProgress,
 } from '@mui/material';
 import {
   Edit as EditIcon, Share as ShareIcon, Delete as DeleteIcon,
@@ -9,6 +9,7 @@ import {
   Visibility, VisibilityOff, ExpandMore as ExpandMoreIcon,
   VpnKey, Key, VerifiedUser, Api, Notes,
   OpenInNew as LinkIcon, Link as ExternalLinkIcon,
+  GppBad as BreachIcon, Security as SecurityIcon,
 } from '@mui/icons-material';
 import type { SecretDetail, SecretPayload, SecretType, SecretScope } from '../../api/secrets.api';
 import SecretVersionHistory from './SecretVersionHistory';
@@ -46,6 +47,7 @@ interface SecretDetailViewProps {
   onDelete: () => void;
   onToggleFavorite: () => void;
   onRestore: () => void;
+  onCheckBreach?: (secretId: string) => Promise<number>;
 }
 
 function SensitiveField({ label, value }: { label: string; value: string }) {
@@ -192,7 +194,10 @@ export default function SecretDetailView({
   onDelete,
   onToggleFavorite,
   onRestore,
+  onCheckBreach,
 }: SecretDetailViewProps) {
+  const [breachChecking, setBreachChecking] = useState(false);
+
   const formatDate = (iso: string) =>
     new Date(iso).toLocaleDateString(undefined, {
       month: 'short', day: 'numeric', year: 'numeric',
@@ -206,6 +211,18 @@ export default function SecretDetailView({
   }, [secret.expiresAt]);
 
   const isReadOnly = secret.shared && secret.permission === 'READ_ONLY';
+
+  const hasCheckablePassword = ['LOGIN', 'SSH_KEY', 'CERTIFICATE'].includes(secret.type);
+
+  const handleCheckBreach = async () => {
+    if (!onCheckBreach) return;
+    setBreachChecking(true);
+    try {
+      await onCheckBreach(secret.id);
+    } finally {
+      setBreachChecking(false);
+    }
+  };
 
   return (
     <Box sx={{ p: 2, overflow: 'auto', height: '100%' }}>
@@ -245,6 +262,23 @@ export default function SecretDetailView({
         )}
       </Box>
 
+      {secret.pwnedCount > 0 && (
+        <Alert
+          severity="error"
+          icon={<BreachIcon />}
+          sx={{ mb: 2 }}
+          action={
+            !isReadOnly ? (
+              <Button color="error" size="small" onClick={onEdit}>
+                Rotate
+              </Button>
+            ) : undefined
+          }
+        >
+          Password found in {secret.pwnedCount.toLocaleString()} data breach(es). You should change this password immediately.
+        </Alert>
+      )}
+
       {daysUntilExpiry !== null && daysUntilExpiry <= 30 && (
         <Alert
           severity={daysUntilExpiry <= 0 ? 'error' : daysUntilExpiry <= 7 ? 'warning' : 'info'}
@@ -254,6 +288,20 @@ export default function SecretDetailView({
             ? 'This secret has expired. Update the credentials or the expiry date.'
             : `This secret expires in ${daysUntilExpiry} day(s). Consider rotating credentials.`}
         </Alert>
+      )}
+
+      {hasCheckablePassword && secret.pwnedCount === 0 && onCheckBreach && (
+        <Box sx={{ mb: 2 }}>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={breachChecking ? <CircularProgress size={16} /> : <SecurityIcon />}
+            onClick={handleCheckBreach}
+            disabled={breachChecking}
+          >
+            {breachChecking ? 'Checking...' : 'Check for breaches'}
+          </Button>
+        </Box>
       )}
 
       {secret.description && (

--- a/client/src/components/Keychain/SecretListPanel.tsx
+++ b/client/src/components/Keychain/SecretListPanel.tsx
@@ -12,6 +12,7 @@ import {
   Edit as EditIcon, Share as ShareIcon, Delete as DeleteIcon,
   ContentCopy as CopyIcon,
   DriveFileMove as MoveIcon,
+  GppBad as BreachIcon,
 } from '@mui/icons-material';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
@@ -107,6 +108,15 @@ function DraggableSecretItem({
             <Typography variant="caption" color="text.secondary" noWrap>
               {TYPE_LABELS[secret.type]}
             </Typography>
+            {secret.pwnedCount > 0 && (
+              <Chip
+                icon={<BreachIcon sx={{ fontSize: '0.7rem' }} />}
+                label="Breached"
+                size="small"
+                color="error"
+                sx={{ height: 16, fontSize: '0.6rem' }}
+              />
+            )}
             {daysUntilExpiry !== null && daysUntilExpiry <= 30 && (
               <Chip
                 label={daysUntilExpiry <= 0 ? 'Expired' : `${daysUntilExpiry}d left`}

--- a/client/src/components/Keychain/SecretPicker.tsx
+++ b/client/src/components/Keychain/SecretPicker.tsx
@@ -83,6 +83,7 @@ export default function SecretPicker({
         metadata: null,
         tags: [],
         isFavorite: false,
+        pwnedCount: 0,
         expiresAt: null,
         currentVersion: 1,
         createdAt: '',

--- a/client/src/components/Layout/MainLayout.tsx
+++ b/client/src/components/Layout/MainLayout.tsx
@@ -71,6 +71,8 @@ export default function MainLayout() {
 
   const expiringCount = useSecretStore((s) => s.expiringCount);
   const fetchExpiringCount = useSecretStore((s) => s.fetchExpiringCount);
+  const pwnedCount = useSecretStore((s) => s.pwnedCount);
+  const fetchPwnedCount = useSecretStore((s) => s.fetchPwnedCount);
 
   useGatewayMonitor();
   useShareSync();
@@ -92,8 +94,9 @@ export default function MainLayout() {
   useEffect(() => {
     if (vaultUnlocked) {
       fetchExpiringCount();
+      fetchPwnedCount();
     }
-  }, [vaultUnlocked, fetchExpiringCount]);
+  }, [vaultUnlocked, fetchExpiringCount, fetchPwnedCount]);
 
   // PWA app shortcut deep-link: read ?action= query param to pre-open a dialog on mount (PWA-003)
   const [pwaAction] = useState(() => {
@@ -262,7 +265,7 @@ export default function MainLayout() {
             title="Keychain"
             sx={{ mr: 1, '&:hover': { bgcolor: (theme) => `${theme.palette.primary.main}14` } }}
           >
-            <Badge badgeContent={expiringCount} color="error" max={99}>
+            <Badge badgeContent={expiringCount + pwnedCount} color="error" max={99}>
               <KeychainIcon />
             </Badge>
           </IconButton>

--- a/client/src/store/secretStore.ts
+++ b/client/src/store/secretStore.ts
@@ -7,6 +7,8 @@ import {
   deleteSecret as apiDeleteSecret,
   getTenantVaultStatus,
   initTenantVault as apiInitTenantVault,
+  checkSecretBreach as apiCheckSecretBreach,
+  checkAllSecretBreaches as apiCheckAllBreaches,
 } from '../api/secrets.api';
 import type {
   SecretListItem,
@@ -15,6 +17,7 @@ import type {
   CreateSecretInput,
   UpdateSecretInput,
   TenantVaultStatus,
+  BatchBreachCheckResult,
 } from '../api/secrets.api';
 import { listVaultFolders } from '../api/vault-folders.api';
 import type { VaultFolderData } from '../api/vault-folders.api';
@@ -27,6 +30,7 @@ interface SecretState {
   filters: SecretListFilters;
   tenantVaultStatus: TenantVaultStatus | null;
   expiringCount: number;
+  pwnedCount: number;
 
   // Vault folders
   vaultFolders: VaultFolderData[];
@@ -45,6 +49,9 @@ interface SecretState {
   fetchTenantVaultStatus: () => Promise<void>;
   initTenantVault: () => Promise<void>;
   fetchExpiringCount: () => Promise<void>;
+  fetchPwnedCount: () => Promise<void>;
+  checkSecretBreach: (secretId: string) => Promise<number>;
+  checkAllBreaches: () => Promise<BatchBreachCheckResult>;
 
   // Vault folder actions
   fetchVaultFolders: () => Promise<void>;
@@ -60,6 +67,7 @@ export const useSecretStore = create<SecretState>((set, get) => ({
   filters: {},
   tenantVaultStatus: null,
   expiringCount: 0,
+  pwnedCount: 0,
 
   // Vault folders
   vaultFolders: [],
@@ -166,6 +174,39 @@ export const useSecretStore = create<SecretState>((set, get) => ({
     } catch {
       // ignore — vault may be locked
     }
+  },
+
+  fetchPwnedCount: async () => {
+    try {
+      const allSecrets = await listSecrets({});
+      const count = allSecrets.filter((s) => s.pwnedCount > 0).length;
+      set({ pwnedCount: count });
+    } catch {
+      // ignore — vault may be locked
+    }
+  },
+
+  checkSecretBreach: async (secretId: string) => {
+    const result = await apiCheckSecretBreach(secretId);
+    // Update the secret in the list
+    set((state) => ({
+      secrets: state.secrets.map((s) =>
+        s.id === secretId ? { ...s, pwnedCount: result.pwnedCount } : s,
+      ),
+      selectedSecret:
+        state.selectedSecret?.id === secretId
+          ? { ...state.selectedSecret, pwnedCount: result.pwnedCount }
+          : state.selectedSecret,
+    }));
+    return result.pwnedCount;
+  },
+
+  checkAllBreaches: async () => {
+    const result = await apiCheckAllBreaches();
+    // Refresh list to get updated pwnedCount values
+    await get().fetchSecrets();
+    set({ pwnedCount: result.pwned });
+    return result;
   },
 
   // Vault folder actions

--- a/server/prisma/migrations/20260319000000_sec_112_pwned_count/migration.sql
+++ b/server/prisma/migrations/20260319000000_sec_112_pwned_count/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "VaultSecret" ADD COLUMN "pwnedCount" INTEGER NOT NULL DEFAULT 0;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -752,6 +752,7 @@ model VaultSecret {
   metadata       Json?
   tags           String[]    @default([])
   isFavorite     Boolean     @default(false)
+  pwnedCount     Int         @default(0)
   expiresAt      DateTime?
   currentVersion Int         @default(1)
   createdAt      DateTime    @default(now())

--- a/server/src/controllers/secret.controller.ts
+++ b/server/src/controllers/secret.controller.ts
@@ -252,6 +252,27 @@ export async function listShares(req: AuthRequest, res: Response) {
   res.json(result);
 }
 
+// --- Breach check handlers ---
+
+export async function checkBreach(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const result = await secretService.checkSecretBreach(
+    req.user.userId,
+    req.params.id as string,
+    req.user.tenantId
+  );
+  res.json(result);
+}
+
+export async function checkAllBreaches(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const result = await secretService.checkAllSecretBreaches(
+    req.user.userId,
+    req.user.tenantId
+  );
+  res.json(result);
+}
+
 // --- Tenant vault handlers ---
 
 export async function initTenantVault(req: AuthRequest, res: Response) {

--- a/server/src/routes/secret.routes.ts
+++ b/server/src/routes/secret.routes.ts
@@ -16,6 +16,9 @@ router.post('/tenant-vault/init', asyncHandler(secretController.initTenantVault)
 router.post('/tenant-vault/distribute', validate(distributeTenantKeySchema), asyncHandler(secretController.distributeTenantKey));
 router.get('/tenant-vault/status', asyncHandler(secretController.tenantVaultStatus));
 
+// Breach check — batch (before /:id to avoid param collision)
+router.post('/breach-check', asyncHandler(secretController.checkAllBreaches));
+
 // External share revoke (before /:id to avoid param collision)
 router.delete('/external-shares/:shareId', asyncHandler(externalShareController.revoke));
 
@@ -25,6 +28,9 @@ router.post('/', validate(createSecretSchema), asyncHandler(secretController.cre
 router.get('/:id', validateUuidParam(), asyncHandler(secretController.getOne));
 router.put('/:id', validateUuidParam(), validate(updateSecretSchema), asyncHandler(secretController.update));
 router.delete('/:id', validateUuidParam(), asyncHandler(secretController.remove));
+
+// Breach check — single secret
+router.post('/:id/breach-check', validateUuidParam(), asyncHandler(secretController.checkBreach));
 
 // Versions
 router.get('/:id/versions', validateUuidParam(), asyncHandler(secretController.listVersions));

--- a/server/src/services/pwnedPassword.service.ts
+++ b/server/src/services/pwnedPassword.service.ts
@@ -1,0 +1,71 @@
+import crypto from 'crypto';
+import { logger } from '../utils/logger';
+
+const log = logger.child('pwnedPassword');
+
+const HIBP_API_URL = 'https://api.pwnedpasswords.com/range';
+const HIBP_USER_AGENT = 'Arsenale-PasswordCheck';
+
+/**
+ * Check if a password has been exposed in known data breaches
+ * using the HaveIBeenPwned k-Anonymity API.
+ *
+ * Only the first 5 characters of the SHA-1 hash are sent to the API.
+ * The full hash never leaves the server.
+ *
+ * @returns The number of times the password has been seen in breaches (0 = not found).
+ */
+export async function checkPwnedPassword(password: string): Promise<number> {
+  try {
+    const sha1 = crypto.createHash('sha1').update(password).digest('hex').toUpperCase();
+    const prefix = sha1.substring(0, 5);
+    const suffix = sha1.substring(5);
+
+    const response = await fetch(`${HIBP_API_URL}/${prefix}`, {
+      headers: {
+        'User-Agent': HIBP_USER_AGENT,
+        'Add-Padding': 'true',
+      },
+    });
+
+    if (!response.ok) {
+      log.warn(`HIBP API returned status ${response.status}`);
+      return 0; // fail open — do not block the user
+    }
+
+    const text = await response.text();
+    const lines = text.split('\n');
+
+    for (const line of lines) {
+      const [hashSuffix, countStr] = line.trim().split(':');
+      if (hashSuffix === suffix) {
+        const count = parseInt(countStr, 10);
+        return isNaN(count) ? 0 : count;
+      }
+    }
+
+    return 0;
+  } catch (err) {
+    log.warn('Failed to check HIBP API', err);
+    return 0; // fail open — do not block the user
+  }
+}
+
+/**
+ * Extract the password from a secret payload if it has one.
+ * Returns null for secret types that don't contain passwords.
+ */
+export function extractPasswordFromPayload(
+  data: { type: string; password?: string; passphrase?: string }
+): string | null {
+  switch (data.type) {
+    case 'LOGIN':
+      return data.password || null;
+    case 'SSH_KEY':
+      return data.passphrase || null;
+    case 'CERTIFICATE':
+      return data.passphrase || null;
+    default:
+      return null;
+  }
+}

--- a/server/src/services/secret.service.ts
+++ b/server/src/services/secret.service.ts
@@ -13,6 +13,7 @@ import {
 } from './crypto.service';
 import { resolveTeamKey } from './team.service';
 import * as permissionService from './permission.service';
+import { checkPwnedPassword, extractPasswordFromPayload } from './pwnedPassword.service';
 import type { EncryptedField, SecretPayload } from '../types';
 
 // --- Input / Output interfaces ---
@@ -229,6 +230,7 @@ function secretSummary(secret: any) {
     metadata: secret.metadata,
     tags: secret.tags,
     isFavorite: secret.isFavorite,
+    pwnedCount: secret.pwnedCount ?? 0,
     expiresAt: secret.expiresAt,
     currentVersion: secret.currentVersion,
     createdAt: secret.createdAt,
@@ -291,6 +293,10 @@ export async function createSecret(
   const plaintext = JSON.stringify(input.data);
   const encrypted = encrypt(plaintext, encryptionKey);
 
+  // Check password against HIBP (non-blocking — uses k-Anonymity)
+  const passwordToCheck = extractPasswordFromPayload(input.data);
+  const pwnedCount = passwordToCheck ? await checkPwnedPassword(passwordToCheck) : 0;
+
   const secret = await prisma.$transaction(async (tx) => {
     const s = await tx.vaultSecret.create({
       data: {
@@ -312,6 +318,7 @@ export async function createSecret(
         dataTag: encrypted.tag,
         metadata: (input.metadata as Prisma.InputJsonValue) ?? undefined,
         tags: input.tags ?? [],
+        pwnedCount,
         expiresAt: input.expiresAt || null,
       },
     });
@@ -419,9 +426,14 @@ export async function updateSecret(
     const plaintext = JSON.stringify(input.data);
     const encrypted = encrypt(plaintext, encryptionKey);
 
+    // Re-check password against HIBP on update
+    const passwordToCheck = extractPasswordFromPayload(input.data);
+    const pwnedCount = passwordToCheck ? await checkPwnedPassword(passwordToCheck) : 0;
+
     data.encryptedData = encrypted.ciphertext;
     data.dataIV = encrypted.iv;
     data.dataTag = encrypted.tag;
+    data.pwnedCount = pwnedCount;
     data.currentVersion = secret.currentVersion + 1;
 
     const updated = await prisma.$transaction(async (tx) => {
@@ -547,6 +559,7 @@ export async function listSecrets(
       metadata: true,
       tags: true,
       isFavorite: true,
+      pwnedCount: true,
       expiresAt: true,
       currentVersion: true,
       createdAt: true,
@@ -671,4 +684,100 @@ export async function restoreSecretVersion(
     currentVersion: updated.currentVersion,
     updatedAt: updated.updatedAt,
   };
+}
+
+// --- Pwned password breach check ---
+
+/**
+ * On-demand breach check for a single secret.
+ * Decrypts the secret, extracts the password, checks HIBP, and persists the result.
+ */
+export async function checkSecretBreach(
+  userId: string,
+  secretId: string,
+  tenantId?: string | null
+): Promise<{ pwnedCount: number }> {
+  const access = await permissionService.canViewSecret(userId, secretId, tenantId);
+  if (!access.allowed) throw new AppError('Secret not found', 404);
+
+  const secret = access.secret;
+
+  // Shared secrets: use shared encrypted data
+  let decryptedJson: string;
+  if (access.accessType === 'shared') {
+    const sharedRecord = await prisma.sharedSecret.findFirst({
+      where: { secretId, sharedWithUserId: userId },
+    });
+    if (!sharedRecord) throw new AppError('Secret not found', 404);
+
+    const personalKey = requireMasterKey(userId);
+    decryptedJson = decrypt(
+      { ciphertext: sharedRecord.encryptedData, iv: sharedRecord.dataIV, tag: sharedRecord.dataTag },
+      personalKey
+    );
+  } else {
+    const encryptionKey = await resolveSecretEncryptionKey(
+      userId,
+      secret.scope,
+      secret.teamId,
+      secret.tenantId
+    );
+    decryptedJson = decrypt(
+      { ciphertext: secret.encryptedData, iv: secret.dataIV, tag: secret.dataTag },
+      encryptionKey
+    );
+  }
+
+  const data: SecretPayload = JSON.parse(decryptedJson);
+  const passwordToCheck = extractPasswordFromPayload(data);
+
+  if (!passwordToCheck) {
+    // Secret type has no checkable password
+    return { pwnedCount: 0 };
+  }
+
+  const pwnedCount = await checkPwnedPassword(passwordToCheck);
+
+  // Persist the result (only if user is owner/manager, not shared)
+  if (access.accessType !== 'shared') {
+    await prisma.vaultSecret.update({
+      where: { id: secretId },
+      data: { pwnedCount },
+    });
+  }
+
+  return { pwnedCount };
+}
+
+/**
+ * Batch breach check for all secrets accessible to a user.
+ * Returns an array of { id, pwnedCount } for secrets that have checkable passwords.
+ */
+export async function checkAllSecretBreaches(
+  userId: string,
+  tenantId?: string | null
+): Promise<{ checked: number; pwned: number; results: Array<{ id: string; name: string; pwnedCount: number }> }> {
+  // Get all user's secrets (personal scope only for batch check)
+  const secrets = await listSecrets(userId, {}, tenantId);
+  const results: Array<{ id: string; name: string; pwnedCount: number }> = [];
+  let checked = 0;
+  let pwned = 0;
+
+  for (const secretItem of secrets) {
+    // Only check types that have passwords
+    if (!['LOGIN', 'SSH_KEY', 'CERTIFICATE'].includes(secretItem.type)) continue;
+
+    try {
+      const result = await checkSecretBreach(userId, secretItem.id, tenantId);
+      checked++;
+      if (result.pwnedCount > 0) {
+        pwned++;
+        results.push({ id: secretItem.id, name: secretItem.name, pwnedCount: result.pwnedCount });
+      }
+    } catch {
+      // Skip secrets we can't decrypt (e.g., locked scope)
+    }
+  }
+
+  return { checked, pwned, results };
 }


### PR DESCRIPTION
## Summary
- Integrate HaveIBeenPwned k-Anonymity API to check vault credentials against known data breaches (MITRE ATT&CK T1552)
- Auto-check passwords during secret creation/update and store `pwnedCount` on the VaultSecret model
- Add single-secret and batch breach check API endpoints for on-demand re-scanning
- Show breach warning badges in the Keychain list, detail alerts with rotation suggestions, and include pwned count in the toolbar badge

## Technical Details
- **Server**: New `pwnedPassword.service.ts` using SHA-1 k-Anonymity (only first 5 hex chars sent to HIBP API)
- **Database**: New `pwnedCount` (Int, default 0) column on VaultSecret with migration
- **API**: `POST /api/secrets/:id/breach-check` (single) and `POST /api/secrets/breach-check` (batch)
- **Client**: Updated SecretListPanel, SecretDetailView, KeychainDialog, secretStore, and MainLayout

## Test plan
- [ ] Create a LOGIN secret with a known-breached password (e.g., "password") and verify `pwnedCount > 0` is returned
- [ ] Create a LOGIN secret with a strong unique password and verify `pwnedCount === 0`
- [ ] Edit a secret's password and verify the pwned count is re-evaluated
- [ ] Use the "Check for breaches" button in the detail view and confirm it updates the badge
- [ ] Verify the "Breached" chip appears in the secret list for compromised entries
- [ ] Verify the breach alert with "Rotate" button appears in detail view for pwned secrets
- [ ] Verify the Keychain toolbar badge includes pwned count
- [ ] Confirm k-Anonymity: only 5 hex chars of SHA-1 are sent (check network tab or server logs)

Refs #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)