### PR TITLE
feat: async tenant vault key distribution with escrow (VAULT-207)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ Tasks use isolated git worktrees at `.worktrees/task/<code>/` (must be in `.giti
 
 ## Agent Teams Mode
 
-**Default execution mode.** Use Agent Teams for any task involving development, research, or parallel work. Immediately create the agent team and spawn teammates for each unit of work as per the configurations below. Expecially when using the yolo mode.
+**Default execution mode.** Use Agent Teams for any task involving development, research, or parallel work. Fall back to standalone subagents only if Teams tools are unavailable.
 
 ### Team Lifecycle
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ Tasks use isolated git worktrees at `.worktrees/task/<code>/` (must be in `.giti
 
 ## Agent Teams Mode
 
-**Default execution mode.** Use Agent Teams for any task involving development, research, or parallel work. Fall back to standalone subagents only if Teams tools are unavailable.
+**Default execution mode.** Use Agent Teams for any task involving development, research, or parallel work. Immediately create the agent team and spawn teammates for each unit of work as per the configurations below. Expecially when using the yolo mode.
 
 ### Team Lifecycle
 

--- a/docs/rag-summary.md
+++ b/docs/rag-summary.md
@@ -50,7 +50,7 @@ Batch sharing allows multiple connections to be shared simultaneously, and folde
 
 External sharing enables creating time-limited, access-limited links for secrets that can be shared with people outside the platform. These links can optionally be protected with a PIN code. External shares have configurable expiration dates and maximum access counts, and can be revoked at any time.
 
-Teams provide a collaborative workspace within an organization. Teams have their own connection pools, folders, and vault sections. Team members are assigned roles (admin, editor, viewer) that control their level of access. Team vaults use a separate encryption key distributed to members, ensuring team secrets are accessible only to team members.
+Teams provide a collaborative workspace within an organization. Teams have their own connection pools, folders, and vault sections. Team members are assigned roles (admin, editor, viewer) that control their level of access. Team vaults use a separate encryption key distributed to members, ensuring team secrets are accessible only to team members. Tenant vault key distribution is asynchronous: when a user's personal vault is locked at the time of distribution (e.g., during tenant vault initialization or when an admin distributes keys), the encrypted tenant key is held in a server-side escrow (AES-256-GCM encrypted with an HMAC-SHA256-derived escrow key) and automatically finalized when the target user next unlocks their personal vault. This ensures that offline or locked-vault users receive tenant vault access without requiring both parties to be online simultaneously.
 
 Folder organization supports nested hierarchies with drag-and-drop reordering for both personal and team connections.
 

--- a/server/prisma/migrations/20260326030000_add_pending_vault_key_distribution/migration.sql
+++ b/server/prisma/migrations/20260326030000_add_pending_vault_key_distribution/migration.sql
@@ -1,0 +1,28 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'TENANT_VAULT_KEY_RECEIVED';
+
+-- CreateTable
+CREATE TABLE "PendingVaultKeyDistribution" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "targetUserId" TEXT NOT NULL,
+    "encryptedTenantVaultKey" TEXT NOT NULL,
+    "tenantVaultKeyIV" TEXT NOT NULL,
+    "tenantVaultKeyTag" TEXT NOT NULL,
+    "distributorUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PendingVaultKeyDistribution_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PendingVaultKeyDistribution_tenantId_targetUserId_key" ON "PendingVaultKeyDistribution"("tenantId", "targetUserId");
+
+-- AddForeignKey
+ALTER TABLE "PendingVaultKeyDistribution" ADD CONSTRAINT "PendingVaultKeyDistribution_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PendingVaultKeyDistribution" ADD CONSTRAINT "PendingVaultKeyDistribution_targetUserId_fkey" FOREIGN KEY ("targetUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PendingVaultKeyDistribution" ADD CONSTRAINT "PendingVaultKeyDistribution_distributorUserId_fkey" FOREIGN KEY ("distributorUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -62,6 +62,7 @@ model Tenant {
   sshKeyPair         SshKeyPair?
   vaultSecrets       VaultSecret[]
   tenantVaultMembers TenantVaultMember[]
+  pendingVaultKeyDistributions PendingVaultKeyDistribution[]
   syncProfiles       SyncProfile[]
   externalVaultProviders ExternalVaultProvider[]
   aiConfig           TenantAiConfig?
@@ -177,6 +178,8 @@ model User {
   secretVersionChanges   VaultSecretVersion[]   @relation("SecretVersionChanger")
   vaultFolders           VaultFolder[]
   tenantVaultMemberships TenantVaultMember[]
+  pendingVaultKeyTargets       PendingVaultKeyDistribution[] @relation("PendingVaultKeyTarget")
+  pendingVaultKeyDistributions PendingVaultKeyDistribution[] @relation("PendingVaultKeyDistributor")
   secretsSharedWithMe    SharedSecret[]         @relation("SecretSharedWith")
   secretsSharedByMe      SharedSecret[]         @relation("SecretSharedBy")
   externalSecretShares   ExternalSecretShare[]
@@ -776,6 +779,7 @@ enum NotificationType {
   SECRET_CHECKOUT_EXPIRED
   LATERAL_MOVEMENT_ALERT
   SESSION_TERMINATED_POLICY_VIOLATION
+  TENANT_VAULT_KEY_RECEIVED
 }
 
 model Notification {
@@ -958,6 +962,23 @@ model TenantVaultMember {
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([tenantId, userId])
+}
+
+model PendingVaultKeyDistribution {
+  id                      String   @id @default(uuid())
+  tenantId                String
+  targetUserId            String
+  encryptedTenantVaultKey String
+  tenantVaultKeyIV        String
+  tenantVaultKeyTag       String
+  distributorUserId       String
+  createdAt               DateTime @default(now())
+
+  tenant      Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  targetUser  User   @relation("PendingVaultKeyTarget", fields: [targetUserId], references: [id], onDelete: Cascade)
+  distributor User   @relation("PendingVaultKeyDistributor", fields: [distributorUserId], references: [id], onDelete: Cascade)
+
+  @@unique([tenantId, targetUserId])
 }
 
 model ExternalSecretShare {

--- a/server/src/controllers/secret.controller.ts
+++ b/server/src/controllers/secret.controller.ts
@@ -314,7 +314,7 @@ export async function distributeTenantKey(req: AuthRequest, res: Response) {
   }
 
   const { targetUserId } = req.body as DistributeTenantKeyInput;
-  await secretService.distributeTenantKeyToUser(
+  const result = await secretService.distributeTenantKeyToUser(
     req.user.tenantId,
     targetUserId,
     req.user.userId
@@ -325,11 +325,11 @@ export async function distributeTenantKey(req: AuthRequest, res: Response) {
     action: 'TENANT_VAULT_KEY_DISTRIBUTE',
     targetType: 'User',
     targetId: targetUserId,
-    details: { tenantId: req.user.tenantId },
+    details: { tenantId: req.user.tenantId, pending: result.pending },
     ipAddress: getClientIp(req),
   });
 
-  res.json({ distributed: true });
+  res.json(result);
 }
 
 export async function tenantVaultStatus(req: AuthRequest, res: Response) {

--- a/server/src/services/crypto.service.ts
+++ b/server/src/services/crypto.service.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto, { createHmac } from 'crypto';
 import argon2 from 'argon2';
 import { EncryptedField, VaultSession } from '../types';
 import { config } from '../config';
@@ -437,4 +437,21 @@ export function lockUserTenantVaults(userId: string): void {
       tenantVaultStore.delete(key);
     }
   }
+}
+
+// Escrow key derivation for pending vault key distribution
+
+export function deriveEscrowKey(tenantId: string): Buffer {
+  return createHmac('sha256', config.serverEncryptionKey)
+    .update(tenantId)
+    .digest();
+}
+
+export function encryptWithEscrow(tenantKey: Buffer, escrowKey: Buffer): EncryptedField {
+  return encrypt(tenantKey.toString('hex'), escrowKey);
+}
+
+export function decryptWithEscrow(field: EncryptedField, escrowKey: Buffer): Buffer {
+  const hex = decrypt(field, escrowKey);
+  return Buffer.from(hex, 'hex');
 }

--- a/server/src/services/email/templates/notification.ts
+++ b/server/src/services/email/templates/notification.ts
@@ -23,6 +23,7 @@ const SUBJECT_MAP: Record<NotificationType, string> = {
   [NotificationType.SECRET_CHECKOUT_EXPIRED]: 'Credential check-out expired — Arsenale',
   [NotificationType.LATERAL_MOVEMENT_ALERT]: 'Security Alert: Lateral Movement Anomaly Detected — Arsenale',
   [NotificationType.SESSION_TERMINATED_POLICY_VIOLATION]: 'Security Alert: SSH Session Terminated by Policy — Arsenale',
+  [NotificationType.TENANT_VAULT_KEY_RECEIVED]: 'Organization vault access granted — Arsenale',
 };
 
 function escapeHtml(str: string): string {

--- a/server/src/services/secret.service.ts
+++ b/server/src/services/secret.service.ts
@@ -10,6 +10,9 @@ import {
   decryptTenantKey,
   storeTenantVaultSession,
   getTenantMasterKey as getCachedTenantKey,
+  deriveEscrowKey,
+  encryptWithEscrow,
+  decryptWithEscrow,
 } from './crypto.service';
 import { resolveTeamKey } from './team.service';
 import * as permissionService from './permission.service';
@@ -162,6 +165,21 @@ export async function initTenantVault(
             tenantVaultKeyTag: encKey.tag,
           },
         });
+      } else {
+        // Vault closed — save pending distribution with escrow key
+        const escrowKey = deriveEscrowKey(tenantId);
+        const encKey = encryptWithEscrow(tenantKey, escrowKey);
+        await tx.pendingVaultKeyDistribution.create({
+          data: {
+            tenantId,
+            targetUserId: user.id,
+            encryptedTenantVaultKey: encKey.ciphertext,
+            tenantVaultKeyIV: encKey.iv,
+            tenantVaultKeyTag: encKey.tag,
+            distributorUserId: initiatorUserId,
+          },
+        });
+        escrowKey.fill(0);
       }
     }
   });
