### PR TITLE
feat: expose system settings in WebUI admin panel (CFG-2040)

### DIFF
--- a/client/src/api/systemSettings.api.ts
+++ b/client/src/api/systemSettings.api.ts
@@ -1,0 +1,54 @@
+import api from './client';
+
+export type SettingType = 'boolean' | 'number' | 'string' | 'select' | 'string[]';
+
+export interface SettingValue {
+  key: string;
+  value: unknown;
+  source: 'env' | 'db' | 'default';
+  envLocked: boolean;
+  canEdit: boolean;
+  type: SettingType;
+  default: unknown;
+  options?: string[];
+  group: string;
+  label: string;
+  description: string;
+  restartRequired: boolean;
+}
+
+export interface SettingGroup {
+  key: string;
+  label: string;
+  order: number;
+}
+
+export interface SystemSettingsResponse {
+  settings: SettingValue[];
+  groups: SettingGroup[];
+}
+
+export async function getSystemSettings(): Promise<SystemSettingsResponse> {
+  const { data } = await api.get<SystemSettingsResponse>('/admin/system-settings');
+  return data;
+}
+
+export async function updateSystemSetting(
+  key: string,
+  value: unknown,
+): Promise<{ key: string; value: unknown; source: 'db' }> {
+  const { data } = await api.put<{ key: string; value: unknown; source: 'db' }>(
+    `/admin/system-settings/${encodeURIComponent(key)}`,
+    { value },
+  );
+  return data;
+}
+
+export async function bulkUpdateSystemSettings(
+  updates: Array<{ key: string; value: unknown }>,
+): Promise<{ results: Array<{ key: string; success: boolean; error?: string }> }> {
+  const { data } = await api.put<{
+    results: Array<{ key: string; success: boolean; error?: string }>;
+  }>('/admin/system-settings', { updates });
+  return data;
+}

--- a/client/src/components/Dialogs/SettingsDialog.tsx
+++ b/client/src/components/Dialogs/SettingsDialog.tsx
@@ -36,6 +36,7 @@ import TeamSection from '../Settings/TeamSection';
 import GatewaySection from '../Settings/GatewaySection';
 import EmailProviderSection from '../Settings/EmailProviderSection';
 import SelfSignupSection from '../Settings/SelfSignupSection';
+import SystemSettingsSection from '../Settings/SystemSettingsSection';
 import IpAllowlistSection from '../Settings/IpAllowlistSection';
 import TenantAuditLogSection from '../Settings/TenantAuditLogSection';
 import LdapConfigSection from '../Settings/LdapConfigSection';
