### PR TITLE
Add GitHub workflow badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
   <img src="icons/Arsenale_logo_transparent.png" alt="Arsenale" width="500" />
 </div>
 
+[![Verify Server](https://github.com/dnviti/arsenale/actions/workflows/docker-build.yml/badge.svg)](https://github.com/dnviti/arsenale/actions/workflows/docker-build.yml)
+[![Verify Server](https://github.com/dnviti/arsenale/actions/workflows/gateway-builds.yml/badge.svg)](https://github.com/dnviti/arsenale/actions/workflows/gateway-builds.yml)
+[![Verify Server](https://github.com/dnviti/arsenale/actions/workflows/release.yml/badge.svg)](https://github.com/dnviti/arsenale/actions/workflows/release.yml)
+[![Verify Server](https://github.com/dnviti/arsenale/actions/workflows/security.yml/badge.svg)](https://github.com/dnviti/arsenale/actions/workflows/security.yml)
+[![Verify Server](https://github.com/dnviti/arsenale/actions/workflows/verify.yml/badge.svg)](https://github.com/dnviti/arsenale/actions/workflows/verify.yml)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
-[![Verify Server](https://github.com/dnviti/arsenale/actions/workflows/verify-server.yml/badge.svg)](https://github.com/dnviti/arsenale/actions/workflows/verify-server.yml)
-[![Verify Client](https://github.com/dnviti/arsenale/actions/workflows/verify-client.yml/badge.svg)](https://github.com/dnviti/arsenale/actions/workflows/verify-client.yml)
 [![Version](https://img.shields.io/badge/version-1.7.1-green.svg)](CHANGELOG.md)
 
 A web-based application for managing and accessing remote SSH and RDP connections from your browser. Organize connections in folders, share them with team members, and keep credentials encrypted at rest with a personal vault.


### PR DESCRIPTION
This pull request updates the badges displayed in the `README.md` file to better reflect the current CI workflows and improve project status visibility.

**Documentation and CI badge updates:**

* Added new badges for several GitHub Actions workflows, including `docker-build.yml`, `gateway-builds.yml`, `release.yml`, `security.yml`, and `verify.yml` to the top of the `README.md` for improved CI/CD status tracking.
* Removed outdated badges for `verify-server.yml` and `verify-client.yml` workflows from the `README.md` to reflect changes in the project's CI pipeline.