### PR TITLE
fix: eager DB connectivity check prevents false connected state (DBFIX-2117)

### DIFF
--- a/client/src/components/DatabaseClient/DbEditor.tsx
+++ b/client/src/components/DatabaseClient/DbEditor.tsx
@@ -70,6 +70,7 @@ interface DbEditorProps {
   tabId: string;
   isActive?: boolean;
   credentials?: CredentialOverride;
+  initialProtocol?: string;
 }
 
 interface QuerySubTab {
@@ -132,6 +133,7 @@ export default function DbEditor({
   tabId,
   isActive = true,
   credentials,
+  initialProtocol,
 }: DbEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const monacoEditorRef = useRef<monacoNs.editor.IStandaloneCodeEditor | null>(null);
@@ -157,7 +159,7 @@ export default function DbEditor({
 
   const [connectionState, setConnectionState] = useState<DbConnectionState>('connecting');
   const [error, setError] = useState('');
-  const [protocol, setProtocol] = useState('postgresql');
+  const [protocol, setProtocol] = useState(initialProtocol || 'postgresql');
   const [databaseName, setDatabaseName] = useState<string | undefined>();
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [schemaData, setSchemaData] = useState<DbSchemaInfo>({ tables: [] });

--- a/client/src/components/Tabs/TabPanel.tsx
+++ b/client/src/components/Tabs/TabPanel.tsx
@@ -46,7 +46,7 @@ export default function TabPanel() {
           ) : tab.connection.type === 'VNC' ? (
             <VncViewer connectionId={tab.connection.id} tabId={tab.id} isActive={tab.id === activeTabId} credentials={tab.credentials} />
           ) : tab.connection.type === 'DATABASE' ? (
-            <DbEditor connectionId={tab.connection.id} tabId={tab.id} isActive={tab.id === activeTabId} credentials={tab.credentials} />
+            <DbEditor connectionId={tab.connection.id} tabId={tab.id} isActive={tab.id === activeTabId} credentials={tab.credentials} initialProtocol={tab.connection.dbSettings?.protocol} />
           ) : (
             <RdpViewer connectionId={tab.connection.id} tabId={tab.id} isActive={tab.id === activeTabId} enableDrive={tab.connection.enableDrive} credentials={tab.credentials} />
           )}

--- a/server/src/services/dbProxy.service.ts
+++ b/server/src/services/dbProxy.service.ts
@@ -174,6 +174,57 @@ export async function createDbProxySession(params: {
     routingDecision,
   });
 
+  // Eagerly test database connectivity so the client gets an immediate error
+  // instead of a false "connected" state when the target DB is unreachable.
+  try {
+    await dbQueryExecutor.testConnection({
+      sessionId,
+      connectionId,
+      userId,
+      tenantId: tenantId ?? '',
+      metadata: {
+        host: conn.host,
+        port: conn.port,
+        dbProtocol,
+        databaseName,
+        username,
+        resolvedHost: proxyHost,
+        resolvedPort: proxyPort,
+        ...(dbSettings.oracleConnectionType && { oracleConnectionType: dbSettings.oracleConnectionType }),
+        ...(dbSettings.oracleSid && { oracleSid: dbSettings.oracleSid }),
+        ...(dbSettings.oracleServiceName && { oracleServiceName: dbSettings.oracleServiceName }),
+        ...(dbSettings.oracleRole && { oracleRole: dbSettings.oracleRole }),
+        ...(dbSettings.oracleTnsAlias && { oracleTnsAlias: dbSettings.oracleTnsAlias }),
+        ...(dbSettings.oracleTnsDescriptor && { oracleTnsDescriptor: dbSettings.oracleTnsDescriptor }),
+        ...(dbSettings.oracleConnectString && { oracleConnectString: dbSettings.oracleConnectString }),
+        ...(dbSettings.mssqlInstanceName && { mssqlInstanceName: dbSettings.mssqlInstanceName }),
+        ...(dbSettings.mssqlAuthMode && { mssqlAuthMode: dbSettings.mssqlAuthMode }),
+        ...(dbSettings.db2DatabaseAlias && { db2DatabaseAlias: dbSettings.db2DatabaseAlias }),
+        ...(sessionConfig && { sessionConfig }),
+      },
+    });
+  } catch (err) {
+    // Connectivity check failed — clean up the session record
+    await sessionService.endSession(sessionId, 'connectivity_check_failed');
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    log.warn(`DB connectivity check failed for session ${sessionId}: ${msg}`);
+
+    if (err instanceof AppError) throw err;
+
+    // Classify common driver errors into user-friendly responses
+    const lower = msg.toLowerCase();
+    if (lower.includes('econnrefused') || lower.includes('connection refused')) {
+      throw new AppError('Database unreachable — connection refused', 502);
+    }
+    if (lower.includes('authentication') || lower.includes('password') || lower.includes('login failed') || lower.includes('access denied')) {
+      throw new AppError('Database authentication failed', 401);
+    }
+    if (lower.includes('timeout') || lower.includes('etimedout') || lower.includes('timed out')) {
+      throw new AppError('Database connection timed out', 504);
+    }
+    throw new AppError(`Failed to connect to database: ${msg}`, 502);
+  }
+
   log.info(`DB proxy session ${sessionId} created for connection ${connectionId} (${dbProtocol})`);
 
   auditService.log({

--- a/server/src/services/dbQueryExecutor.service.ts
+++ b/server/src/services/dbQueryExecutor.service.ts
@@ -141,6 +141,65 @@ function pickDbSettingsFields(meta: Record<string, unknown>): Partial<DbSettings
 }
 
 // ---------------------------------------------------------------------------
+// Eager connectivity test (used during session creation)
+// ---------------------------------------------------------------------------
+
+/**
+ * Eagerly create the driver pool for a session **and** verify the target
+ * database is actually reachable by acquiring (and releasing) a real
+ * connection. Some drivers (Oracle with poolMin:0, pg Pool) create pool
+ * metadata without opening a TCP connection, so pool creation alone is not
+ * sufficient to detect an unreachable host.
+ *
+ * On success the pool is kept in the registry, ready for the first query.
+ * On failure the partial pool is destroyed and the error is re-thrown.
+ */
+export async function testConnection(params: PoolParams): Promise<void> {
+  let managed: ManagedPool | undefined;
+  try {
+    managed = await getOrCreatePool(params);
+
+    // Acquire a real connection to verify the target DB is reachable
+    const { driver } = managed;
+    switch (driver.type) {
+      case 'postgresql': {
+        const client = await driver.pool.connect();
+        client.release();
+        break;
+      }
+      case 'mysql': {
+        const conn = await driver.pool.getConnection();
+        conn.release();
+        break;
+      }
+      case 'oracle': {
+        const conn = await driver.pool.getConnection();
+        await conn.close();
+        break;
+      }
+      case 'mssql': {
+        // mssql.ConnectionPool.connect() is called during createPool — already connected.
+        // Issue a lightweight request to confirm.
+        await driver.pool.request().query('SELECT 1');
+        break;
+      }
+      case 'mongodb': {
+        await driver.client.db(driver.dbName).command({ ping: 1 });
+        break;
+      }
+      case 'db2': {
+        // ibm_db openSync already connects eagerly; nothing extra needed.
+        break;
+      }
+    }
+  } catch (err) {
+    // Clean up any partial pool that was registered before the driver threw
+    await destroyPool(params.sessionId);
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Statement splitting — most drivers only execute one statement per call.
 // MongoDB is excluded (JSON-based, not SQL).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds eager connectivity check during DB session creation — server now verifies the target database is reachable before returning success
- Fixes all 6 drivers: Oracle (`poolMin:0` was silently lazy), PostgreSQL, MySQL, MSSQL, MongoDB, DB2 each get a real connection ping
- Fixes protocol label always showing "POSTGRESQL" on connection error by passing the connection's actual protocol to DbEditor

## Details
**Root cause:** `createDbProxySession()` created a session record and returned success without touching the target DB. The driver pool was lazily created on first query, so unreachable databases only errored later. Oracle was worst — `oracledb.createPool()` with `poolMin:0` doesn't open any TCP connection.

**Fix:** After session creation, `testConnection()` calls `getOrCreatePool()` then acquires and releases a real connection per driver type. On failure, the session is cleaned up and a classified error is returned (connection refused → 502, auth failure → 401, timeout → 504).

**Protocol label:** `DbEditor` now receives `initialProtocol` from the connection's `dbSettings.protocol` instead of hardcoding `'postgresql'`.

Refs #544

## Test plan
- [x] Open a DATABASE connection to an unreachable host — should show error immediately, not "connected"
- [x] Open a DATABASE connection with wrong credentials — should show "Database authentication failed"
- [x] Open a valid DATABASE connection — should connect normally, first query works without delay
- [x] Test Oracle, MySQL, PostgreSQL, MSSQL specifically — protocol label should match the actual DB type on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)