### PR TITLE
feat: Automatic Password Rotation on Target Systems (PAM-112)

### DIFF
--- a/client/src/api/secrets.api.ts
+++ b/client/src/api/secrets.api.ts
@@ -327,6 +327,66 @@ export async function revokeExternalShare(shareId: string): Promise<{ revoked: t
   return data;
 }
 
+// --- Password rotation API ---
+
+export interface RotationStatusResult {
+  enabled: boolean;
+  intervalDays: number;
+  lastRotatedAt: string | null;
+  nextRotationAt: string | null;
+}
+
+export interface RotationHistoryEntry {
+  id: string;
+  status: 'SUCCESS' | 'FAILED' | 'PENDING';
+  trigger: 'SCHEDULED' | 'CHECKIN' | 'MANUAL';
+  targetOS: 'LINUX' | 'WINDOWS';
+  targetHost: string;
+  targetUser: string;
+  errorMessage: string | null;
+  durationMs: number | null;
+  createdAt: string;
+}
+
+export interface RotationResult {
+  success: boolean;
+  secretId: string;
+  logId: string;
+  error?: string;
+}
+
+export async function enableRotation(
+  secretId: string,
+  intervalDays?: number,
+): Promise<{ enabled: true; intervalDays: number }> {
+  const { data } = await api.post(`/secrets/${secretId}/rotation/enable`, { intervalDays });
+  return data;
+}
+
+export async function disableRotation(secretId: string): Promise<{ enabled: false }> {
+  const { data } = await api.post(`/secrets/${secretId}/rotation/disable`);
+  return data;
+}
+
+export async function triggerRotation(secretId: string): Promise<RotationResult> {
+  const { data } = await api.post(`/secrets/${secretId}/rotation/trigger`);
+  return data;
+}
+
+export async function getRotationStatus(secretId: string): Promise<RotationStatusResult> {
+  const { data } = await api.get(`/secrets/${secretId}/rotation/status`);
+  return data;
+}
+
+export async function getRotationHistory(
+  secretId: string,
+  limit?: number,
+): Promise<RotationHistoryEntry[]> {
+  const params = limit ? { limit: String(limit) } : {};
+  const { data } = await api.get(`/secrets/${secretId}/rotation/history`, { params });
+  return data;
+}
+
 // --- External share API (public, no auth) ---
 
 const publicApi = axios.create({

--- a/client/src/components/Keychain/PasswordRotationPanel.tsx
+++ b/client/src/components/Keychain/PasswordRotationPanel.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box, Typography, Switch, FormControlLabel, Button, Chip,
+  CircularProgress, Alert, TextField, Accordion, AccordionSummary,
+  AccordionDetails, Table, TableBody, TableCell, TableHead, TableRow,
+  Tooltip,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  Autorenew as RotateIcon,
+  CheckCircle as SuccessIcon,
+  Error as ErrorIcon,
+  HourglassEmpty as PendingIcon,
+} from '@mui/icons-material';
+import {
+  getRotationStatus, enableRotation, disableRotation,
+  triggerRotation, getRotationHistory,
+} from '../../api/secrets.api';
+import type { RotationStatusResult, RotationHistoryEntry } from '../../api/secrets.api';
+import { extractApiError } from '../../utils/apiError';
+
+interface PasswordRotationPanelProps {
+  secretId: string;
+  isReadOnly?: boolean;
+}
+
+const STATUS_ICONS: Record<string, React.ReactNode> = {
+  SUCCESS: <SuccessIcon fontSize="small" color="success" />,
+  FAILED: <ErrorIcon fontSize="small" color="error" />,
+  PENDING: <PendingIcon fontSize="small" color="warning" />,
+};
+
+export default function PasswordRotationPanel({ secretId, isReadOnly }: PasswordRotationPanelProps) {
+  const [status, setStatus] = useState<RotationStatusResult | null>(null);
+  const [history, setHistory] = useState<RotationHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [rotating, setRotating] = useState(false);
+  const [toggling, setToggling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [intervalDays, setIntervalDays] = useState(30);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [s, h] = await Promise.all([
+        getRotationStatus(secretId),
+        getRotationHistory(secretId, 10),
+      ]);
+      setStatus(s);
+      setHistory(h);
+      setIntervalDays(s.intervalDays);
+    } catch (err) {
+      setError(extractApiError(err, 'Failed to load rotation status'));
+    } finally {
+      setLoading(false);
+    }
+  }, [secretId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleToggle = async (enabled: boolean) => {
+    setToggling(true);
+    setError(null);
+    setSuccessMsg(null);
+    try {
+      if (enabled) {
+        await enableRotation(secretId, intervalDays);
+        setSuccessMsg('Password rotation enabled');
+      } else {
+        await disableRotation(secretId);
+        setSuccessMsg('Password rotation disabled');
+      }
+      await fetchData();
+    } catch (err) {
+      setError(extractApiError(err, 'Failed to update rotation settings'));
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleTrigger = async () => {
+    setRotating(true);
+    setError(null);
+    setSuccessMsg(null);
+    try {
+      const result = await triggerRotation(secretId);
+      if (result.success) {
+        setSuccessMsg('Password rotated successfully');
+      } else {
+        setError(`Rotation failed: ${result.error || 'Unknown error'}`);
+      }
+      await fetchData();
+    } catch (err) {
+      setError(extractApiError(err, 'Failed to trigger rotation'));
+    } finally {
+      setRotating(false);
+    }
+  };
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString(undefined, {
+      month: 'short', day: 'numeric', year: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    });
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {error && (
+        <Alert severity="error" sx={{ mb: 1 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      {successMsg && (
+        <Alert severity="success" sx={{ mb: 1 }} onClose={() => setSuccessMsg(null)}>
+          {successMsg}
+        </Alert>
+      )}
+
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={status?.enabled ?? false}
+              onChange={(_, checked) => handleToggle(checked)}
+              disabled={isReadOnly || toggling}
+              size="small"
+            />
+          }
+          label={
+            <Typography variant="body2">
+              Auto-rotate password
+            </Typography>
+          }
+        />
+        {status?.enabled && !isReadOnly && (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={rotating ? <CircularProgress size={16} /> : <RotateIcon />}
+            onClick={handleTrigger}
+            disabled={rotating}
+          >
+            Rotate Now
+          </Button>
+        )}
+      </Box>
+
+      {status?.enabled && (
+        <Box sx={{ mb: 1.5 }}>
+          <TextField
+            label="Interval (days)"
+            type="number"
+            value={intervalDays}
+            onChange={(e) => setIntervalDays(Math.max(1, parseInt(e.target.value, 10) || 1))}
+            onBlur={() => {
+              if (intervalDays !== status.intervalDays) {
+                handleToggle(true);
+              }
+            }}
+            size="small"
+            disabled={isReadOnly || toggling}
+            slotProps={{ htmlInput: { min: 1, max: 365 } }}
+            sx={{ width: 140 }}
+          />
+          <Box sx={{ mt: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {status.lastRotatedAt && (
+              <Chip label={`Last rotated: ${formatDate(status.lastRotatedAt)}`} size="small" variant="outlined" />
+            )}
+            {status.nextRotationAt && (
+              <Chip label={`Next: ${formatDate(status.nextRotationAt)}`} size="small" color="info" variant="outlined" />
+            )}
+          </Box>
+        </Box>
+      )}
+
+      {/* Rotation history */}
+      {history.length > 0 && (
+        <Accordion disableGutters elevation={0} variant="outlined" sx={{ mt: 1 }}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography variant="body2">
+              Rotation History ({history.length})
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ p: 0 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Status</TableCell>
+                  <TableCell>Trigger</TableCell>
+                  <TableCell>Target</TableCell>
+                  <TableCell>Date</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {history.map((entry) => (
+                  <TableRow key={entry.id}>
+                    <TableCell>
+                      <Tooltip title={entry.errorMessage ?? entry.status}>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                          {STATUS_ICONS[entry.status]}
+                          <Typography variant="caption">{entry.status}</Typography>
+                        </Box>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="caption">{entry.trigger}</Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
+                        {entry.targetUser}@{entry.targetHost}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="caption">{formatDate(entry.createdAt)}</Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </AccordionDetails>
+        </Accordion>
+      )}
+    </Box>
+  );
+}

--- a/client/src/components/Keychain/SecretDetailView.tsx
+++ b/client/src/components/Keychain/SecretDetailView.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/icons-material';
 import type { SecretDetail, SecretPayload, SecretType, SecretScope } from '../../api/secrets.api';
 import SecretVersionHistory from './SecretVersionHistory';
+import PasswordRotationPanel from './PasswordRotationPanel';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 
 const TYPE_ICONS: Record<SecretType, React.ReactNode> = {
@@ -341,6 +342,18 @@ export default function SecretDetailView({
           color={daysUntilExpiry <= 0 ? 'error' : daysUntilExpiry <= 7 ? 'error' : daysUntilExpiry <= 30 ? 'warning' : 'default'}
           sx={{ mt: 1 }}
         />
+      )}
+
+      {/* Password Rotation (LOGIN secrets only) */}
+      {secret.type === 'LOGIN' && (
+        <Accordion sx={{ mt: 2 }} disableGutters elevation={0} variant="outlined">
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography variant="subtitle2">Password Rotation</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <PasswordRotationPanel secretId={secret.id} isReadOnly={isReadOnly} />
+          </AccordionDetails>
+        </Accordion>
       )}
 
       {/* Version history */}

--- a/server/prisma/migrations/20260318100000_pam_112_password_rotation/migration.sql
+++ b/server/prisma/migrations/20260318100000_pam_112_password_rotation/migration.sql
@@ -1,0 +1,46 @@
+-- CreateEnum
+CREATE TYPE "RotationStatus" AS ENUM ('SUCCESS', 'FAILED', 'PENDING');
+
+-- CreateEnum
+CREATE TYPE "RotationTrigger" AS ENUM ('SCHEDULED', 'CHECKIN', 'MANUAL');
+
+-- CreateEnum
+CREATE TYPE "RotationTargetOS" AS ENUM ('LINUX', 'WINDOWS');
+
+-- AlterEnum
+ALTER TYPE "AuditAction" ADD VALUE 'PASSWORD_ROTATION_SUCCESS';
+ALTER TYPE "AuditAction" ADD VALUE 'PASSWORD_ROTATION_FAILED';
+
+-- AlterTable
+ALTER TABLE "VaultSecret" ADD COLUMN "targetRotationEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "VaultSecret" ADD COLUMN "rotationIntervalDays" INTEGER NOT NULL DEFAULT 30;
+ALTER TABLE "VaultSecret" ADD COLUMN "lastRotatedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "PasswordRotationLog" (
+    "id" TEXT NOT NULL,
+    "secretId" TEXT NOT NULL,
+    "status" "RotationStatus" NOT NULL,
+    "trigger" "RotationTrigger" NOT NULL,
+    "targetOS" "RotationTargetOS" NOT NULL,
+    "targetHost" TEXT NOT NULL,
+    "targetUser" TEXT NOT NULL,
+    "errorMessage" TEXT,
+    "durationMs" INTEGER,
+    "initiatedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordRotationLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PasswordRotationLog_secretId_createdAt_idx" ON "PasswordRotationLog"("secretId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PasswordRotationLog_status_idx" ON "PasswordRotationLog"("status");
+
+-- CreateIndex
+CREATE INDEX "VaultSecret_targetRotationEnabled_lastRotatedAt_idx" ON "VaultSecret"("targetRotationEnabled", "lastRotatedAt");
+
+-- AddForeignKey
+ALTER TABLE "PasswordRotationLog" ADD CONSTRAINT "PasswordRotationLog_secretId_fkey" FOREIGN KEY ("secretId") REFERENCES "VaultSecret"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -655,6 +655,8 @@ enum AuditAction {
   TUNNEL_TOKEN_ROTATE
   SESSION_DENIED_ABAC
   ANOMALOUS_LATERAL_MOVEMENT
+  PASSWORD_ROTATION_SUCCESS
+  PASSWORD_ROTATION_FAILED
 }
 
 model AuditLog {
@@ -761,6 +763,9 @@ model VaultSecret {
   pwnedCount     Int         @default(0)
   expiresAt      DateTime?
   currentVersion Int         @default(1)
+  targetRotationEnabled  Boolean   @default(false)
+  rotationIntervalDays   Int       @default(30)
+  lastRotatedAt          DateTime?
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt
 
@@ -772,12 +777,14 @@ model VaultSecret {
   shares         SharedSecret[]
   externalShares ExternalSecretShare[]
   connections    Connection[]
+  rotationLogs   PasswordRotationLog[]
 
   @@index([userId, scope])
   @@index([teamId])
   @@index([tenantId, scope])
   @@index([expiresAt])
   @@index([expiresAt, userId])
+  @@index([targetRotationEnabled, lastRotatedAt])
 }
 
 model VaultSecretVersion {
@@ -1123,4 +1130,41 @@ model AccessPolicy {
   updatedAt           DateTime @updatedAt
 
   @@index([targetType, targetId])
+}
+
+enum RotationStatus {
+  SUCCESS
+  FAILED
+  PENDING
+}
+
+enum RotationTrigger {
+  SCHEDULED
+  CHECKIN
+  MANUAL
+}
+
+enum RotationTargetOS {
+  LINUX
+  WINDOWS
+}
+
+/// Tracks every password rotation attempt on a target system.
+model PasswordRotationLog {
+  id          String          @id @default(uuid())
+  secretId    String
+  status      RotationStatus
+  trigger     RotationTrigger
+  targetOS    RotationTargetOS
+  targetHost  String
+  targetUser  String
+  errorMessage String?
+  durationMs  Int?
+  initiatedBy String?
+  createdAt   DateTime        @default(now())
+
+  secret VaultSecret @relation(fields: [secretId], references: [id], onDelete: Cascade)
+
+  @@index([secretId, createdAt])
+  @@index([status])
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -34,6 +34,7 @@ import syncRoutes from './routes/sync.routes';
 import externalVaultRoutes from './routes/externalVault.routes';
 import accessPolicyRoutes from './routes/accessPolicy.routes';
 import dbProxyRoutes from './routes/dbProxy.routes';
+import passwordRotationRoutes from './routes/passwordRotation.routes';
 import healthRoutes from './routes/health.routes';
 import { errorHandler } from './middleware/error.middleware';
 import { requestLogger } from './middleware/requestLogger.middleware';
@@ -122,6 +123,7 @@ app.use('/api/sync-profiles', syncRoutes);
 app.use('/api/vault-providers', externalVaultRoutes);
 app.use('/api/access-policies', accessPolicyRoutes);
 app.use('/api/sessions/database', dbProxyRoutes);
+app.use('/api/secrets', passwordRotationRoutes);
 
 // Health & readiness probes
 app.use('/api', healthRoutes);

--- a/server/src/controllers/passwordRotation.controller.ts
+++ b/server/src/controllers/passwordRotation.controller.ts
@@ -1,0 +1,82 @@
+import { Response } from 'express';
+import { AuthRequest, assertAuthenticated } from '../types';
+import * as passwordRotationService from '../services/passwordRotation.service';
+import * as auditService from '../services/audit.service';
+import { getClientIp } from '../utils/ip';
+import type { EnableRotationInput } from '../schemas/passwordRotation.schemas';
+
+export async function enableRotation(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const secretId = req.params.id as string;
+  const { intervalDays } = req.body as EnableRotationInput;
+
+  await passwordRotationService.enableRotation(
+    req.user.userId,
+    secretId,
+    intervalDays,
+    req.user.tenantId,
+  );
+
+  auditService.log({
+    userId: req.user.userId,
+    action: 'SECRET_UPDATE',
+    targetType: 'VaultSecret',
+    targetId: secretId,
+    details: { field: 'targetRotationEnabled', value: true, intervalDays },
+    ipAddress: getClientIp(req),
+  });
+
+  res.json({ enabled: true, intervalDays: intervalDays ?? 30 });
+}
+
+export async function disableRotation(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const secretId = req.params.id as string;
+
+  await passwordRotationService.disableRotation(
+    req.user.userId,
+    secretId,
+    req.user.tenantId,
+  );
+
+  auditService.log({
+    userId: req.user.userId,
+    action: 'SECRET_UPDATE',
+    targetType: 'VaultSecret',
+    targetId: secretId,
+    details: { field: 'targetRotationEnabled', value: false },
+    ipAddress: getClientIp(req),
+  });
+
+  res.json({ enabled: false });
+}
+
+export async function triggerRotation(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const secretId = req.params.id as string;
+
+  const result = await passwordRotationService.rotatePassword(
+    secretId,
+    req.user.userId,
+    'MANUAL',
+  );
+
+  res.json(result);
+}
+
+export async function getRotationStatus(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const secretId = req.params.id as string;
+
+  const status = await passwordRotationService.getRotationStatus(secretId);
+  res.json(status);
+}
+
+export async function getRotationHistory(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const secretId = req.params.id as string;
+  const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 20;
+
+  const history = await passwordRotationService.getRotationHistory(secretId, limit);
+  res.json(history);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,7 +8,7 @@ import { initializePassport } from './config/passport';
 import { setupSocketIO } from './socket';
 import { logger, toGuacamoleLogLevel } from './utils/logger';
 import prisma from './lib/prisma';
-import { startKeyRotationJob, startLdapSyncJob, startMembershipExpiryJob, stopAllJobs } from './services/scheduler.service';
+import { startKeyRotationJob, startLdapSyncJob, startMembershipExpiryJob, startPasswordRotationJob, stopAllJobs } from './services/scheduler.service';
 import { startAllSyncJobs, stopAllSyncJobs } from './services/syncScheduler.service';
 import { startAllMonitors, stopAllMonitors } from './services/gatewayMonitor.service';
 import { cleanupExpiredShares } from './services/externalShare.service';
@@ -105,6 +105,7 @@ async function main() {
   startKeyRotationJob();
   startLdapSyncJob();
   startMembershipExpiryJob();
+  startPasswordRotationJob();
   startAllSyncJobs().catch((err) => {
     logger.error('Failed to start sync jobs:', err);
   });

--- a/server/src/lib/prisma.ts
+++ b/server/src/lib/prisma.ts
@@ -14,4 +14,4 @@ const adapter = new PrismaPg({
 const prisma = new PrismaClient({ adapter });
 
 export default prisma;
-export { Prisma, ConnectionType, GatewayType, GatewayHealthStatus, Permission, AuditAction, NotificationType, TeamRole, SecretType, SecretScope, SessionProtocol, SessionStatus, ManagedInstanceStatus, LoadBalancingStrategy, RecordingStatus, SyncProvider, SyncStatus, AccessPolicyTargetType } from '../generated/prisma/client';
+export { Prisma, ConnectionType, GatewayType, GatewayHealthStatus, Permission, AuditAction, NotificationType, TeamRole, SecretType, SecretScope, SessionProtocol, SessionStatus, ManagedInstanceStatus, LoadBalancingStrategy, RecordingStatus, SyncProvider, SyncStatus, AccessPolicyTargetType, RotationStatus, RotationTrigger, RotationTargetOS } from '../generated/prisma/client';

--- a/server/src/routes/passwordRotation.routes.ts
+++ b/server/src/routes/passwordRotation.routes.ts
@@ -1,0 +1,47 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth.middleware';
+import { validate, validateUuidParam } from '../middleware/validate.middleware';
+import { enableRotationSchema } from '../schemas/passwordRotation.schemas';
+import * as passwordRotationController from '../controllers/passwordRotation.controller';
+import { asyncHandler } from '../middleware/asyncHandler';
+
+const router = Router();
+
+router.use(authenticate);
+
+// Enable/disable rotation on a secret
+router.post(
+  '/:id/rotation/enable',
+  validateUuidParam(),
+  validate(enableRotationSchema),
+  asyncHandler(passwordRotationController.enableRotation),
+);
+
+router.post(
+  '/:id/rotation/disable',
+  validateUuidParam(),
+  asyncHandler(passwordRotationController.disableRotation),
+);
+
+// Manually trigger rotation
+router.post(
+  '/:id/rotation/trigger',
+  validateUuidParam(),
+  asyncHandler(passwordRotationController.triggerRotation),
+);
+
+// Get rotation status for a secret
+router.get(
+  '/:id/rotation/status',
+  validateUuidParam(),
+  asyncHandler(passwordRotationController.getRotationStatus),
+);
+
+// Get rotation history for a secret
+router.get(
+  '/:id/rotation/history',
+  validateUuidParam(),
+  asyncHandler(passwordRotationController.getRotationHistory),
+);
+
+export default router;

--- a/server/src/schemas/passwordRotation.schemas.ts
+++ b/server/src/schemas/passwordRotation.schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const enableRotationSchema = z.object({
+  intervalDays: z.number().int().min(1).max(365).optional().default(30),
+});
+export type EnableRotationInput = z.infer<typeof enableRotationSchema>;
+
+export const triggerRotationSchema = z.object({});
+export type TriggerRotationInput = z.infer<typeof triggerRotationSchema>;

--- a/server/src/services/passwordRotation.service.ts
+++ b/server/src/services/passwordRotation.service.ts
@@ -1,0 +1,596 @@
+import crypto from 'crypto';
+import { Client } from 'ssh2';
+import prisma, { RotationTrigger, RotationTargetOS } from '../lib/prisma';
+import { encrypt, decrypt } from './crypto.service';
+import { resolveSecretEncryptionKey } from './secret.service';
+import * as auditService from './audit.service';
+import { AppError } from '../middleware/error.middleware';
+import { logger } from '../utils/logger';
+import type { LoginSecretData, SecretPayload } from '../types';
+
+const SSH_TIMEOUT_MS = 15_000;
+
+// --- Password generation ---
+
+const PASSWORD_LENGTH = 32;
+const PASSWORD_CHARSET =
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?';
+
+/**
+ * Generate a cryptographically strong password using crypto.randomBytes.
+ * Ensures at least one character from each class (lower, upper, digit, special).
+ */
+export function generateStrongPassword(length: number = PASSWORD_LENGTH): string {
+  const bytes = crypto.randomBytes(length);
+  const chars: string[] = [];
+  for (let i = 0; i < length; i++) {
+    chars.push(PASSWORD_CHARSET[bytes[i] % PASSWORD_CHARSET.length]);
+  }
+  // Guarantee at least one of each character class
+  const lower = 'abcdefghijklmnopqrstuvwxyz';
+  const upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const digit = '0123456789';
+  const special = '!@#$%^&*()-_=+[]{}|;:,.<>?';
+  const rand = crypto.randomBytes(4);
+  chars[0] = lower[rand[0] % lower.length];
+  chars[1] = upper[rand[1] % upper.length];
+  chars[2] = digit[rand[2] % digit.length];
+  chars[3] = special[rand[3] % special.length];
+  // Shuffle to avoid predictable positions
+  for (let i = chars.length - 1; i > 0; i--) {
+    const j = crypto.randomBytes(1)[0] % (i + 1);
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+  return chars.join('');
+}
+
+// --- SSH-based password change (Linux) ---
+
+interface SshRotationParams {
+  host: string;
+  port: number;
+  username: string;
+  currentPassword: string;
+  newPassword: string;
+  privateKey?: string;
+  passphrase?: string;
+}
+
+/**
+ * Connect via SSH and change the password on a Linux target.
+ * Uses `chpasswd` for non-interactive password change.
+ */
+export function changePasswordViaSsh(params: SshRotationParams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const client = new Client();
+    const authMethod = params.privateKey
+      ? { privateKey: params.privateKey, passphrase: params.passphrase }
+      : { password: params.currentPassword };
+
+    const timer = setTimeout(() => {
+      client.end();
+      reject(new Error('SSH password rotation timed out'));
+    }, SSH_TIMEOUT_MS);
+
+    client.on('ready', () => {
+      // Use chpasswd for non-interactive password change
+      const escapedUser = params.username.replace(/'/g, "'\\''");
+      const escapedPass = params.newPassword.replace(/'/g, "'\\''");
+      const cmd = `echo '${escapedUser}:${escapedPass}' | sudo chpasswd`;
+
+      client.exec(cmd, (err, stream) => {
+        if (err) {
+          clearTimeout(timer);
+          client.end();
+          return reject(new Error(`SSH exec failed: ${err.message}`));
+        }
+
+        let stderr = '';
+        stream.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+
+        stream.on('close', (code: number | null) => {
+          clearTimeout(timer);
+          client.end();
+          if (code !== 0) {
+            return reject(
+              new Error(`chpasswd exited with code ${code}: ${stderr.trim() || 'unknown error'}`),
+            );
+          }
+          resolve();
+        });
+      });
+    });
+
+    client.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`SSH connection failed: ${err.message}`));
+    });
+
+    client.connect({
+      host: params.host,
+      port: params.port,
+      username: params.username,
+      ...authMethod,
+      readyTimeout: SSH_TIMEOUT_MS,
+    });
+  });
+}
+
+// --- WinRM / SSH-based password change (Windows) ---
+
+interface WindowsRotationParams {
+  host: string;
+  port: number;
+  username: string;
+  currentPassword: string;
+  newPassword: string;
+  privateKey?: string;
+  passphrase?: string;
+}
+
+/**
+ * Connect via SSH and change the password on a Windows target using PowerShell.
+ * Assumes SSH is available on the Windows target (OpenSSH for Windows).
+ */
+export function changePasswordViaWindowsSsh(params: WindowsRotationParams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const client = new Client();
+    const authMethod = params.privateKey
+      ? { privateKey: params.privateKey, passphrase: params.passphrase }
+      : { password: params.currentPassword };
+
+    const timer = setTimeout(() => {
+      client.end();
+      reject(new Error('Windows SSH password rotation timed out'));
+    }, SSH_TIMEOUT_MS);
+
+    client.on('ready', () => {
+      // PowerShell command to change local user password
+      const escapedUser = params.username.replace(/"/g, '`"');
+      const escapedPass = params.newPassword.replace(/"/g, '`"');
+      const cmd = `powershell -Command "Set-LocalUser -Name '${escapedUser}' -Password (ConvertTo-SecureString '${escapedPass}' -AsPlainText -Force)"`;
+
+      client.exec(cmd, (err, stream) => {
+        if (err) {
+          clearTimeout(timer);
+          client.end();
+          return reject(new Error(`Windows SSH exec failed: ${err.message}`));
+        }
+
+        let stderr = '';
+        stream.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+
+        stream.on('close', (code: number | null) => {
+          clearTimeout(timer);
+          client.end();
+          if (code !== 0) {
+            return reject(
+              new Error(
+                `PowerShell Set-LocalUser exited with code ${code}: ${stderr.trim() || 'unknown error'}`,
+              ),
+            );
+          }
+          resolve();
+        });
+      });
+    });
+
+    client.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`Windows SSH connection failed: ${err.message}`));
+    });
+
+    client.connect({
+      host: params.host,
+      port: params.port,
+      username: params.username,
+      ...authMethod,
+      readyTimeout: SSH_TIMEOUT_MS,
+    });
+  });
+}
+
+// --- Rotation orchestrator ---
+
+export interface RotationResult {
+  success: boolean;
+  secretId: string;
+  logId: string;
+  error?: string;
+}
+
+/**
+ * Detect the target OS based on the connection's metadata or a default assumption.
+ * In real usage, the connection type or metadata indicates the OS.
+ */
+function detectTargetOS(connection: { type: string }): RotationTargetOS {
+  // SSH connections default to Linux, RDP defaults to Windows
+  if (connection.type === 'RDP') return 'WINDOWS';
+  return 'LINUX';
+}
+
+/**
+ * Rotate a password for a specific VaultSecret that is linked to a connection.
+ * 1. Decrypt current credentials from VaultSecret
+ * 2. Generate a new strong password
+ * 3. Change the password on the remote target via SSH
+ * 4. Atomically update the VaultSecret with the new encrypted password + create a new version
+ * 5. Log the result
+ *
+ * If the remote password change fails, the vault is NOT updated (atomic guarantee).
+ */
+export async function rotatePassword(
+  secretId: string,
+  userId: string,
+  trigger: RotationTrigger,
+): Promise<RotationResult> {
+  const startTime = Date.now();
+
+  // Load the secret and its linked connection(s)
+  const secret = await prisma.vaultSecret.findUnique({
+    where: { id: secretId },
+    include: {
+      connections: {
+        select: { id: true, host: true, port: true, type: true },
+        take: 1,
+      },
+    },
+  });
+
+  if (!secret) {
+    throw new AppError('Secret not found', 404);
+  }
+
+  if (secret.type !== 'LOGIN') {
+    throw new AppError('Password rotation is only supported for LOGIN-type secrets', 400);
+  }
+
+  if (secret.connections.length === 0) {
+    throw new AppError('Secret must be linked to at least one connection for rotation', 400);
+  }
+
+  const connection = secret.connections[0];
+  const targetOS = detectTargetOS(connection);
+  const targetHost = connection.host;
+  const targetPort = connection.port;
+
+  // Decrypt the current secret data
+  const encryptionKey = await resolveSecretEncryptionKey(
+    userId,
+    secret.scope,
+    secret.teamId,
+    secret.tenantId,
+  );
+
+  const decryptedJson = decrypt(
+    { ciphertext: secret.encryptedData, iv: secret.dataIV, tag: secret.dataTag },
+    encryptionKey,
+  );
+  const secretData: SecretPayload = JSON.parse(decryptedJson);
+
+  if (secretData.type !== 'LOGIN') {
+    throw new AppError('Secret data is not LOGIN type', 400);
+  }
+
+  const currentUsername = secretData.username;
+  const currentPassword = secretData.password;
+  const newPassword = generateStrongPassword();
+
+  // Create a PENDING log entry
+  const logEntry = await prisma.passwordRotationLog.create({
+    data: {
+      secretId,
+      status: 'PENDING',
+      trigger,
+      targetOS,
+      targetHost,
+      targetUser: currentUsername,
+      initiatedBy: userId,
+    },
+  });
+
+  try {
+    // Execute the remote password change
+    if (targetOS === 'LINUX') {
+      await changePasswordViaSsh({
+        host: targetHost,
+        port: targetPort,
+        username: currentUsername,
+        currentPassword,
+        newPassword,
+      });
+    } else {
+      await changePasswordViaWindowsSsh({
+        host: targetHost,
+        port: targetPort,
+        username: currentUsername,
+        currentPassword,
+        newPassword,
+      });
+    }
+
+    // Remote change succeeded — atomically update the vault
+    const updatedSecretData: LoginSecretData = {
+      ...secretData,
+      password: newPassword,
+    };
+    const plaintext = JSON.stringify(updatedSecretData);
+    const encrypted = encrypt(plaintext, encryptionKey);
+    const newVersion = secret.currentVersion + 1;
+
+    await prisma.$transaction(async (tx) => {
+      await tx.vaultSecret.update({
+        where: { id: secretId },
+        data: {
+          encryptedData: encrypted.ciphertext,
+          dataIV: encrypted.iv,
+          dataTag: encrypted.tag,
+          currentVersion: newVersion,
+          lastRotatedAt: new Date(),
+        },
+      });
+
+      await tx.vaultSecretVersion.create({
+        data: {
+          secretId,
+          version: newVersion,
+          encryptedData: encrypted.ciphertext,
+          dataIV: encrypted.iv,
+          dataTag: encrypted.tag,
+          changedBy: userId,
+          changeNote: `Password rotated (${trigger.toLowerCase()})`,
+        },
+      });
+
+      await tx.passwordRotationLog.update({
+        where: { id: logEntry.id },
+        data: {
+          status: 'SUCCESS',
+          durationMs: Date.now() - startTime,
+        },
+      });
+    });
+
+    auditService.log({
+      userId,
+      action: 'PASSWORD_ROTATION_SUCCESS',
+      targetType: 'VaultSecret',
+      targetId: secretId,
+      details: {
+        trigger,
+        targetOS,
+        targetHost,
+        targetUser: currentUsername,
+        durationMs: Date.now() - startTime,
+      },
+    });
+
+    logger.info(
+      `[password-rotation] Rotation succeeded for secret ${secretId} ` +
+        `on ${targetHost} (${targetOS}, ${trigger})`,
+    );
+
+    return { success: true, secretId, logId: logEntry.id };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+
+    // Update log entry with failure
+    await prisma.passwordRotationLog.update({
+      where: { id: logEntry.id },
+      data: {
+        status: 'FAILED',
+        errorMessage,
+        durationMs: Date.now() - startTime,
+      },
+    });
+
+    auditService.log({
+      userId,
+      action: 'PASSWORD_ROTATION_FAILED',
+      targetType: 'VaultSecret',
+      targetId: secretId,
+      details: {
+        trigger,
+        targetOS,
+        targetHost,
+        targetUser: currentUsername,
+        error: errorMessage,
+      },
+    });
+
+    logger.error(
+      `[password-rotation] Rotation failed for secret ${secretId} ` +
+        `on ${targetHost}: ${errorMessage}`,
+    );
+
+    return { success: false, secretId, logId: logEntry.id, error: errorMessage };
+  }
+}
+
+// --- Configuration management ---
+
+export async function enableRotation(
+  userId: string,
+  secretId: string,
+  intervalDays: number = 30,
+  _tenantId?: string | null,
+): Promise<void> {
+  const secret = await prisma.vaultSecret.findUnique({
+    where: { id: secretId },
+    select: { userId: true, type: true, scope: true, teamId: true, tenantId: true },
+  });
+
+  if (!secret) throw new AppError('Secret not found', 404);
+  if (secret.type !== 'LOGIN') {
+    throw new AppError('Password rotation is only supported for LOGIN-type secrets', 400);
+  }
+
+  // Check that the user has manage permission (owner, team editor, or admin)
+  if (secret.scope === 'PERSONAL' && secret.userId !== userId) {
+    throw new AppError('Not authorized', 403);
+  }
+
+  await prisma.vaultSecret.update({
+    where: { id: secretId },
+    data: {
+      targetRotationEnabled: true,
+      rotationIntervalDays: intervalDays,
+    },
+  });
+}
+
+export async function disableRotation(
+  userId: string,
+  secretId: string,
+  _tenantId?: string | null,
+): Promise<void> {
+  const secret = await prisma.vaultSecret.findUnique({
+    where: { id: secretId },
+    select: { userId: true, scope: true },
+  });
+
+  if (!secret) throw new AppError('Secret not found', 404);
+
+  if (secret.scope === 'PERSONAL' && secret.userId !== userId) {
+    throw new AppError('Not authorized', 403);
+  }
+
+  await prisma.vaultSecret.update({
+    where: { id: secretId },
+    data: {
+      targetRotationEnabled: false,
+    },
+  });
+}
+
+export async function getRotationStatus(
+  secretId: string,
+): Promise<{
+  enabled: boolean;
+  intervalDays: number;
+  lastRotatedAt: Date | null;
+  nextRotationAt: Date | null;
+}> {
+  const secret = await prisma.vaultSecret.findUnique({
+    where: { id: secretId },
+    select: {
+      targetRotationEnabled: true,
+      rotationIntervalDays: true,
+      lastRotatedAt: true,
+    },
+  });
+
+  if (!secret) throw new AppError('Secret not found', 404);
+
+  let nextRotationAt: Date | null = null;
+  if (secret.targetRotationEnabled && secret.lastRotatedAt) {
+    nextRotationAt = new Date(
+      secret.lastRotatedAt.getTime() + secret.rotationIntervalDays * 24 * 60 * 60 * 1000,
+    );
+  }
+
+  return {
+    enabled: secret.targetRotationEnabled,
+    intervalDays: secret.rotationIntervalDays,
+    lastRotatedAt: secret.lastRotatedAt,
+    nextRotationAt,
+  };
+}
+
+export async function getRotationHistory(
+  secretId: string,
+  limit: number = 20,
+): Promise<{
+  id: string;
+  status: string;
+  trigger: string;
+  targetOS: string;
+  targetHost: string;
+  targetUser: string;
+  errorMessage: string | null;
+  durationMs: number | null;
+  createdAt: Date;
+}[]> {
+  return prisma.passwordRotationLog.findMany({
+    where: { secretId },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    select: {
+      id: true,
+      status: true,
+      trigger: true,
+      targetOS: true,
+      targetHost: true,
+      targetUser: true,
+      errorMessage: true,
+      durationMs: true,
+      createdAt: true,
+    },
+  });
+}
+
+// --- Scheduled rotation ---
+
+/**
+ * Process all secrets that are due for scheduled rotation.
+ * Called by the scheduler service on a cron basis.
+ */
+export async function processScheduledRotations(): Promise<void> {
+  const now = new Date();
+
+  logger.info(`[password-rotation] Starting scheduled rotation check at ${now.toISOString()}`);
+
+  // Find all LOGIN secrets with rotation enabled that are due
+  const candidates = await prisma.vaultSecret.findMany({
+    where: {
+      targetRotationEnabled: true,
+      type: 'LOGIN',
+      connections: { some: {} }, // must have at least one linked connection
+    },
+    select: {
+      id: true,
+      userId: true,
+      lastRotatedAt: true,
+      rotationIntervalDays: true,
+    },
+  });
+
+  let rotatedCount = 0;
+  let failedCount = 0;
+
+  for (const secret of candidates) {
+    // Check if the secret is due for rotation
+    const intervalMs = secret.rotationIntervalDays * 24 * 60 * 60 * 1000;
+    const lastRotated = secret.lastRotatedAt?.getTime() ?? 0;
+
+    if (now.getTime() - lastRotated < intervalMs) {
+      continue; // Not yet due
+    }
+
+    try {
+      const result = await rotatePassword(secret.id, secret.userId, 'SCHEDULED');
+      if (result.success) {
+        rotatedCount++;
+      } else {
+        failedCount++;
+      }
+    } catch (err) {
+      failedCount++;
+      logger.error(
+        `[password-rotation] Scheduled rotation error for secret ${secret.id}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  if (rotatedCount > 0 || failedCount > 0) {
+    logger.info(
+      `[password-rotation] Scheduled rotation complete. ` +
+        `Rotated: ${rotatedCount}, Failed: ${failedCount}`,
+    );
+  }
+}

--- a/server/src/services/scheduler.service.ts
+++ b/server/src/services/scheduler.service.ts
@@ -9,6 +9,7 @@ import * as auditService from './audit.service';
 let rotationTask: ScheduledTask | null = null;
 let ldapSyncTask: ScheduledTask | null = null;
 let membershipExpiryTask: ScheduledTask | null = null;
+let passwordRotationTask: ScheduledTask | null = null;
 
 export function startKeyRotationJob(): void {
   const cronExpr = config.keyRotationCron;
@@ -287,6 +288,27 @@ export async function processExpiredMemberships(): Promise<void> {
   }
 }
 
+// Password rotation job: runs daily at 3 AM UTC
+const PASSWORD_ROTATION_CRON = '0 3 * * *';
+
+export function startPasswordRotationJob(): void {
+  passwordRotationTask = cron.schedule(
+    PASSWORD_ROTATION_CRON,
+    () => {
+      import('./passwordRotation.service').then((svc) =>
+        svc.processScheduledRotations().catch((err) => {
+          logger.error('[scheduler] Unhandled error in processScheduledRotations:', err);
+        }),
+      );
+    },
+    { timezone: 'UTC' },
+  );
+
+  logger.info(
+    `[scheduler] Password rotation job scheduled: "${PASSWORD_ROTATION_CRON}" (UTC)`,
+  );
+}
+
 export function stopAllJobs(): void {
   if (rotationTask) {
     rotationTask.stop();
@@ -299,6 +321,10 @@ export function stopAllJobs(): void {
   if (membershipExpiryTask) {
     membershipExpiryTask.stop();
     membershipExpiryTask = null;
+  }
+  if (passwordRotationTask) {
+    passwordRotationTask.stop();
+    passwordRotationTask = null;
   }
   logger.info('[scheduler] All scheduled jobs stopped.');
 }


### PR DESCRIPTION
## Summary

- Adds an active password rotation engine that connects to remote servers (Linux via SSH `chpasswd`, Windows via SSH+PowerShell `Set-LocalUser`), generates a cryptographically strong password, changes it on the target, and atomically updates the VaultSecret with a new version for rollback capability
- New Prisma fields (`targetRotationEnabled`, `rotationIntervalDays`, `lastRotatedAt`) on VaultSecret and a `PasswordRotationLog` model for full audit trail
- API endpoints for enable/disable rotation, manual trigger, status check, and rotation history under `/api/secrets/:id/rotation/*`
- Daily scheduled cron job (3 AM UTC) for automatic rotations of due secrets
- New `PASSWORD_ROTATION_SUCCESS` and `PASSWORD_ROTATION_FAILED` audit events
- Client-side `PasswordRotationPanel` component integrated into the Keychain SecretDetailView for LOGIN-type secrets

## Test plan

- [ ] Enable rotation on a LOGIN secret linked to a Linux SSH connection and verify the toggle persists
- [ ] Manually trigger rotation and verify password is changed on target and vault is updated with new version
- [ ] Verify rotation history shows SUCCESS/FAILED entries with correct details
- [ ] Verify rotation interval configuration persists and displays next rotation date
- [ ] Disable rotation and verify it stops scheduled processing
- [ ] Verify non-LOGIN secrets do not show the rotation panel
- [ ] Verify audit logs contain PASSWORD_ROTATION_SUCCESS/FAILED events after rotation

Implements PAM-112 for release v1.7.0. Refs #162. Depends on PAM-111 (#161).

Generated with [Claude Code](https://claude.com/claude-code)