@@ -175,7 +193,7 @@ export async function distributeTenantKeyToUser(
   tenantId: string,
   targetUserId: string,
   distributorUserId: string
-): Promise<void> {
+): Promise<{ distributed: boolean; pending: boolean }> {
   const tenant = await prisma.tenant.findUnique({ where: { id: tenantId } });
   if (!tenant?.hasTenantVaultKey) {
     throw new AppError('Tenant vault is not initialized', 400);
@@ -198,20 +216,112 @@ export async function distributeTenantKeyToUser(
   // Distributor needs their vault unlocked + tenant key access
   const tenantKey = await resolveTenantKey(tenantId, distributorUserId);
 
-  // Target user's vault must be unlocked
-  const targetMasterKey = requireMasterKey(targetUserId, "Target user's vault is locked. They must unlock their vault first.");
+  // Check if target vault is unlocked
+  const targetMasterKey = getMasterKey(targetUserId);
 
-  const encKey = encryptTenantKey(tenantKey, targetMasterKey);
+  if (targetMasterKey) {
+    // Direct distribution — target vault is open
+    const encKey = encryptTenantKey(tenantKey, targetMasterKey);
+    await prisma.tenantVaultMember.create({
+      data: {
+        tenantId,
+        userId: targetUserId,
+        encryptedTenantVaultKey: encKey.ciphertext,
+        tenantVaultKeyIV: encKey.iv,
+        tenantVaultKeyTag: encKey.tag,
+      },
+    });
+    return { distributed: true, pending: false };
+  }
 
-  await prisma.tenantVaultMember.create({
-    data: {
-      tenantId,
-      userId: targetUserId,
+  // Deferred distribution — encrypt with escrow key and save pending
+  const escrowKey = deriveEscrowKey(tenantId);
+  const encKey = encryptWithEscrow(tenantKey, escrowKey);
+
+  await prisma.pendingVaultKeyDistribution.upsert({
+    where: { tenantId_targetUserId: { tenantId, targetUserId } },
+    update: {
       encryptedTenantVaultKey: encKey.ciphertext,
       tenantVaultKeyIV: encKey.iv,
       tenantVaultKeyTag: encKey.tag,
+      distributorUserId,
+    },
+    create: {
+      tenantId,
+      targetUserId,
+      encryptedTenantVaultKey: encKey.ciphertext,
+      tenantVaultKeyIV: encKey.iv,
+      tenantVaultKeyTag: encKey.tag,
+      distributorUserId,
     },
   });
+  escrowKey.fill(0);
+  return { distributed: false, pending: true };
+}
+
+export async function processPendingDistributions(userId: string): Promise<number> {
+  const pending = await prisma.pendingVaultKeyDistribution.findMany({
+    where: { targetUserId: userId },
+  });
+
+  if (pending.length === 0) return 0;
+
+  const userMasterKey = requireMasterKey(userId);
+  let processed = 0;
+
+  for (const record of pending) {
+    const escrowKey = deriveEscrowKey(record.tenantId);
+    const tenantKey = decryptWithEscrow(
+      {
+        ciphertext: record.encryptedTenantVaultKey,
+        iv: record.tenantVaultKeyIV,
+        tag: record.tenantVaultKeyTag,
+      },
+      escrowKey
+    );
+    escrowKey.fill(0);
+
+    const encKey = encryptTenantKey(tenantKey, userMasterKey);
+    tenantKey.fill(0);
+
+    await prisma.$transaction(async (tx) => {
+      await tx.tenantVaultMember.upsert({
+        where: { tenantId_userId: { tenantId: record.tenantId, userId } },
+        update: {
+          encryptedTenantVaultKey: encKey.ciphertext,
+          tenantVaultKeyIV: encKey.iv,
+          tenantVaultKeyTag: encKey.tag,
+        },
+        create: {
+          tenantId: record.tenantId,
+          userId,
+          encryptedTenantVaultKey: encKey.ciphertext,
+          tenantVaultKeyIV: encKey.iv,
+          tenantVaultKeyTag: encKey.tag,
+        },
+      });
+
+      await tx.pendingVaultKeyDistribution.delete({
+        where: { id: record.id },
+      });
+    });
+
+    processed++;
+  }
+
+  // Fire notification if any were processed
+  if (processed > 0) {
+    const { createNotificationAsync } = await import('./notification.service');
+    createNotificationAsync({
+      userId,
+      type: 'TENANT_VAULT_KEY_RECEIVED' as never,
+      message: processed === 1
+        ? 'You now have access to an organization vault.'
+        : `You now have access to ${processed} organization vaults.`,
+    });
+  }
+
+  return processed;
 }
 
 // --- Secret CRUD ---

--- a/server/src/services/vault.service.ts
+++ b/server/src/services/vault.service.ts
@@ -21,6 +21,7 @@ import {
 } from './crypto.service';
 import { verifyCode as verifyTotpCode, getDecryptedSecret } from './totp.service';
 import { AppError } from '../middleware/error.middleware';
+import { processPendingDistributions } from './secret.service';
 
 // Resolve the effective vault auto-lock TTL for a user (in minutes, 0 = never)
 async function resolveVaultTtl(userId: string): Promise<number> {
@@ -76,6 +77,8 @@ export async function unlockVault(userId: string, password: string) {
     const ttl = await resolveVaultTtl(userId);
     storeVaultSession(userId, masterKey, ttl);
     storeVaultRecovery(userId, masterKey);
+    // Process any pending tenant vault key distributions
+    processPendingDistributions(userId).catch(() => {/* non-blocking */});
     masterKey.fill(0);
     derivedKey.fill(0);
 
@@ -160,6 +163,7 @@ export async function unlockVaultWithTotp(userId: string, code: string) {
     throw new AppError('Invalid TOTP code', 401);
   }
 
+  processPendingDistributions(userId).catch(() => {/* non-blocking */});
   masterKey.fill(0);
   return { unlocked: true };
 }
@@ -186,6 +190,7 @@ export async function unlockVaultWithWebAuthn(userId: string, credential: Record
 
   const ttl = await resolveVaultTtl(userId);
   storeVaultSession(userId, masterKey, ttl);
+  processPendingDistributions(userId).catch(() => {/* non-blocking */});
   masterKey.fill(0);
   return { unlocked: true };
 }
@@ -220,6 +225,7 @@ export async function unlockVaultWithSms(userId: string, code: string) {
 
   const ttl = await resolveVaultTtl(userId);
   storeVaultSession(userId, masterKey, ttl);
+  processPendingDistributions(userId).catch(() => {/* non-blocking */});
   masterKey.fill(0);
   return { unlocked: true };
 }


### PR DESCRIPTION
## Summary
- Implements asynchronous tenant vault key distribution using server-side escrow encryption (HMAC-SHA256 + AES-256-GCM)
- When admin distributes tenant vault key and target user's vault is locked, key is encrypted with escrow and saved as `PendingVaultKeyDistribution`
- On vault unlock (password, TOTP, WebAuthn, SMS), pending distributions are automatically finalized and user is notified
- Resolves the coordination problem where both admin and target needed unlocked vaults simultaneously

Closes #136

## Changes
| File | Change |
|------|--------|
| `server/prisma/schema.prisma` | New `PendingVaultKeyDistribution` model, `TENANT_VAULT_KEY_RECEIVED` notification type, User/Tenant relations |
| `server/src/services/crypto.service.ts` | `deriveEscrowKey`, `encryptWithEscrow`, `decryptWithEscrow` |
| `server/src/services/secret.service.ts` | Modified `distributeTenantKeyToUser` (returns `{distributed, pending}`), modified `initTenantVault` (pending for locked users), new `processPendingDistributions` |
| `server/src/services/vault.service.ts` | Hooked `processPendingDistributions` into all 4 unlock paths |
| `server/src/controllers/secret.controller.ts` | Updated response to include distributed/pending flags |
| `docs/rag-summary.md` | Updated vault documentation |

## Security Review
Approved by security-scanner: 0 critical, 0 high. Cryptographic usage correct (AES-256-GCM, HMAC-SHA256, proper key zeroing). No sensitive data in logs.

## Test plan
- [ ] Distribute key to user with locked vault — expect `{ distributed: false, pending: true }`
- [ ] Login as target user, unlock vault — expect pending auto-finalized + notification
- [ ] Verify `PendingVaultKeyDistribution` row cleaned up after processing
- [ ] Distribute key to user with open vault — expect `{ distributed: true, pending: false }` (direct path)
- [ ] Init tenant vault with mix of locked/unlocked users — locked get pending records
- [ ] `npm run verify` passes (415 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)