### PR TITLE
feat: vault preservation on password reset — Element-style recovery (VAULT-208)

### DIFF
--- a/client/src/api/vault.api.ts
+++ b/client/src/api/vault.api.ts
@@ -2,6 +2,7 @@ import api from './client';
 
 export interface VaultStatusResponse {
   unlocked: boolean;
+  vaultNeedsRecovery: boolean;
   mfaUnlockAvailable: boolean;
   mfaUnlockMethods: string[];
 }
@@ -69,4 +70,26 @@ export async function getVaultAutoLock() {
 export async function setVaultAutoLock(autoLockMinutes: number | null) {
   const { data } = await api.put('/vault/auto-lock', { autoLockMinutes });
   return data as VaultAutoLockResponse;
+}
+
+// Vault recovery (after password reset)
+
+export interface VaultRecoveryStatusResponse {
+  needsRecovery: boolean;
+  hasRecoveryKey: boolean;
+}
+
+export async function getVaultRecoveryStatus() {
+  const { data } = await api.get('/vault/recovery-status');
+  return data as VaultRecoveryStatusResponse;
+}
+
+export async function recoverVaultWithKey(recoveryKey: string, password: string) {
+  const { data } = await api.post('/vault/recover-with-key', { recoveryKey, password });
+  return data as { success: boolean; newRecoveryKey: string };
+}
+
+export async function explicitVaultReset(password: string) {
+  const { data } = await api.post('/vault/explicit-reset', { password, confirmReset: true });
+  return data as { success: boolean; newRecoveryKey: string };
 }

--- a/client/src/components/Dialogs/KeychainDialog.tsx
+++ b/client/src/components/Dialogs/KeychainDialog.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import {
   Dialog, AppBar, Toolbar, Typography, IconButton, Box,
-  Alert, Button,
+  Alert, Button, TextField, Divider,
   DialogTitle, DialogContent, DialogContentText, DialogActions,
 } from '@mui/material';
 import {
@@ -32,7 +32,10 @@ import type { SecretListItem, SecretDetail } from '../../api/secrets.api';
 import type { VaultFolderData, VaultFolderScope } from '../../api/vault-folders.api';
 import { getSecret } from '../../api/secrets.api';
 import { SlideUp } from '../common/SlideUp';
+import RecoveryKeyConfirmDialog from '../common/RecoveryKeyConfirmDialog';
 import { isAdminOrAbove } from '../../utils/roles';
+import { getVaultRecoveryStatus, recoverVaultWithKey, explicitVaultReset } from '../../api/vault.api';
+import { useAsyncAction } from '../../hooks/useAsyncAction';
 
 interface KeychainDialogProps {
   open: boolean;
@@ -64,6 +67,19 @@ export default function KeychainDialog({ open, onClose }: KeychainDialogProps) {
   const [initializingVault, setInitializingVault] = useState(false);
   const [activeSecretDrag, setActiveSecretDrag] = useState<SecretListItem | null>(null);
 
+  // Vault recovery state
+  const [vaultNeedsRecovery, setVaultNeedsRecovery] = useState(false);
+  const [vaultHasRecoveryKey, setVaultHasRecoveryKey] = useState(false);
+  const [recoveryKeyInput, setRecoveryKeyInput] = useState('');
+  const [recoveryPasswordInput, setRecoveryPasswordInput] = useState('');
+  const [newRecoveryKey, setNewRecoveryKey] = useState('');
+  const [showRecoveryKeyDialog, setShowRecoveryKeyDialog] = useState(false);
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+  const [resetConfirmText, setResetConfirmText] = useState('');
+  const [resetPasswordInput, setResetPasswordInput] = useState('');
+  const recoverAction = useAsyncAction();
+  const resetAction = useAsyncAction();
+
   // DnD sensors
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -88,9 +104,49 @@ export default function KeychainDialog({ open, onClose }: KeychainDialogProps) {
     await moveSecret(secret.id, targetFolderId);
   };
 
+  // Fetch vault recovery status on open
+  const fetchRecoveryStatus = useCallback(async () => {
+    try {
+      const status = await getVaultRecoveryStatus();
+      setVaultNeedsRecovery(status.needsRecovery);
+      setVaultHasRecoveryKey(status.hasRecoveryKey);
+    } catch {
+      // silently fail — non-critical
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) fetchRecoveryStatus();
+  }, [open, fetchRecoveryStatus]);
+
   useEffect(() => {
     if (open && hasTenant) fetchTenantVaultStatus();
   }, [open, hasTenant, fetchTenantVaultStatus]);
+
+  const handleRecoverVault = async () => {
+    const success = await recoverAction.run(async () => {
+      const result = await recoverVaultWithKey(recoveryKeyInput, recoveryPasswordInput);
+      setNewRecoveryKey(result.newRecoveryKey);
+      setShowRecoveryKeyDialog(true);
+      setVaultNeedsRecovery(false);
+      setRecoveryKeyInput('');
+      setRecoveryPasswordInput('');
+    }, 'Vault recovery failed');
+    if (!success) return;
+  };
+
+  const handleExplicitReset = async () => {
+    const success = await resetAction.run(async () => {
+      const result = await explicitVaultReset(resetPasswordInput);
+      setNewRecoveryKey(result.newRecoveryKey);
+      setShowRecoveryKeyDialog(true);
+      setVaultNeedsRecovery(false);
+      setResetConfirmOpen(false);
+      setResetConfirmText('');
+      setResetPasswordInput('');
+    }, 'Vault reset failed');
+    if (!success) return;
+  };
 
   const handleInitTenantVault = async () => {
     setInitializingVault(true);
@@ -188,6 +244,66 @@ export default function KeychainDialog({ open, onClose }: KeychainDialogProps) {
           </Typography>
         </Toolbar>
       </AppBar>
+
+      {/* Vault recovery banner */}
+      {vaultNeedsRecovery && (
+        <Box sx={{ p: 2, bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider' }}>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" gutterBottom>
+              Vault Recovery Required
+            </Typography>
+            <Typography variant="body2">
+              Your vault is locked after a password reset. Enter your recovery key to restore access to your credentials.
+            </Typography>
+          </Alert>
+
+          {recoverAction.error && (
+            <Alert severity="error" sx={{ mb: 2 }}>{recoverAction.error}</Alert>
+          )}
+          {resetAction.error && (
+            <Alert severity="error" sx={{ mb: 2 }}>{resetAction.error}</Alert>
+          )}
+
+          {vaultHasRecoveryKey && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 2 }}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Recovery Key"
+                value={recoveryKeyInput}
+                onChange={(e) => setRecoveryKeyInput(e.target.value.trim())}
+                placeholder="Enter your vault recovery key"
+              />
+              <TextField
+                fullWidth
+                size="small"
+                label="Current Password"
+                type="password"
+                value={recoveryPasswordInput}
+                onChange={(e) => setRecoveryPasswordInput(e.target.value)}
+                placeholder="Enter your current password"
+              />
+              <Button
+                variant="contained"
+                onClick={handleRecoverVault}
+                disabled={recoverAction.loading || !recoveryKeyInput || !recoveryPasswordInput}
+              >
+                {recoverAction.loading ? 'Recovering...' : 'Recover Vault'}
+              </Button>
+            </Box>
+          )}
+
+          <Divider sx={{ my: 2 }}>or</Divider>
+
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => setResetConfirmOpen(true)}
+          >
+            Reset Vault (lose all data)
+          </Button>
+        </Box>
+      )}
 
       {/* Tenant vault banner */}
       {hasTenant && tenantVaultStatus && !tenantVaultStatus.initialized && isAdmin && (
@@ -377,6 +493,58 @@ export default function KeychainDialog({ open, onClose }: KeychainDialogProps) {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Vault explicit reset confirmation */}
+      <Dialog open={resetConfirmOpen} onClose={() => { setResetConfirmOpen(false); setResetConfirmText(''); setResetPasswordInput(''); resetAction.clearError(); }}>
+        <DialogTitle>Reset Vault</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>
+            This will permanently delete all your saved credentials, secrets, and encrypted data. This action cannot be undone.
+          </DialogContentText>
+          {resetAction.error && (
+            <Alert severity="error" sx={{ mb: 2 }}>{resetAction.error}</Alert>
+          )}
+          <TextField
+            fullWidth
+            size="small"
+            label="Current Password"
+            type="password"
+            value={resetPasswordInput}
+            onChange={(e) => setResetPasswordInput(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          <DialogContentText variant="body2" sx={{ mb: 1 }}>
+            Type <strong>RESET</strong> to confirm:
+          </DialogContentText>
+          <TextField
+            fullWidth
+            size="small"
+            value={resetConfirmText}
+            onChange={(e) => setResetConfirmText(e.target.value)}
+            placeholder="RESET"
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => { setResetConfirmOpen(false); setResetConfirmText(''); setResetPasswordInput(''); resetAction.clearError(); }}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleExplicitReset}
+            color="error"
+            variant="contained"
+            disabled={resetConfirmText !== 'RESET' || !resetPasswordInput || resetAction.loading}
+          >
+            {resetAction.loading ? 'Resetting...' : 'Reset Vault'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Recovery key display after successful recovery/reset */}
+      <RecoveryKeyConfirmDialog
+        open={showRecoveryKeyDialog}
+        recoveryKey={newRecoveryKey}
+        onConfirmed={() => { setShowRecoveryKeyDialog(false); setNewRecoveryKey(''); }}
+      />
     </Dialog>
   );
 }

--- a/client/src/pages/ResetPasswordPage.tsx
+++ b/client/src/pages/ResetPasswordPage.tsx
@@ -318,7 +318,7 @@ export default function ResetPasswordPage() {
                 </Alert>
               ) : (
                 <Alert severity="warning" sx={{ mb: 2, bgcolor: (theme) => `${theme.palette.warning.main}14`, color: 'warning.light', border: (theme) => `1px solid ${theme.palette.warning.main}26`, '& .MuiAlert-icon': { color: 'warning.light' } }}>
-                  Your vault has been reset. Previously saved connection passwords and secrets have been cleared.
+                  Your vault is locked. Enter your recovery key in Keychain to restore access to your credentials.
                 </Alert>
               )}
               <Typography variant="body2" align="center" sx={{ color: 'text.secondary' }}>

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -115,7 +115,8 @@ model User {
   encryptedVaultKey  String?
   vaultKeyIV         String?
   vaultKeyTag        String?
-  vaultSetupComplete Boolean     @default(true)
+  vaultSetupComplete  Boolean     @default(true)
+  vaultNeedsRecovery  Boolean     @default(false)
   sshDefaults        Json?
   rdpDefaults        Json?
   totpSecret          String?
@@ -640,6 +641,9 @@ enum AuditAction {
   PASSWORD_RESET_FAILURE
   VAULT_RECOVERY_KEY_GENERATED
   VAULT_RESET
+  VAULT_NEEDS_RECOVERY
+  VAULT_RECOVERED
+  VAULT_EXPLICIT_RESET
   TENANT_CREATE_USER
   TENANT_TOGGLE_USER
   APP_CONFIG_UPDATE

--- a/server/src/controllers/vault.controller.ts
+++ b/server/src/controllers/vault.controller.ts
@@ -3,7 +3,7 @@ import { AuthRequest, assertAuthenticated } from '../types';
 import * as vaultService from '../services/vault.service';
 import * as auditService from '../services/audit.service';
 import { getClientIp } from '../utils/ip';
-import type { UnlockInput, CodeInput, CredentialInput, RevealInput, AutoLockInput } from '../schemas/vault.schemas';
+import type { UnlockInput, CodeInput, CredentialInput, RevealInput, AutoLockInput, RecoverWithKeyInput, ExplicitResetInput } from '../schemas/vault.schemas';
 
 export async function unlock(req: AuthRequest, res: Response) {
   assertAuthenticated(req);
@@ -87,6 +87,40 @@ export async function revealPassword(req: AuthRequest, res: Response) {
     userId: req.user.userId, action: 'PASSWORD_REVEAL',
     targetType: 'Connection', targetId: connectionId,
     ipAddress: getClientIp(req),
+  });
+  res.json(result);
+}
+
+// Vault recovery (after password reset)
+
+export async function recoveryStatus(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const result = await vaultService.getVaultRecoveryStatus(req.user.userId);
+  res.json(result);
+}
+
+export async function recoverWithKey(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const { recoveryKey, password } = req.body as RecoverWithKeyInput;
+  const result = await vaultService.recoverVaultWithKey(req.user.userId, recoveryKey, password);
+  auditService.log({
+    userId: req.user.userId,
+    action: 'VAULT_RECOVERED',
+    ipAddress: getClientIp(req),
+    details: { method: 'recovery_key' },
+  });
+  res.json(result);
+}
+
+export async function explicitReset(req: AuthRequest, res: Response) {
+  assertAuthenticated(req);
+  const { password } = req.body as ExplicitResetInput;
+  const result = await vaultService.explicitVaultReset(req.user.userId, password);
+  auditService.log({
+    userId: req.user.userId,
+    action: 'VAULT_EXPLICIT_RESET',
+    ipAddress: getClientIp(req),
+    details: { reason: 'user_requested' },
   });
   res.json(result);
 }

--- a/server/src/routes/vault.routes.ts
+++ b/server/src/routes/vault.routes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { authenticate } from '../middleware/auth.middleware';
 import { validate } from '../middleware/validate.middleware';
 import { vaultUnlockRateLimiter, vaultMfaRateLimiter } from '../middleware/vaultRateLimit.middleware';
-import { unlockSchema, codeSchema, credentialSchema, revealSchema, autoLockSchema } from '../schemas/vault.schemas';
+import { unlockSchema, codeSchema, credentialSchema, revealSchema, autoLockSchema, recoverWithKeySchema, explicitResetSchema } from '../schemas/vault.schemas';
 import { asyncHandler } from '../middleware/asyncHandler';
 import * as vaultController from '../controllers/vault.controller';
 
@@ -24,5 +24,10 @@ router.post('/unlock-mfa/sms', vaultMfaRateLimiter, validate(codeSchema), asyncH
 // Vault auto-lock preference
 router.get('/auto-lock', asyncHandler(vaultController.getAutoLock));
 router.put('/auto-lock', validate(autoLockSchema), asyncHandler(vaultController.setAutoLock));
+
+// Vault recovery (after password reset without recovery key)
+router.get('/recovery-status', asyncHandler(vaultController.recoveryStatus));
+router.post('/recover-with-key', vaultUnlockRateLimiter, validate(recoverWithKeySchema), asyncHandler(vaultController.recoverWithKey));
+router.post('/explicit-reset', vaultUnlockRateLimiter, validate(explicitResetSchema), asyncHandler(vaultController.explicitReset));
 
 export default router;

--- a/server/src/schemas/vault.schemas.ts
+++ b/server/src/schemas/vault.schemas.ts
@@ -19,3 +19,15 @@ export const autoLockSchema = z.object({
   autoLockMinutes: z.number().int().min(0).nullable(),
 });
 export type AutoLockInput = z.infer<typeof autoLockSchema>;
+
+export const recoverWithKeySchema = z.object({
+  recoveryKey: z.string().min(1),
+  password: z.string().min(1),
+});
+export type RecoverWithKeyInput = z.infer<typeof recoverWithKeySchema>;
+
+export const explicitResetSchema = z.object({
+  password: z.string().min(1),
+  confirmReset: z.literal(true),
+});
+export type ExplicitResetInput = z.infer<typeof explicitResetSchema>;

--- a/server/src/services/passwordReset.service.ts
+++ b/server/src/services/passwordReset.service.ts
@@ -233,6 +233,7 @@ export async function completePasswordReset(params: {
           vaultRecoveryKeyIV: newRecovery.encrypted.iv,
           vaultRecoveryKeyTag: newRecovery.encrypted.tag,
           vaultRecoveryKeySalt: newRecovery.salt,
+          vaultNeedsRecovery: false,
           passwordResetTokenHash: null,
           passwordResetExpiry: null,
         },

--- a/server/src/services/passwordReset.service.ts
+++ b/server/src/services/passwordReset.service.ts
@@ -5,7 +5,6 @@ import { logger } from '../utils/logger';
 import {
   hashToken,
   generateSalt,
-  generateMasterKey,
   deriveKeyFromPassword,
   encryptMasterKey,
   decryptMasterKeyWithRecovery,
@@ -248,106 +247,31 @@ export async function completePasswordReset(params: {
   }
 
   if (!vaultPreserved) {
-    // Generate fresh vault
-    const newMasterKey = generateMasterKey();
-    const newVaultSalt = generateSalt();
-    const newDerivedKey = await deriveKeyFromPassword(newPassword, newVaultSalt);
-    const newEncryptedVault = encryptMasterKey(newMasterKey, newDerivedKey);
-
-    // Generate new recovery key for the fresh vault
-    newRecoveryKeyValue = generateRecoveryKey();
-    const newRecovery = await encryptMasterKeyWithRecovery(newMasterKey, newRecoveryKeyValue);
-
-    newMasterKey.fill(0);
-    newDerivedKey.fill(0);
-
-    // Wipe all encrypted data and update vault in a transaction
-    await prisma.$transaction(async (tx) => {
-      // Update user: new password, new vault, clear reset token
-      await tx.user.update({
-        where: { id: user.id },
-        data: {
-          passwordHash,
-          vaultSalt: newVaultSalt,
-          encryptedVaultKey: newEncryptedVault.ciphertext,
-          vaultKeyIV: newEncryptedVault.iv,
-          vaultKeyTag: newEncryptedVault.tag,
-          encryptedVaultRecoveryKey: newRecovery.encrypted.ciphertext,
-          vaultRecoveryKeyIV: newRecovery.encrypted.iv,
-          vaultRecoveryKeyTag: newRecovery.encrypted.tag,
-          vaultRecoveryKeySalt: newRecovery.salt,
-          passwordResetTokenHash: null,
-          passwordResetExpiry: null,
-          // Disable TOTP (encrypted secret is lost)
-          totpEnabled: false,
-          totpSecret: null,
-          encryptedTotpSecret: null,
-          totpSecretIV: null,
-          totpSecretTag: null,
-          // Clear encrypted domain password (master key changed)
-          encryptedDomainPassword: null,
-          domainPasswordIV: null,
-          domainPasswordTag: null,
-        },
-      });
-
-      // Wipe encrypted connection credentials owned by this user
-      await tx.connection.updateMany({
-        where: { userId: user.id },
-        data: {
-          encryptedUsername: null,
-          usernameIV: null,
-          usernameTag: null,
-          encryptedPassword: null,
-          passwordIV: null,
-          passwordTag: null,
-        },
-      });
-
-      // Wipe shared connection credentials shared BY this user
-      await tx.sharedConnection.deleteMany({
-        where: { sharedByUserId: user.id },
-      });
-
-      // Wipe team vault keys for this user
-      await tx.teamMember.updateMany({
-        where: { userId: user.id },
-        data: {
-          encryptedTeamVaultKey: null,
-          teamVaultKeyIV: null,
-          teamVaultKeyTag: null,
-        },
-      });
-
-      // Wipe tenant vault memberships for this user
-      await tx.tenantVaultMember.deleteMany({
-        where: { userId: user.id },
-      });
-
-      // Wipe vault secrets owned by this user
-      await tx.vaultSecret.deleteMany({
-        where: { userId: user.id },
-      });
-
-      // Wipe secrets shared BY this user
-      await tx.sharedSecret.deleteMany({
-        where: { sharedByUserId: user.id },
-      });
-
-      // Wipe external secret shares created by this user
-      await tx.externalSecretShare.deleteMany({
-        where: { secret: { userId: user.id } },
-      });
+    // Element/Matrix-style: NEVER auto-wipe encrypted data.
+    // Mark vault as "awaiting recovery" — the user can provide the recovery
+    // key at any time (from Keychain) to restore access.
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        passwordHash,
+        vaultNeedsRecovery: true,
+        passwordResetTokenHash: null,
+        passwordResetExpiry: null,
+        // Note: encryptedVaultKey and all encrypted data are preserved.
+        // They remain encrypted with the OLD master key. The user must
+        // provide the recovery key to decrypt the old master key and
+        // re-encrypt it with the new password-derived key.
+      },
     });
 
     auditService.log({
       userId: user.id,
-      action: 'VAULT_RESET',
-      details: { reason: 'password_reset_no_recovery_key' },
+      action: 'VAULT_NEEDS_RECOVERY',
+      details: { reason: 'password_reset_without_recovery_key' },
       ipAddress,
     });
 
-    log.verbose(`Password reset with vault reset for user ${user.id}`);
+    log.verbose(`Password reset with vault pending recovery for user ${user.id}`);
   }
 
   // Invalidate all refresh tokens (force re-login on all devices)

--- a/server/src/services/vault.service.ts
+++ b/server/src/services/vault.service.ts
@@ -377,13 +377,24 @@ export async function revealPassword(
 export async function getVaultRecoveryStatus(userId: string) {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { vaultNeedsRecovery: true, encryptedVaultRecoveryKey: true },
+    select: {
+      vaultNeedsRecovery: true,
+      encryptedVaultRecoveryKey: true,
+      vaultRecoveryKeyIV: true,
+      vaultRecoveryKeyTag: true,
+      vaultRecoveryKeySalt: true,
+    },
   });
   if (!user) throw new AppError('User not found', 404);
 
   return {
     needsRecovery: user.vaultNeedsRecovery,
-    hasRecoveryKey: !!user.encryptedVaultRecoveryKey,
+    hasRecoveryKey: !!(
+      user.encryptedVaultRecoveryKey &&
+      user.vaultRecoveryKeyIV &&
+      user.vaultRecoveryKeyTag &&
+      user.vaultRecoveryKeySalt
+    ),
   };
 }
 
@@ -405,6 +416,11 @@ export async function recoverVaultWithKey(
   ) {
     throw new AppError('No recovery key available. You must reset your vault.', 400);
   }
+
+  // Verify current password before proceeding
+  if (!user.passwordHash) throw new AppError('No password set for this account', 400);
+  const passwordValid = await bcrypt.compare(currentPassword, user.passwordHash);
+  if (!passwordValid) throw new AppError('Invalid password', 401);
 
   // Decrypt old master key using the recovery key
   let masterKey: Buffer;
@@ -496,6 +512,10 @@ export async function explicitVaultReset(userId: string, password: string) {
         totpSecretTag: null,
         totpSecret: null,
         totpEnabled: false,
+        // Clear encrypted domain password (master key changed)
+        encryptedDomainPassword: null,
+        domainPasswordIV: null,
+        domainPasswordTag: null,
       },
     });
 
@@ -509,10 +529,18 @@ export async function explicitVaultReset(userId: string, password: string) {
         encryptedUsername: null,
         usernameIV: null,
         usernameTag: null,
+        encryptedDomain: null,
+        domainIV: null,
+        domainTag: null,
       },
     });
 
-    // Wipe shared connection encrypted data
+    // Delete shared connections shared BY this user (recipients lose access)
+    await tx.sharedConnection.deleteMany({
+      where: { sharedByUserId: userId },
+    });
+
+    // Wipe shared connection encrypted data shared WITH this user
     await tx.sharedConnection.updateMany({
       where: { sharedWithUserId: userId },
       data: {
@@ -522,11 +550,17 @@ export async function explicitVaultReset(userId: string, password: string) {
         encryptedUsername: null,
         usernameIV: null,
         usernameTag: null,
+        encryptedDomain: null,
+        domainIV: null,
+        domainTag: null,
       },
     });
 
     // Delete vault secrets owned by this user
     await tx.vaultSecret.deleteMany({ where: { userId } });
+
+    // Delete shared secrets created BY this user
+    await tx.sharedSecret.deleteMany({ where: { sharedByUserId: userId } });
 
     // Delete shared secrets for this user
     await tx.sharedSecret.deleteMany({ where: { sharedWithUserId: userId } });

--- a/server/src/services/vault.service.ts
+++ b/server/src/services/vault.service.ts
@@ -1,5 +1,6 @@
 import prisma from '../lib/prisma';
 import { config } from '../config';
+import bcrypt from 'bcrypt';
 import {
   deriveKeyFromPassword,
   decryptMasterKey,
@@ -11,6 +12,12 @@ import {
   getVaultRecovery,
   hasVaultRecovery,
   decrypt,
+  generateMasterKey,
+  generateSalt,
+  encryptMasterKey,
+  generateRecoveryKey,
+  encryptMasterKeyWithRecovery,
+  decryptMasterKeyWithRecovery,
 } from './crypto.service';
 import { verifyCode as verifyTotpCode, getDecryptedSecret } from './totp.service';
 import { AppError } from '../middleware/error.middleware';
@@ -87,11 +94,24 @@ export async function getVaultStatus(userId: string) {
   const unlocked = checkVaultUnlocked(userId);
   const recoveryAvailable = hasVaultRecovery(userId);
 
-  if (!recoveryAvailable || unlocked) {
-    return { unlocked, mfaUnlockAvailable: false, mfaUnlockMethods: [] as string[] };
-  }
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      vaultNeedsRecovery: true,
+      webauthnEnabled: true,
+      totpEnabled: true,
+      smsMfaEnabled: true,
+    },
+  });
 
-  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!recoveryAvailable || unlocked) {
+    return {
+      unlocked,
+      vaultNeedsRecovery: user?.vaultNeedsRecovery ?? false,
+      mfaUnlockAvailable: false,
+      mfaUnlockMethods: [] as string[],
+    };
+  }
 
   const methods: string[] = [];
   if (user?.webauthnEnabled) methods.push('webauthn');
@@ -100,6 +120,7 @@ export async function getVaultStatus(userId: string) {
 
   return {
     unlocked,
+    vaultNeedsRecovery: user?.vaultNeedsRecovery ?? false,
     mfaUnlockAvailable: methods.length > 0,
     mfaUnlockMethods: methods,
   };
@@ -349,4 +370,179 @@ export async function revealPassword(
   }
 
   throw new AppError('Connection not found or insufficient permissions', 403);
+}
+
+// Vault recovery after password reset
+
+export async function getVaultRecoveryStatus(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { vaultNeedsRecovery: true, encryptedVaultRecoveryKey: true },
+  });
+  if (!user) throw new AppError('User not found', 404);
+
+  return {
+    needsRecovery: user.vaultNeedsRecovery,
+    hasRecoveryKey: !!user.encryptedVaultRecoveryKey,
+  };
+}
+
+export async function recoverVaultWithKey(
+  userId: string,
+  recoveryKey: string,
+  currentPassword: string
+) {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new AppError('User not found', 404);
+  if (!user.vaultNeedsRecovery) {
+    throw new AppError('Vault does not need recovery', 400);
+  }
+  if (
+    !user.encryptedVaultRecoveryKey ||
+    !user.vaultRecoveryKeyIV ||
+    !user.vaultRecoveryKeyTag ||
+    !user.vaultRecoveryKeySalt
+  ) {
+    throw new AppError('No recovery key available. You must reset your vault.', 400);
+  }
+
+  // Decrypt old master key using the recovery key
+  let masterKey: Buffer;
+  try {
+    masterKey = await decryptMasterKeyWithRecovery(
+      {
+        ciphertext: user.encryptedVaultRecoveryKey,
+        iv: user.vaultRecoveryKeyIV,
+        tag: user.vaultRecoveryKeyTag,
+      },
+      recoveryKey,
+      user.vaultRecoveryKeySalt
+    );
+  } catch {
+    throw new AppError('Invalid recovery key', 401);
+  }
+
+  // Derive new key from current password
+  const newSalt = generateSalt();
+  const derivedKey = await deriveKeyFromPassword(currentPassword, newSalt);
+
+  // Re-encrypt master key with the new password-derived key
+  const newEncryptedVault = encryptMasterKey(masterKey, derivedKey);
+
+  // Generate a new recovery key
+  const newRecoveryKeyPlain = generateRecoveryKey();
+  const newRecovery = await encryptMasterKeyWithRecovery(masterKey, newRecoveryKeyPlain);
+
+  // Update user in a transaction
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      vaultSalt: newSalt,
+      encryptedVaultKey: newEncryptedVault.ciphertext,
+      vaultKeyIV: newEncryptedVault.iv,
+      vaultKeyTag: newEncryptedVault.tag,
+      encryptedVaultRecoveryKey: newRecovery.encrypted.ciphertext,
+      vaultRecoveryKeyIV: newRecovery.encrypted.iv,
+      vaultRecoveryKeyTag: newRecovery.encrypted.tag,
+      vaultRecoveryKeySalt: newRecovery.salt,
+      vaultNeedsRecovery: false,
+    },
+  });
+
+  // Zero sensitive buffers
+  masterKey.fill(0);
+  derivedKey.fill(0);
+
+  return { success: true, newRecoveryKey: newRecoveryKeyPlain };
+}
+
+export async function explicitVaultReset(userId: string, password: string) {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new AppError('User not found', 404);
+
+  // Verify current password
+  if (!user.passwordHash) throw new AppError('No password set for this account', 400);
+  const passwordValid = await bcrypt.compare(password, user.passwordHash);
+  if (!passwordValid) throw new AppError('Invalid password', 401);
+
+  // Generate fresh vault
+  const masterKey = generateMasterKey();
+  const newSalt = generateSalt();
+  const derivedKey = await deriveKeyFromPassword(password, newSalt);
+  const newEncryptedVault = encryptMasterKey(masterKey, derivedKey);
+
+  // Generate new recovery key
+  const newRecoveryKeyPlain = generateRecoveryKey();
+  const newRecovery = await encryptMasterKeyWithRecovery(masterKey, newRecoveryKeyPlain);
+
+  // Wipe all encrypted data and update vault in a transaction
+  await prisma.$transaction(async (tx) => {
+    // Update user vault fields
+    await tx.user.update({
+      where: { id: userId },
+      data: {
+        vaultSalt: newSalt,
+        encryptedVaultKey: newEncryptedVault.ciphertext,
+        vaultKeyIV: newEncryptedVault.iv,
+        vaultKeyTag: newEncryptedVault.tag,
+        encryptedVaultRecoveryKey: newRecovery.encrypted.ciphertext,
+        vaultRecoveryKeyIV: newRecovery.encrypted.iv,
+        vaultRecoveryKeyTag: newRecovery.encrypted.tag,
+        vaultRecoveryKeySalt: newRecovery.salt,
+        vaultNeedsRecovery: false,
+        // Clear TOTP secrets
+        encryptedTotpSecret: null,
+        totpSecretIV: null,
+        totpSecretTag: null,
+        totpSecret: null,
+        totpEnabled: false,
+      },
+    });
+
+    // Wipe encrypted connection data
+    await tx.connection.updateMany({
+      where: { userId },
+      data: {
+        encryptedPassword: null,
+        passwordIV: null,
+        passwordTag: null,
+        encryptedUsername: null,
+        usernameIV: null,
+        usernameTag: null,
+      },
+    });
+
+    // Wipe shared connection encrypted data
+    await tx.sharedConnection.updateMany({
+      where: { sharedWithUserId: userId },
+      data: {
+        encryptedPassword: null,
+        passwordIV: null,
+        passwordTag: null,
+        encryptedUsername: null,
+        usernameIV: null,
+        usernameTag: null,
+      },
+    });
+
+    // Delete vault secrets owned by this user
+    await tx.vaultSecret.deleteMany({ where: { userId } });
+
+    // Delete shared secrets for this user
+    await tx.sharedSecret.deleteMany({ where: { sharedWithUserId: userId } });
+
+    // Delete external secret shares for secrets owned by this user
+    await tx.externalSecretShare.deleteMany({
+      where: { secret: { userId } },
+    });
+
+    // Remove tenant vault membership
+    await tx.tenantVaultMember.deleteMany({ where: { userId } });
+  });
+
+  // Zero sensitive buffers
+  masterKey.fill(0);
+  derivedKey.fill(0);
+
+  return { success: true, newRecoveryKey: newRecoveryKeyPlain };
 }


