### PR TITLE
chore(deps): bump fast-xml-parser minimum to ^5.5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16468,7 +16468,7 @@
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
-        "fast-xml-parser": "^5.4.2",
+        "fast-xml-parser": "^5.5.7",
         "form-data": "^4.0.5",
         "guacamole-lite": "^1.2.0",
         "helmet": "^8.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
-    "fast-xml-parser": "^5.4.2",
+    "fast-xml-parser": "^5.5.7",
     "form-data": "^4.0.5",
     "guacamole-lite": "^1.2.0",
     "helmet": "^8.1.0",


### PR DESCRIPTION
## Summary

- Bumps `fast-xml-parser` minimum version in `server/package.json` from `^5.4.2` to `^5.5.7`
- Addresses Dependabot PR #375 (which targets main — this supersedes it via develop)
- Lock file already resolves to 5.5.8; this tightens the constraint so future installs can't resolve to vulnerable versions

Closes #375

## Test plan

- [x] `npm run verify` passes locally
- [x] `npm audit --audit-level=critical` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)