### PR TITLE
Clarify Agent Teams Mode usage in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,11 +203,9 @@ Skills: `/release-plan` (manage plans), `/release-plan suggest` (AI grouping). I
 
 Tasks use isolated git worktrees at `.worktrees/task/<code>/` (must be in `.gitignore`). `/task pick` creates worktree, auto-removed on close. `/task continue` creates fresh worktree from existing branch. `task_manager.py` reads/writes task files from main repo root. Run `/release` and `/setup env` from main repository.
 
-<!-- CodeClaw:START -->
-
 ## Agent Teams Mode
 
-**Default execution mode.** Use Agent Teams for any task involving development, research, or parallel work. Fall back to standalone subagents only if Teams tools are unavailable.
+**Default execution mode.** Use Agent Teams for any task involving development (/claw:task skill), research (/claw:idea skill), or parallel work in general. No exceptions. This is the core of the CLAUDE workflow.
 
 ### Team Lifecycle
 
@@ -246,4 +244,3 @@ Supports Windows, macOS, Linux with auto OS detection.
 **Utilities:** `platform_utils.py` (cmd detection, shell info, file copy), `app_manager.py` (port/process mgmt), `task_manager.py find-files` (cross-platform find).
 
 **Windows:** Requires PowerShell Core (pwsh). Enable long paths, configure `core.autocrlf true`, enable symlinks via Developer Mode. See Windows troubleshooting in project docs if issues arise.
-<!-- CodeClaw:END -->


### PR DESCRIPTION
This pull request updates the documentation in `CLAUDE.md` to clarify the use of Agent Teams as the default execution mode and to emphasize its importance in the CLAUDE workflow. It also removes CodeClaw comment markers.

Agent Teams workflow clarification:

* Updated the description of Agent Teams mode to specify that it should be used for any task involving development (`/claw:task` skill), research (`/claw:idea` skill), or parallel work, with no exceptions, highlighting its central role in the CLAUDE workflow.

Documentation cleanup:

* Removed CodeClaw comment markers from the documentation for better readability.