### PR DESCRIPTION
## Summary

- **Stop auto-wiping vault on password reset** — When a user resets their password without providing a recovery key, the vault is no longer destroyed. Instead, it's flagged as `vaultNeedsRecovery` and all encrypted data is preserved.
- **New recovery endpoint** `POST /api/vault/recover-with-key` — Users can provide their recovery key at any time (from Keychain) to decrypt the old master key and re-encrypt it with their new password.
- **Explicit vault reset** `POST /api/vault/explicit-reset` — Last-resort option with triple confirmation for users who permanently lost their recovery key.
- **Keychain recovery zone** — Prominent warning banner in KeychainDialog when vault needs recovery, with recovery key input and explicit reset option.

### Key Changes

| File | Change |
|------|--------|
| `server/prisma/schema.prisma` | Added `vaultNeedsRecovery` field + 3 new audit actions |
| `server/src/services/passwordReset.service.ts` | Removed vault wipe, sets `vaultNeedsRecovery = true` |
| `server/src/services/vault.service.ts` | Added `recoverVaultWithKey()`, `explicitVaultReset()`, `getVaultRecoveryStatus()` |
| `server/src/controllers/vault.controller.ts` | 3 new controller functions |
| `server/src/routes/vault.routes.ts` | 3 new routes (recovery-status, recover-with-key, explicit-reset) |
| `client/src/components/Dialogs/KeychainDialog.tsx` | Recovery zone banner with inputs + triple-confirm reset |
| `client/src/pages/ResetPasswordPage.tsx` | Updated messaging (no more "data cleared") |

Refs #137

## Test plan
- [ ] Reset password WITHOUT recovery key → vault flagged, data preserved
- [ ] Open Keychain → recovery banner visible
- [ ] Enter valid recovery key + password → vault recovered, new key displayed
- [ ] Enter invalid recovery key → error message
- [ ] Use "Reset Vault" with triple confirmation → vault wiped, fresh key
- [ ] Reset password WITH recovery key → existing flow unchanged
- [ ] Vault status endpoint returns `vaultNeedsRecovery` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>