@@ -307,6 +308,7 @@ export default function SettingsDialog({ open, onClose, initialTab, linkedProvid
           {resolvedTab === 'administration' && (
             <Stack spacing={3}>
               <SelfSignupSection />
+              <SystemSettingsSection />
               <NativeSshSection />
               <IpAllowlistSection />
               <AccessPolicySection />

--- a/client/src/components/Settings/SettingField.tsx
+++ b/client/src/components/Settings/SettingField.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import {
+  Box, Switch, TextField, Select, MenuItem, FormControlLabel,
+  Typography, Chip, Tooltip, IconButton, CircularProgress,
+} from '@mui/material';
+import LockIcon from '@mui/icons-material/Lock';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import SaveIcon from '@mui/icons-material/Save';
+import type { SettingValue } from '../../api/systemSettings.api';
+import { updateSystemSetting } from '../../api/systemSettings.api';
+import { extractApiError } from '../../utils/apiError';
+
+interface Props {
+  setting: SettingValue;
+  onUpdated: (key: string, value: unknown) => void;
+}
+
+function sourceChip(source: 'env' | 'db' | 'default') {
+  switch (source) {
+    case 'env':
+      return <Chip label="ENV" size="small" color="warning" variant="outlined" icon={<LockIcon />} />;
+    case 'db':
+      return <Chip label="Custom" size="small" color="primary" variant="outlined" />;
+    default:
+      return <Chip label="Default" size="small" variant="outlined" />;
+  }
+}
+
+export default function SettingField({ setting, onUpdated }: Props) {
+  const [localValue, setLocalValue] = useState<unknown>(setting.value);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const dirty = String(localValue) !== String(setting.value);
+  const disabled = !setting.canEdit || setting.envLocked || saving;
+
+  const handleSave = async (value: unknown) => {
+    setSaving(true);
+    setError('');
+    try {
+      await updateSystemSetting(setting.key, value);
+      onUpdated(setting.key, value);
+    } catch (err: unknown) {
+      setError(extractApiError(err, 'Failed to update setting'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleBooleanToggle = async () => {
+    const newVal = !localValue;
+    setLocalValue(newVal);
+    await handleSave(newVal);
+  };
+
+  if (setting.type === 'boolean') {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', py: 0.5 }}>
+        <Box sx={{ flex: 1, mr: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={Boolean(localValue)}
+                  onChange={handleBooleanToggle}
+                  disabled={disabled}
+                  size="small"
+                />
+              }
+              label={
+                <Typography variant="body2" fontWeight="medium">{setting.label}</Typography>
+              }
+            />
+            {sourceChip(setting.source)}
+            {setting.restartRequired && (
+              <Tooltip title="Requires server restart to take effect">
+                <RestartAltIcon fontSize="small" color="action" />
+              </Tooltip>
+            )}
+          </Box>
+          <Typography variant="caption" color="text.secondary" sx={{ ml: 4.5, display: 'block' }}>
+            {setting.description}
+          </Typography>
+          {error && (
+            <Typography variant="caption" color="error" sx={{ ml: 4.5, display: 'block' }}>
+              {error}
+            </Typography>
+          )}
+        </Box>
+        {saving && <CircularProgress size={16} />}
+      </Box>
+    );
+  }
+
+  if (setting.type === 'select' && setting.options) {
+    return (
+      <Box sx={{ py: 0.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <Typography variant="body2" fontWeight="medium">{setting.label}</Typography>
+          {sourceChip(setting.source)}
+          {setting.restartRequired && (
+            <Tooltip title="Requires server restart to take effect">
+              <RestartAltIcon fontSize="small" color="action" />
+            </Tooltip>
+          )}
+        </Box>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+          {setting.description}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Select
+            size="small"
+            value={String(localValue)}
+            onChange={(e) => {
+              setLocalValue(e.target.value);
+              handleSave(e.target.value);
+            }}
+            disabled={disabled}
+            sx={{ minWidth: 180 }}
+          >
+            {setting.options.map((opt) => (
+              <MenuItem key={opt} value={opt}>
+                {opt || '(disabled)'}
+              </MenuItem>
+            ))}
+          </Select>
+          {saving && <CircularProgress size={16} />}
+        </Box>
+        {error && (
+          <Typography variant="caption" color="error" sx={{ mt: 0.5, display: 'block' }}>
+            {error}
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ py: 0.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+        <Typography variant="body2" fontWeight="medium">{setting.label}</Typography>
+        {sourceChip(setting.source)}
+        {setting.restartRequired && (
+          <Tooltip title="Requires server restart to take effect">
+            <RestartAltIcon fontSize="small" color="action" />
+          </Tooltip>
+        )}
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        {setting.description}
+      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <TextField
+          size="small"
+          type={setting.type === 'number' ? 'number' : 'text'}
+          value={String(localValue ?? '')}
+          onChange={(e) => {
+            const val = setting.type === 'number' ? Number(e.target.value) : e.target.value;
+            setLocalValue(val);
+          }}
+          disabled={disabled}
+          sx={{ minWidth: 220 }}
+          slotProps={{
+            input: {
+              endAdornment: setting.envLocked ? (
+                <Tooltip title="Set via environment variable">
+                  <LockIcon fontSize="small" color="action" />
+                </Tooltip>
+              ) : undefined,
+            },
+          }}
+        />
+        {dirty && !disabled && (
+          <Tooltip title="Save">
+            <IconButton
+              size="small"
+              color="primary"
+              onClick={() => handleSave(localValue)}
+              disabled={saving}
+            >
+              {saving ? <CircularProgress size={16} /> : <SaveIcon fontSize="small" />}
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
+      {error && (
+        <Typography variant="caption" color="error" sx={{ mt: 0.5, display: 'block' }}>
+          {error}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/client/src/components/Settings/SystemSettingsSection.tsx
+++ b/client/src/components/Settings/SystemSettingsSection.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Card, CardContent, Typography, CircularProgress, Alert, Accordion,
+  AccordionSummary, AccordionDetails, Box, Divider, Chip,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import TuneIcon from '@mui/icons-material/Tune';
+import { getSystemSettings } from '../../api/systemSettings.api';
+import type { SettingValue, SettingGroup } from '../../api/systemSettings.api';
+import { extractApiError } from '../../utils/apiError';
+import SettingField from './SettingField';
+
+export default function SystemSettingsSection() {
+  const [settings, setSettings] = useState<SettingValue[]>([]);
+  const [groups, setGroups] = useState<SettingGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    getSystemSettings()
+      .then((data) => {
+        setSettings(data.settings);
+        setGroups(data.groups);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(extractApiError(err, 'Failed to load system settings'));
+        setLoading(false);
+      });
+  }, []);
+
+  const handleUpdated = useCallback((key: string, value: unknown) => {
+    setSettings((prev) =>
+      prev.map((s) =>
+        s.key === key ? { ...s, value, source: 'db' as const, envLocked: false } : s,
+      ),
+    );
+  }, []);
+
+  if (loading) {
+    return (
+      <Card variant="outlined">
+        <CardContent sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+          <CircularProgress size={24} />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Alert severity="error">{error}</Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const grouped = new Map<string, SettingValue[]>();
+  for (const s of settings) {
+    const arr = grouped.get(s.group) || [];
+    arr.push(s);
+    grouped.set(s.group, arr);
+  }
+
+  const sortedGroups = groups
+    .filter((g) => grouped.has(g.key))
+    .sort((a, b) => a.order - b.order);
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+          <TuneIcon color="primary" />
+          <Typography variant="subtitle1" fontWeight="bold">
+            System Settings
+          </Typography>
+          <Chip
+            label={`${settings.length} settings`}
+            size="small"
+            variant="outlined"
+          />
+        </Box>
+
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Settings locked by environment variables are read-only. Changes to settings marked
+          with a restart icon take effect after the server is restarted.
+        </Alert>
+
+        {sortedGroups.map((group) => {
+          const groupSettings = grouped.get(group.key) || [];
+          const envCount = groupSettings.filter((s) => s.envLocked).length;
+
+          return (
+            <Accordion key={group.key} disableGutters variant="outlined" sx={{ mb: 1 }}>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography variant="body1" fontWeight="medium">
+                    {group.label}
+                  </Typography>
+                  <Chip
+                    label={`${groupSettings.length}`}
+                    size="small"
+                    variant="outlined"
+                  />
+                  {envCount > 0 && (
+                    <Chip
+                      label={`${envCount} locked`}
+                      size="small"
+                      color="warning"
+                      variant="outlined"
+                    />
+                  )}
+                </Box>
+              </AccordionSummary>
+              <AccordionDetails>
+                {groupSettings.map((s, idx) => (
+                  <Box key={s.key}>
+                    {idx > 0 && <Divider sx={{ my: 1 }} />}
+                    <SettingField setting={s} onUpdated={handleUpdated} />
+                  </Box>
+                ))}
+              </AccordionDetails>
+            </Accordion>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -42,6 +42,7 @@ import dbAuditRoutes from './routes/dbAudit.routes';
 import passwordRotationRoutes from './routes/passwordRotation.routes';
 import dbTunnelRoutes from './routes/dbTunnel.routes';
 import keystrokePolicyRoutes from './routes/keystrokePolicy.routes';
+import systemSettingsRoutes from './routes/systemSettings.routes';
 import healthRoutes from './routes/health.routes';
 import { errorHandler } from './middleware/error.middleware';
 import { requestLogger } from './middleware/requestLogger.middleware';
@@ -147,6 +148,7 @@ app.use('/api/sessions/database', dbProxyRoutes);
 app.use('/api/db-audit', dbAuditRoutes);
 app.use('/api/secrets', passwordRotationRoutes);
 app.use('/api/keystroke-policies', keystrokePolicyRoutes);
+app.use('/api/admin/system-settings', systemSettingsRoutes);
 
 // Health & readiness probes
 app.use('/api', healthRoutes);

--- a/server/src/controllers/systemSettings.controller.ts
+++ b/server/src/controllers/systemSettings.controller.ts
@@ -1,0 +1,55 @@
+import type { Response, NextFunction } from 'express';
+import type { AuthRequest } from '../types';
+import { assertTenantAuthenticated } from '../types';
+import * as systemSettingsService from '../services/systemSettings.service';
+import * as auditService from '../services/audit.service';
+import { getClientIp } from '../utils/ip';
+
+export async function getAllSettings(req: AuthRequest, res: Response, _next: NextFunction) {
+  assertTenantAuthenticated(req);
+  const settings = await systemSettingsService.getAllSettings(req.user.tenantRole);
+  const groups = systemSettingsService.SETTING_GROUPS;
+  res.json({ settings, groups });
+}
+
+export async function updateSetting(req: AuthRequest, res: Response, _next: NextFunction) {
+  assertTenantAuthenticated(req);
+  const key = String(req.params.key);
+  const { value } = req.body;
+
+  const result = await systemSettingsService.setSetting(key, value, req.user.tenantRole);
+
+  auditService.log({
+    userId: req.user.userId,
+    action: 'APP_CONFIG_UPDATE',
+    targetType: 'system_setting',
+    targetId: key,
+    details: { key, value },
+    ipAddress: getClientIp(req),
+  });
+
+  res.json(result);
+}
+
+export async function bulkUpdateSettings(req: AuthRequest, res: Response, _next: NextFunction) {
+  assertTenantAuthenticated(req);
+  const { updates } = req.body;
+
+  const results = await systemSettingsService.setSettings(updates, req.user.tenantRole);
+
+  for (const r of results) {
+    if (r.success) {
+      const update = updates.find((u: { key: string }) => u.key === r.key);
+      auditService.log({
+        userId: req.user.userId,
+        action: 'APP_CONFIG_UPDATE',
+        targetType: 'system_setting',
+        targetId: r.key,
+        details: { key: r.key, value: update?.value },
+        ipAddress: getClientIp(req),
+      });
+    }
+  }
+
+  res.json({ results });
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,6 +26,7 @@ import { setupTunnelHandler } from './socket/tunnel.handler';
 import { startSshProxyServer, stopSshProxyServer } from './services/sshProxy.service';
 import { cleanupIdleTunnels } from './services/rdGateway.service';
 import { cleanupExpiredDeviceCodes } from './services/deviceAuth.service';
+import { applySystemSettings } from './services/systemSettings.service';
 
 function freePort(port: number): void {
   try {
@@ -83,6 +84,7 @@ async function main() {
 
   await runDatabaseMigrations();
   await runStartupMigrations();
+  await applySystemSettings();
 
   // Recover orphaned sessions from previous server instance
   const recovered = await sessionService.recoverOrphanedSessions();

--- a/server/src/routes/systemSettings.routes.ts
+++ b/server/src/routes/systemSettings.routes.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth.middleware';
+import { requireTenantRoleAny } from '../middleware/tenant.middleware';
+import { validate } from '../middleware/validate.middleware';
+import { updateSettingSchema, bulkUpdateSettingsSchema } from '../schemas/systemSettings.schemas';
+import { asyncHandler } from '../middleware/asyncHandler';
+import * as controller from '../controllers/systemSettings.controller';
+
+const router = Router();
+
+router.use(authenticate);
+
+// Read: AUDITOR, ADMIN, OWNER
+router.get(
+  '/',
+  requireTenantRoleAny('AUDITOR', 'ADMIN', 'OWNER'),
+  asyncHandler(controller.getAllSettings),
+);
+
+// Write single: ADMIN, OWNER (per-setting role check in service)
+router.put(
+  '/:key',
+  requireTenantRoleAny('ADMIN', 'OWNER'),
+  validate(updateSettingSchema),
+  asyncHandler(controller.updateSetting),
+);
+
+// Write bulk: ADMIN, OWNER (per-setting role check in service)
+router.put(
+  '/',
+  requireTenantRoleAny('ADMIN', 'OWNER'),
+  validate(bulkUpdateSettingsSchema),
+  asyncHandler(controller.bulkUpdateSettings),
+);
+
+export default router;

--- a/server/src/schemas/systemSettings.schemas.ts
+++ b/server/src/schemas/systemSettings.schemas.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const updateSettingSchema = z.object({
+  value: z.union([z.string(), z.number(), z.boolean()]),
+});
+
+export const bulkUpdateSettingsSchema = z.object({
+  updates: z.array(
+    z.object({
+      key: z.string().min(1),
+      value: z.union([z.string(), z.number(), z.boolean()]),
+    }),
+  ).min(1).max(100),
+});

--- a/server/src/services/systemSettings.service.ts
+++ b/server/src/services/systemSettings.service.ts
@@ -1,0 +1,576 @@
+import prisma from '../lib/prisma';
+import { config } from '../config';
+import { logger } from '../utils/logger';
+import { AppError } from '../middleware/error.middleware';
+import type { TenantRoleType } from '../types';
+
+// ---------------------------------------------------------------------------
+// Role hierarchy (mirrors tenant.middleware.ts)
+// ---------------------------------------------------------------------------
+const ROLE_LEVEL: Record<string, number> = {
+  GUEST: 0.1, AUDITOR: 0.3, CONSULTANT: 0.5,
+  MEMBER: 1, OPERATOR: 2, ADMIN: 3, OWNER: 4,
+};
+
+function roleLevel(role: string): number {
+  return ROLE_LEVEL[role] ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Setting types
+// ---------------------------------------------------------------------------
+export type SettingType = 'boolean' | 'number' | 'string' | 'select' | 'string[]';
+
+export interface SettingDef {
+  key: string;           // DB key + API identifier (matches env var name)
+  envVar: string;        // process.env key for env-lock detection
+  configPath?: string;   // Dot path in config object (for hot-patch at startup)
+  type: SettingType;
+  default: unknown;
+  options?: string[];    // For 'select' type
+  group: string;
+  label: string;
+  description: string;
+  minEditRole: 'ADMIN' | 'OWNER';
+  restartRequired?: boolean;
+}
+
+export interface SettingValue {
+  key: string;
+  value: unknown;
+  source: 'env' | 'db' | 'default';
+  envLocked: boolean;
+  canEdit: boolean;
+  type: SettingType;
+  default: unknown;
+  options?: string[];
+  group: string;
+  label: string;
+  description: string;
+  restartRequired: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Settings Registry — single source of truth for all UI-configurable settings
+// ---------------------------------------------------------------------------
+export const SETTINGS_REGISTRY: SettingDef[] = [
+  // ── General ──────────────────────────────────────────────────────────────
+  {
+    key: 'EMAIL_VERIFY_REQUIRED', envVar: 'EMAIL_VERIFY_REQUIRED',
+    configPath: 'emailVerifyRequired', type: 'boolean', default: true,
+    group: 'general', label: 'Require Email Verification',
+    description: 'Require email verification before allowing login.',
+    minEditRole: 'ADMIN',
+  },
+  {
+    key: 'ALLOW_EXTERNAL_SHARING', envVar: 'ALLOW_EXTERNAL_SHARING',
+    configPath: 'allowExternalSharing', type: 'boolean', default: false,
+    group: 'general', label: 'Allow External Sharing',
+    description: 'Allow sharing connections with users outside the tenant.',
+    minEditRole: 'ADMIN',
+  },
+  {
+    key: 'ALLOW_LOCAL_NETWORK', envVar: 'ALLOW_LOCAL_NETWORK',
+    type: 'boolean', default: false,
+    group: 'general', label: 'Allow Local Network Connections',
+    description: 'Allow connections to private/local network addresses (10.x, 172.16-31.x, 192.168.x).',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'CLI_ENABLED', envVar: 'CLI_ENABLED',
+    type: 'boolean', default: false,
+    group: 'general', label: 'CLI Enabled',
+    description: 'Enable the arsenale CLI tool inside the container.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+
+  // ── Logging ──────────────────────────────────────────────────────────────
+  {
+    key: 'LOG_LEVEL', envVar: 'LOG_LEVEL',
+    configPath: 'logLevel', type: 'select', default: 'info',
+    options: ['error', 'warn', 'info', 'verbose', 'debug'],
+    group: 'logging', label: 'Log Level',
+    description: 'Server log verbosity level.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'LOG_FORMAT', envVar: 'LOG_FORMAT',
+    configPath: 'logFormat', type: 'select', default: 'text',
+    options: ['text', 'json'],
+    group: 'logging', label: 'Log Format',
+    description: 'Log output format.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'LOG_TIMESTAMPS', envVar: 'LOG_TIMESTAMPS',
+    configPath: 'logTimestamps', type: 'boolean', default: true,
+    group: 'logging', label: 'Include Timestamps',
+    description: 'Include ISO-8601 timestamps in log output.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'LOG_HTTP_REQUESTS', envVar: 'LOG_HTTP_REQUESTS',
+    configPath: 'logHttpRequests', type: 'boolean', default: false,
+    group: 'logging', label: 'Log HTTP Requests',
+    description: 'Log HTTP requests (method, url, status, duration).',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'LOG_GUACAMOLE', envVar: 'LOG_GUACAMOLE',
+    configPath: 'logGuacamole', type: 'boolean', default: true,
+    group: 'logging', label: 'Log Guacamole',
+    description: 'Enable guacamole-lite (RDP/VNC tunnel) logs.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+
+  // ── Rate Limiting ────────────────────────────────────────────────────────
+  {
+    key: 'GLOBAL_RATE_LIMIT_WINDOW_MS', envVar: 'GLOBAL_RATE_LIMIT_WINDOW_MS',
+    type: 'number', default: 60000,
+    group: 'rate-limiting', label: 'Global Rate Limit Window (ms)',
+    description: 'Sliding window duration for the global API rate limiter.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'GLOBAL_RATE_LIMIT_MAX_AUTHENTICATED', envVar: 'GLOBAL_RATE_LIMIT_MAX_AUTHENTICATED',
+    type: 'number', default: 200,
+    group: 'rate-limiting', label: 'Global Max Requests (Authenticated)',
+    description: 'Maximum API requests per window for authenticated users.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'GLOBAL_RATE_LIMIT_MAX_ANONYMOUS', envVar: 'GLOBAL_RATE_LIMIT_MAX_ANONYMOUS',
+    type: 'number', default: 60,
+    group: 'rate-limiting', label: 'Global Max Requests (Anonymous)',
+    description: 'Maximum API requests per window for anonymous users.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'LOGIN_RATE_LIMIT_WINDOW_MS', envVar: 'LOGIN_RATE_LIMIT_WINDOW_MS',
+    configPath: 'loginRateLimitWindowMs', type: 'number', default: 900000,
+    group: 'rate-limiting', label: 'Login Rate Limit Window (ms)',
+    description: 'Sliding window duration for login attempts.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'LOGIN_RATE_LIMIT_MAX_ATTEMPTS', envVar: 'LOGIN_RATE_LIMIT_MAX_ATTEMPTS',
+    configPath: 'loginRateLimitMaxAttempts', type: 'number', default: 5,
+    group: 'rate-limiting', label: 'Login Max Attempts',
+    description: 'Maximum login attempts per IP within the window.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'ACCOUNT_LOCKOUT_THRESHOLD', envVar: 'ACCOUNT_LOCKOUT_THRESHOLD',
+    configPath: 'accountLockoutThreshold', type: 'number', default: 10,
+    group: 'rate-limiting', label: 'Account Lockout Threshold',
+    description: 'Consecutive failed logins before account lockout.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'ACCOUNT_LOCKOUT_DURATION_MS', envVar: 'ACCOUNT_LOCKOUT_DURATION_MS',
+    configPath: 'accountLockoutDurationMs', type: 'number', default: 1800000,
+    group: 'rate-limiting', label: 'Account Lockout Duration (ms)',
+    description: 'How long an account stays locked after exceeding the threshold.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'RATE_LIMIT_WHITELIST_CIDRS', envVar: 'RATE_LIMIT_WHITELIST_CIDRS',
+    configPath: 'rateLimitWhitelistCidrs', type: 'string',
+    default: '127.0.0.1/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16',
+    group: 'rate-limiting', label: 'Rate Limit Whitelist CIDRs',
+    description: 'Comma-separated CIDR ranges that bypass the global rate limiter.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+
+  // ── Session Defaults ─────────────────────────────────────────────────────
+  {
+    key: 'MAX_CONCURRENT_SESSIONS', envVar: 'MAX_CONCURRENT_SESSIONS',
+    configPath: 'maxConcurrentSessions', type: 'number', default: 0,
+    group: 'sessions', label: 'Max Concurrent Sessions',
+    description: 'Maximum concurrent login sessions per user (0 = unlimited).',
+    minEditRole: 'ADMIN',
+  },
+  {
+    key: 'ABSOLUTE_SESSION_TIMEOUT_SECONDS', envVar: 'ABSOLUTE_SESSION_TIMEOUT_SECONDS',
+    configPath: 'absoluteSessionTimeoutSeconds', type: 'number', default: 43200,
+    group: 'sessions', label: 'Absolute Session Timeout (s)',
+    description: 'Forces re-login regardless of activity (0 = disabled, default: 43200 = 12h).',
+    minEditRole: 'ADMIN',
+  },
+  {
+    key: 'SESSION_INACTIVITY_TIMEOUT_SECONDS', envVar: 'SESSION_INACTIVITY_TIMEOUT_SECONDS',
+    configPath: 'sessionInactivityTimeoutSeconds', type: 'number', default: 3600,
+    group: 'sessions', label: 'Inactivity Timeout (s)',
+    description: 'Idle timeout before a session is marked inactive (default: 3600 = 1h).',
+    minEditRole: 'ADMIN',
+  },
+  {
+    key: 'SESSION_HEARTBEAT_INTERVAL_MS', envVar: 'SESSION_HEARTBEAT_INTERVAL_MS',
+    configPath: 'sessionHeartbeatIntervalMs', type: 'number', default: 30000,
+    group: 'sessions', label: 'Heartbeat Interval (ms)',
+    description: 'How often clients send a heartbeat to keep sessions alive.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'SESSION_IDLE_THRESHOLD_MINUTES', envVar: 'SESSION_IDLE_THRESHOLD_MINUTES',
+    configPath: 'sessionIdleThresholdMinutes', type: 'number', default: 5,
+    group: 'sessions', label: 'Idle Threshold (min)',
+    description: 'Minutes without heartbeat before marking a session as idle.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'SESSION_CLEANUP_RETENTION_DAYS', envVar: 'SESSION_CLEANUP_RETENTION_DAYS',
+    configPath: 'sessionCleanupRetentionDays', type: 'number', default: 30,
+    group: 'sessions', label: 'Cleanup Retention (days)',
+    description: 'Days to retain closed session records before purging.',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+
+  // ── Security Detection ───────────────────────────────────────────────────
+  {
+    key: 'TOKEN_BINDING_ENABLED', envVar: 'TOKEN_BINDING_ENABLED',
+    configPath: 'tokenBindingEnabled', type: 'boolean', default: true,
+    group: 'security-detection', label: 'Token Binding',
+    description: 'Bind JWT tokens to client IP + User-Agent to prevent session hijacking.',
+    minEditRole: 'OWNER',
+  },
+  {
+    key: 'IMPOSSIBLE_TRAVEL_SPEED_KMH', envVar: 'IMPOSSIBLE_TRAVEL_SPEED_KMH',
+    configPath: 'impossibleTravelSpeedKmh', type: 'number', default: 900,
+    group: 'security-detection', label: 'Impossible Travel Speed (km/h)',
+    description: 'Maximum plausible travel speed. Logins exceeding this are flagged. 0 = disabled.',
+    minEditRole: 'OWNER',
+  },
+  {
+    key: 'LATERAL_MOVEMENT_DETECTION_ENABLED', envVar: 'LATERAL_MOVEMENT_DETECTION_ENABLED',
+    configPath: 'lateralMovementEnabled', type: 'boolean', default: true,
+    group: 'security-detection', label: 'Lateral Movement Detection',
+    description: 'Detect and block suspicious lateral movement across targets.',
+    minEditRole: 'OWNER',
+  },
+  {
+    key: 'LATERAL_MOVEMENT_MAX_DISTINCT_TARGETS', envVar: 'LATERAL_MOVEMENT_MAX_DISTINCT_TARGETS',
+    configPath: 'lateralMovementMaxDistinctTargets', type: 'number', default: 10,
+    group: 'security-detection', label: 'Max Distinct Targets',
+    description: 'Maximum distinct targets a user can connect to within the detection window.',
+    minEditRole: 'OWNER',
+  },
+  {
+    key: 'LATERAL_MOVEMENT_WINDOW_MINUTES', envVar: 'LATERAL_MOVEMENT_WINDOW_MINUTES',
+    configPath: 'lateralMovementWindowMinutes', type: 'number', default: 5,
+    group: 'security-detection', label: 'Detection Window (min)',
+    description: 'Time window for counting distinct connection targets.',
+    minEditRole: 'OWNER',
+  },
+  {
+    key: 'LATERAL_MOVEMENT_LOCKOUT_MINUTES', envVar: 'LATERAL_MOVEMENT_LOCKOUT_MINUTES',
+    configPath: 'lateralMovementLockoutMinutes', type: 'number', default: 30,
+    group: 'security-detection', label: 'Lockout Duration (min)',
+    description: 'How long a user is blocked from new connections after a lateral movement alert.',
+    minEditRole: 'OWNER',
+  },
+
+  // ── Storage & Quotas ─────────────────────────────────────────────────────
+  {
+    key: 'FILE_UPLOAD_MAX_SIZE', envVar: 'FILE_UPLOAD_MAX_SIZE',
+    configPath: 'fileUploadMaxSize', type: 'number', default: 10485760,
+    group: 'storage', label: 'Max File Upload Size (bytes)',
+    description: 'Maximum size per uploaded file (default: 10 MB).',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'USER_DRIVE_QUOTA', envVar: 'USER_DRIVE_QUOTA',
+    configPath: 'userDriveQuota', type: 'number', default: 104857600,
+    group: 'storage', label: 'User Drive Quota (bytes)',
+    description: 'Maximum storage per user (default: 100 MB).',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+  {
+    key: 'SFTP_MAX_FILE_SIZE', envVar: 'SFTP_MAX_FILE_SIZE',
+    configPath: 'sftpMaxFileSize', type: 'number', default: 104857600,
+    group: 'storage', label: 'SFTP Max File Size (bytes)',
+    description: 'Maximum SFTP transfer size (default: 100 MB).',
+    minEditRole: 'ADMIN', restartRequired: true,
+  },
+
+  // ── Vault Defaults ───────────────────────────────────────────────────────
+  {
+    key: 'VAULT_TTL_MINUTES', envVar: 'VAULT_TTL_MINUTES',
+    configPath: 'vaultTtlMinutes', type: 'number', default: 30,
+    group: 'vault', label: 'Vault Session TTL (min)',
+    description: 'Default vault master key session lifetime.',
+    minEditRole: 'OWNER',
+  },
+  {
+    key: 'VAULT_RATE_LIMIT_WINDOW_MS', envVar: 'VAULT_RATE_LIMIT_WINDOW_MS',
+    configPath: 'vaultRateLimitWindowMs', type: 'number', default: 60000,
+    group: 'vault', label: 'Vault Unlock Rate Limit Window (ms)',
+    description: 'Sliding window duration for vault unlock attempts.',
+    minEditRole: 'OWNER', restartRequired: true,
+  },
+  {
+    key: 'VAULT_RATE_LIMIT_MAX_ATTEMPTS', envVar: 'VAULT_RATE_LIMIT_MAX_ATTEMPTS',
+    configPath: 'vaultRateLimitMaxAttempts', type: 'number', default: 5,
+    group: 'vault', label: 'Vault Unlock Max Attempts',
+    description: 'Maximum vault unlock attempts per window.',
+    minEditRole: 'OWNER', restartRequired: true,
+  },
+
+  // ── JWT & Tokens ─────────────────────────────────────────────────────────
+  { key: 'JWT_EXPIRES_IN', envVar: 'JWT_EXPIRES_IN', configPath: 'jwtExpiresIn', type: 'string', default: '15m', group: 'jwt', label: 'Access Token Expiration', description: 'JWT access token lifetime (e.g., 15m, 1h, 2d).', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'JWT_REFRESH_EXPIRES_IN', envVar: 'JWT_REFRESH_EXPIRES_IN', configPath: 'jwtRefreshExpiresIn', type: 'string', default: '7d', group: 'jwt', label: 'Refresh Token Expiration', description: 'Refresh token lifetime (e.g., 7d, 30d).', minEditRole: 'OWNER', restartRequired: true },
+
+  // ── Recording ────────────────────────────────────────────────────────────
+  { key: 'RECORDING_ENABLED', envVar: 'RECORDING_ENABLED', configPath: 'recordingEnabled', type: 'boolean', default: false, group: 'recording', label: 'Session Recording', description: 'Enable automatic recording of SSH/RDP/VNC sessions.', minEditRole: 'ADMIN' },
+  { key: 'RECORDING_RETENTION_DAYS', envVar: 'RECORDING_RETENTION_DAYS', configPath: 'recordingRetentionDays', type: 'number', default: 90, group: 'recording', label: 'Recording Retention (days)', description: 'How many days to keep recordings before auto-cleanup.', minEditRole: 'ADMIN' },
+
+  // ── Key Rotation ─────────────────────────────────────────────────────────
+  { key: 'KEY_ROTATION_CRON', envVar: 'KEY_ROTATION_CRON', configPath: 'keyRotationCron', type: 'string', default: '0 2 * * *', group: 'key-rotation', label: 'Key Rotation Schedule (cron)', description: 'Cron expression for the SSH key rotation check job.', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'KEY_ROTATION_ADVANCE_DAYS', envVar: 'KEY_ROTATION_ADVANCE_DAYS', configPath: 'keyRotationAdvanceDays', type: 'number', default: 7, group: 'key-rotation', label: 'Rotation Advance (days)', description: 'How many days before expiration to trigger key rotation.', minEditRole: 'OWNER', restartRequired: true },
+
+  // ── WebAuthn RP ──────────────────────────────────────────────────────────
+  { key: 'WEBAUTHN_RP_ID', envVar: 'WEBAUTHN_RP_ID', configPath: 'webauthn.rpId', type: 'string', default: 'localhost', group: 'webauthn', label: 'Relying Party ID', description: 'WebAuthn relying party identifier (usually the domain name).', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'WEBAUTHN_RP_ORIGIN', envVar: 'WEBAUTHN_RP_ORIGIN', configPath: 'webauthn.rpOrigin', type: 'string', default: 'http://localhost:3000', group: 'webauthn', label: 'Relying Party Origin', description: 'Exact origin expected by the browser (scheme + domain + port).', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'WEBAUTHN_RP_NAME', envVar: 'WEBAUTHN_RP_NAME', configPath: 'webauthn.rpName', type: 'string', default: 'Arsenale', group: 'webauthn', label: 'Relying Party Name', description: 'Human-readable name shown in browser/authenticator prompts.', minEditRole: 'OWNER', restartRequired: true },
+
+  // ── Email Provider (non-secret fields) ───────────────────────────────────
+  { key: 'EMAIL_PROVIDER', envVar: 'EMAIL_PROVIDER', configPath: 'emailProvider', type: 'select', default: 'smtp', options: ['smtp', 'sendgrid', 'ses', 'resend', 'mailgun'], group: 'email', label: 'Email Provider', description: 'Email delivery provider.', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'SMTP_HOST', envVar: 'SMTP_HOST', configPath: 'smtpHost', type: 'string', default: '', group: 'email', label: 'SMTP Host', description: 'SMTP server hostname.', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'SMTP_PORT', envVar: 'SMTP_PORT', configPath: 'smtpPort', type: 'number', default: 587, group: 'email', label: 'SMTP Port', description: 'SMTP server port.', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'SMTP_USER', envVar: 'SMTP_USER', configPath: 'smtpUser', type: 'string', default: '', group: 'email', label: 'SMTP User', description: 'SMTP authentication username.', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'SMTP_FROM', envVar: 'SMTP_FROM', configPath: 'smtpFrom', type: 'string', default: 'noreply@example.com', group: 'email', label: 'SMTP From Address', description: 'Default sender email address.', minEditRole: 'OWNER', restartRequired: true },
+
+  // ── SMS Provider (non-secret fields) ─────────────────────────────────────
+  { key: 'SMS_PROVIDER', envVar: 'SMS_PROVIDER', configPath: 'smsProvider', type: 'select', default: '', options: ['', 'twilio', 'sns', 'vonage'], group: 'sms', label: 'SMS Provider', description: 'SMS delivery provider (empty = disabled, dev mode logs OTP to console).', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'TWILIO_ACCOUNT_SID', envVar: 'TWILIO_ACCOUNT_SID', configPath: 'twilioAccountSid', type: 'string', default: '', group: 'sms', label: 'Twilio Account SID', description: 'Twilio account identifier (not a secret).', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'TWILIO_FROM_NUMBER', envVar: 'TWILIO_FROM_NUMBER', configPath: 'twilioFromNumber', type: 'string', default: '', group: 'sms', label: 'Twilio From Number', description: 'Phone number to send SMS from (e.g., +1234567890).', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'AWS_SNS_REGION', envVar: 'AWS_SNS_REGION', configPath: 'snsRegion', type: 'string', default: 'us-east-1', group: 'sms', label: 'AWS SNS Region', description: 'AWS region for SNS SMS delivery.', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'VONAGE_API_KEY', envVar: 'VONAGE_API_KEY', configPath: 'vonageApiKey', type: 'string', default: '', group: 'sms', label: 'Vonage API Key', description: 'Vonage API key (public identifier, not the secret).', minEditRole: 'OWNER', restartRequired: true },
+  { key: 'VONAGE_FROM_NUMBER', envVar: 'VONAGE_FROM_NUMBER', configPath: 'vonageFromNumber', type: 'string', default: '', group: 'sms', label: 'Vonage From Number', description: 'Phone number or sender ID for Vonage SMS.', minEditRole: 'OWNER', restartRequired: true },
+
+  // ── SSH Proxy ────────────────────────────────────────────────────────────
+  { key: 'SSH_PROXY_ENABLED', envVar: 'SSH_PROXY_ENABLED', configPath: 'sshProxy.enabled', type: 'boolean', default: false, group: 'ssh-proxy', label: 'SSH Proxy Enabled', description: 'Enable the native SSH protocol proxy.', minEditRole: 'ADMIN', restartRequired: true },
+  { key: 'SSH_PROXY_PORT', envVar: 'SSH_PROXY_PORT', configPath: 'sshProxy.port', type: 'number', default: 2222, group: 'ssh-proxy', label: 'SSH Proxy Port', description: 'Port the SSH proxy listens on.', minEditRole: 'ADMIN', restartRequired: true },
+  { key: 'SSH_PROXY_AUTH_METHODS', envVar: 'SSH_PROXY_AUTH_METHODS', configPath: 'sshProxy.allowedAuthMethods', type: 'string', default: 'token,keyboard-interactive', group: 'ssh-proxy', label: 'SSH Proxy Auth Methods', description: 'Comma-separated allowed auth methods (token, keyboard-interactive, certificate).', minEditRole: 'ADMIN', restartRequired: true },
+  { key: 'SSH_PROXY_TOKEN_TTL_SECONDS', envVar: 'SSH_PROXY_TOKEN_TTL_SECONDS', configPath: 'sshProxy.tokenTtlSeconds', type: 'number', default: 300, group: 'ssh-proxy', label: 'SSH Token TTL (s)', description: 'SSH proxy authentication token lifetime.', minEditRole: 'ADMIN', restartRequired: true },
+  { key: 'SSH_PROXY_KEYSTROKE_RECORDING', envVar: 'SSH_PROXY_KEYSTROKE_RECORDING', configPath: 'sshProxy.keystrokeRecording', type: 'boolean', default: false, group: 'ssh-proxy', label: 'Keystroke Recording', description: 'Record keystrokes for SSH proxy sessions.', minEditRole: 'ADMIN', restartRequired: true },
+
+  // ── Orchestration ────────────────────────────────────────────────────────
+  { key: 'ORCHESTRATOR_TYPE', envVar: 'ORCHESTRATOR_TYPE', configPath: 'orchestratorType', type: 'select', default: '', options: ['', 'docker', 'podman', 'kubernetes', 'none'], group: 'orchestration', label: 'Orchestrator Type', description: 'Container orchestrator (empty = auto-detect).', minEditRole: 'ADMIN', restartRequired: true },
+  { key: 'ORCHESTRATOR_SSH_GATEWAY_IMAGE', envVar: 'ORCHESTRATOR_SSH_GATEWAY_IMAGE', configPath: 'orchestratorSshGatewayImage', type: 'string', default: 'ghcr.io/dnviti/arsenale/ssh-gateway:latest', group: 'orchestration', label: 'SSH Gateway Image', description: 'Container image for managed SSH gateways.', minEditRole: 'ADMIN', restartRequired: true },
+  { key: 'ORCHESTRATOR_GUACD_IMAGE', envVar: 'ORCHESTRATOR_GUACD_IMAGE', configPath: 'orchestratorGuacdImage', type: 'string', default: 'guacamole/guacd:1.6.0', group: 'orchestration', label: 'Guacd Image', description: 'Container image for Guacamole daemon.', minEditRole: 'ADMIN', restartRequired: true },
+  { key: 'ORCHESTRATOR_DB_PROXY_IMAGE', envVar: 'ORCHESTRATOR_DB_PROXY_IMAGE', configPath: 'orchestratorDbProxyImage', type: 'string', default: 'ghcr.io/dnviti/arsenale/db-proxy:latest', group: 'orchestration', label: 'DB Proxy Image', description: 'Container image for database proxy.', minEditRole: 'ADMIN', restartRequired: true },
+];
+
+// Group metadata for UI display ordering and labels
+export const SETTING_GROUPS: { key: string; label: string; order: number }[] = [
+  { key: 'general', label: 'General', order: 0 },
+  { key: 'logging', label: 'Logging', order: 1 },
+  { key: 'rate-limiting', label: 'Rate Limiting', order: 2 },
+  { key: 'sessions', label: 'Session Defaults', order: 3 },
+  { key: 'security-detection', label: 'Security Detection', order: 4 },
+  { key: 'storage', label: 'Storage & Quotas', order: 5 },
+  { key: 'vault', label: 'Vault Defaults', order: 6 },
+  { key: 'jwt', label: 'JWT & Tokens', order: 7 },
+  { key: 'recording', label: 'Recording', order: 8 },
+  { key: 'key-rotation', label: 'Key Rotation', order: 9 },
+  { key: 'webauthn', label: 'WebAuthn', order: 10 },
+  { key: 'email', label: 'Email Provider', order: 11 },
+  { key: 'sms', label: 'SMS Provider', order: 12 },
+  { key: 'ssh-proxy', label: 'SSH Proxy', order: 13 },
+  { key: 'orchestration', label: 'Orchestration', order: 14 },
+];
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+const CACHE_TTL_MS = 30_000;
+let dbCache: Map<string, { value: string; expiresAt: number }> = new Map();
+
+async function getDbValue(key: string): Promise<string | undefined> {
+  const cached = dbCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  try {
+    const row = await prisma.appConfig.findUnique({ where: { key } });
+    if (row) {
+      dbCache.set(key, { value: row.value, expiresAt: Date.now() + CACHE_TTL_MS });
+      return row.value;
+    }
+  } catch (err) {
+    logger.error(`Failed to read system setting ${key}:`, err);
+  }
+  return undefined;
+}
+
+function invalidateCache(key: string): void {
+  dbCache.delete(key);
+}
+
+export function invalidateAllCache(): void {
+  dbCache = new Map();
+}
+
+// ---------------------------------------------------------------------------
+// Value parsing
+// ---------------------------------------------------------------------------
+function parseValue(raw: string | undefined, type: SettingType, defaultVal: unknown): unknown {
+  if (raw === undefined || raw === '') return defaultVal;
+  switch (type) {
+    case 'boolean':
+      return raw === 'true' || raw === '1';
+    case 'number': {
+      const n = Number(raw);
+      return Number.isNaN(n) ? defaultVal : n;
+    }
+    case 'select':
+    case 'string':
+    case 'string[]':
+      return raw;
+    default:
+      return raw;
+  }
+}
+
+function serializeValue(value: unknown, _type: SettingType): string {
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+// ---------------------------------------------------------------------------
+// Service functions
+// ---------------------------------------------------------------------------
+
+export async function getAllSettings(callerRole: TenantRoleType): Promise<SettingValue[]> {
+  const callerLevel = roleLevel(callerRole);
+  const results: SettingValue[] = [];
+
+  for (const def of SETTINGS_REGISTRY) {
+    const envRaw = process.env[def.envVar];
+    const envLocked = envRaw !== undefined;
+
+    let value: unknown;
+    let source: 'env' | 'db' | 'default';
+
+    if (envLocked) {
+      value = parseValue(envRaw, def.type, def.default);
+      source = 'env';
+    } else {
+      const dbVal = await getDbValue(def.key);
+      if (dbVal !== undefined) {
+        value = parseValue(dbVal, def.type, def.default);
+        source = 'db';
+      } else {
+        value = def.default;
+        source = 'default';
+      }
+    }
+
+    results.push({
+      key: def.key,
+      value,
+      source,
+      envLocked,
+      canEdit: !envLocked && callerLevel >= roleLevel(def.minEditRole),
+      type: def.type,
+      default: def.default,
+      options: def.options,
+      group: def.group,
+      label: def.label,
+      description: def.description,
+      restartRequired: def.restartRequired ?? false,
+    });
+  }
+
+  return results;
+}
+
+export async function setSetting(
+  key: string,
+  value: unknown,
+  callerRole: TenantRoleType,
+): Promise<{ key: string; value: unknown; source: 'db' }> {
+  const def = SETTINGS_REGISTRY.find(d => d.key === key);
+  if (!def) throw new AppError('Unknown setting key.', 400);
+
+  if (roleLevel(callerRole) < roleLevel(def.minEditRole)) {
+    throw new AppError('Insufficient role to modify this setting.', 403);
+  }
+
+  if (process.env[def.envVar] !== undefined) {
+    throw new AppError(
+      `Setting "${key}" is locked by environment variable and cannot be changed via the admin panel.`,
+      403,
+    );
+  }
+
+  const serialized = serializeValue(value, def.type);
+  await prisma.appConfig.upsert({
+    where: { key },
+    update: { value: serialized },
+    create: { key, value: serialized },
+  });
+
+  invalidateCache(key);
+  return { key, value, source: 'db' };
+}
+
+export async function setSettings(
+  updates: Array<{ key: string; value: unknown }>,
+  callerRole: TenantRoleType,
+): Promise<Array<{ key: string; success: boolean; error?: string }>> {
+  const results: Array<{ key: string; success: boolean; error?: string }> = [];
+
+  for (const { key, value } of updates) {
+    try {
+      await setSetting(key, value, callerRole);
+      results.push({ key, success: true });
+    } catch (err) {
+      results.push({
+        key,
+        success: false,
+        error: err instanceof AppError ? err.message : 'Unknown error',
+      });
+    }
+  }
+
+  return results;
+}
+
+export async function applySystemSettings(): Promise<void> {
+  try {
+    const rows = await prisma.appConfig.findMany();
+    const dbMap = new Map(rows.map((r: { key: string; value: string }) => [r.key, r.value]));
+
+    for (const def of SETTINGS_REGISTRY) {
+      if (!def.configPath) continue;
+      if (process.env[def.envVar] !== undefined) continue;
+
+      const dbVal = dbMap.get(def.key);
+      if (dbVal === undefined) continue;
+
+      const parsed = parseValue(dbVal, def.type, def.default);
+      setNestedValue(config, def.configPath, parsed);
+    }
+
+    logger.info(`System settings loaded: ${rows.length} keys from database.`);
+  } catch (err) {
+    logger.warn('Failed to load system settings from database (using defaults):', err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function setNestedValue(obj: any, path: string, value: unknown): void {
+  const parts = path.split('.');
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (current[parts[i]] === undefined) return;
+    current = current[parts[i]];
+  }
+  current[parts[parts.length - 1]] = value;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Summary
- Registry-driven system settings with ~50 env vars configurable via Settings > Administration tab
- 3-layer RBAC: AUDITOR (read-only), ADMIN (edit operational), OWNER (edit all)
- ENV-locked settings shown as read-only with amber badge; DB-backed via AppConfig with 30s cache
- Startup loader (`applySystemSettings()`) patches config object from DB values after migrations
- 15 setting groups: General, Logging, Rate Limiting, Sessions, Security Detection, Storage, Vault, JWT, Recording, Key Rotation, WebAuthn, Email, SMS, SSH Proxy, Orchestration

## Test plan
- [ ] Open Settings > Administration as ADMIN — verify System Settings card with grouped Accordions
- [ ] Toggle a boolean setting (e.g., Allow External Sharing) — verify save works
- [ ] Set an env var and restart — verify that setting shows ENV badge and is disabled
- [ ] Log in as AUDITOR — verify all fields are read-only
- [ ] Log in as OWNER — verify sensitive settings (JWT, Security Detection) are editable
- [ ] Check Audit Log for APP_CONFIG_UPDATE entries after changing a setting
- [ ] Restart server — verify "System settings loaded" log message

Refs #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)