### PR TITLE
feat(gocache): integrate Go cache sidecar with server (GOCACHE-2107)

### DIFF
--- a/client/src/store/vaultStore.ts
+++ b/client/src/store/vaultStore.ts
@@ -12,6 +12,8 @@ interface VaultState {
   mfaUnlockMethods: string[];
   checkStatus: () => Promise<void>;
   setUnlocked: (unlocked: boolean) => void;
+  /** Handle a vault status event pushed via Socket.IO */
+  handleSocketEvent: (data: { unlocked: boolean }) => void;
   startPolling: () => void;
   stopPolling: () => void;
 }
@@ -37,6 +39,10 @@ export const useVaultStore = create<VaultState>((set, get) => ({
   },
 
   setUnlocked: (unlocked) => set({ unlocked }),
+
+  handleSocketEvent: (data: { unlocked: boolean }) => {
+    set({ unlocked: data.unlocked, initialized: true });
+  },
 
   startPolling: () => {
     if (pollTimer) return;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,7 @@ flowchart TD
     subgraph Data["Data Layer"]
         DB[(PostgreSQL 16)]
         Prisma["Prisma ORM"]
+        GoCache["gocache Sidecar<br/>gRPC :6380"]
     end
 
     subgraph Gateways["Gateway Infrastructure"]
@@ -84,6 +85,7 @@ flowchart TD
     XTerm -->|Socket.IO /ssh| SIO
     Guac -->|WebSocket| GuacWS
     API --> Prisma --> DB
+    Server -->|gRPC| GoCache
     SIO -->|SSH2| SSHGw
     GuacWS --> GuacD
     GuacD -->|RDP/VNC Protocol| SSHGw
@@ -115,6 +117,9 @@ Additional gateway components (not npm workspaces):
 - `gateways/guacd/` — Custom guacd image with embedded tunnel agent
 - `gateways/guacenc/` — Recording processor (Guacamole → MP4, asciicast → GIF)
 - `gateways/ssh-gateway/` — SSH bastion with embedded tunnel agent
+
+Infrastructure components:
+- `infrastructure/gocache/` — Go-based in-memory cache sidecar (KV, pub/sub, locks, queues over gRPC)
 
 ## Server Architecture
 
@@ -487,6 +492,53 @@ sequenceDiagram
 - Stream ID (4 bytes): Multiplexed stream identifier
 - Payload length (3 bytes)
 - Payload (variable)
+
+## Distributed State (Go Cache Sidecar)
+
+The `gocache` sidecar (`infrastructure/gocache/`) is a Go-based in-memory cache server that enables multi-instance Arsenale deployments by providing distributed KV storage, pub/sub, distributed locks, and named queues over gRPC.
+
+### Integration Architecture
+
+```mermaid
+flowchart TD
+    subgraph Instances["Server Instances"]
+        S1["Server 1"]
+        S2["Server 2"]
+    end
+
+    subgraph Sidecar["gocache Sidecar (gRPC :6380)"]
+        KV["KV Store<br/>TTL + LWW replication"]
+        PS["Pub/Sub Broker<br/>Pattern subscriptions"]
+        LK["Lock Manager<br/>Fencing tokens"]
+        QU["Queue Manager<br/>Named queues"]
+    end
+
+    S1 -->|gRPC| KV
+    S1 -->|gRPC| PS
+    S1 -->|gRPC| LK
+    S2 -->|gRPC| KV
+    S2 -->|gRPC| PS
+    S2 -->|gRPC| LK
+```
+
+### Subsystems Using the Sidecar
+
+| Subsystem | Primitive | Key Pattern | Fallback |
+|-----------|-----------|-------------|----------|
+| Socket.IO adapter | Pub/sub | `sio:<namespace>`, `sio:server:<namespace>` | In-memory adapter |
+| Auth codes | KV (GetDel) | `auth:code:<hex>` | Local Map |
+| Link codes | KV (GetDel) | `link:code:<hex>` | Local Map |
+| Relay state | KV (GetDel) | `relay:code:<hex>` | Local Map |
+| Leader election | Distributed locks | Lock name per job | Every instance runs |
+| Vault session index | KV | JSON index arrays | Local Map cleanup |
+
+### Leader Election
+
+Background jobs use `runIfLeader()` or `startLeaderHeartbeat()` from `server/src/utils/leaderElection.ts` to ensure only one instance executes scheduled work. Locks use configurable TTLs with periodic renewal. If the leader crashes, the lock expires and another instance acquires it.
+
+### Graceful Degradation
+
+All sidecar operations return `null`/`false` on failure rather than throwing. Each store maintains a local in-memory fallback. Setting `CACHE_SIDECAR_ENABLED=false` disables all distributed features, making the sidecar fully optional for single-instance deployments.
 
 ## Security Architecture
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,7 +368,8 @@ Anomaly detection for rapid connection to many distinct targets (MITRE T1021).
 |----------|---------|-------------|
 | `CACHE_SIDECAR_URL` | `localhost:6380` | gRPC endpoint of the gocache sidecar |
 | `CACHE_SIDECAR_ENABLED` | `true` | Set to `false` to disable distributed cache (single-instance fallback) |
-| `CACHE_PROTO_PATH` | `infrastructure/gocache/proto/cache.proto` | Proto file path (override for Docker builds) |
+
+> **Note:** The TypeScript gRPC client uses a manual JSON codec service definition that matches the Go sidecar's custom codec (`infrastructure/gocache/codec.go`). No `.proto` file is loaded at runtime.
 
 Sidecar-side configuration (container environment):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -362,6 +362,29 @@ Anomaly detection for rapid connection to many distinct targets (MITRE T1021).
 | `LOG_HTTP_REQUESTS` | `false` | Log HTTP requests |
 | `LOG_GUACAMOLE` | `true` | Log guacamole-lite tunneling |
 
+## Cache Sidecar (gocache)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CACHE_SIDECAR_URL` | `localhost:6380` | gRPC endpoint of the gocache sidecar |
+| `CACHE_SIDECAR_ENABLED` | `true` | Set to `false` to disable distributed cache (single-instance fallback) |
+| `CACHE_PROTO_PATH` | `infrastructure/gocache/proto/cache.proto` | Proto file path (override for Docker builds) |
+
+Sidecar-side configuration (container environment):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CACHE_LISTEN` | `tcp://localhost:6380` | gRPC listen address (`tcp://` or `unix://`) |
+| `CACHE_HEALTH_ADDR` | `0.0.0.0:6381` | Health HTTP endpoint address |
+| `CACHE_MAX_MEMORY` | `256mb` | Maximum KV store memory |
+| `CACHE_DISCOVERY` | `manual` | Peer discovery: `docker`, `kubernetes`, `manual` |
+| `CACHE_PEERS` | — | Comma-separated peer addresses (manual mode) |
+| `CACHE_K8S_SERVICE` | `gocache` | Kubernetes headless service name |
+| `CACHE_K8S_NAMESPACE` | — | Kubernetes namespace |
+| `CACHE_REPLICATION_ADDR` | `0.0.0.0:7380` | Peer replication listener address |
+| `CACHE_REPLICATION_BUFFER` | `10mb` | Replication buffer size |
+| `CACHE_GRPC_REFLECTION` | `false` | Enable gRPC reflection (debugging) |
+
 ## AI / LLM Integration
 
 | Variable | Default | Description |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,12 +44,14 @@ flowchart TD
         GuacD["guacd<br/>:4822"]
         GuacEnc["guacenc<br/>:3003"]
         SSHGw["ssh-gateway<br/>:2222"]
+        GoCache["gocache<br/>:6380"]
     end
 
     Browser --> Client
     Client -->|/api proxy| Server
     Client -->|/guacamole proxy| Server
     Server --> Postgres
+    Server -->|gRPC| GoCache
     Server --> GuacD
     Server --> GuacEnc
     GuacD --> SSHGw
@@ -76,6 +78,7 @@ flowchart TD
 | **guacenc** | `./gateways/guacenc` | Internal | Recording → video conversion |
 | **server** | `./server/Dockerfile` | 3001, 3002 | Express API + Guacamole WS |
 | **client** | `./client/Dockerfile` | 8080 → 3000 | Nginx reverse proxy + SPA |
+| **gocache** | `./infrastructure/gocache` | 6380, 6381 | In-memory cache sidecar (gRPC + health) |
 | **ssh-gateway** | `./gateways/ssh-gateway` | 2222 | SSH bastion (optional) |
 
 ### Volumes
@@ -85,6 +88,7 @@ flowchart TD
 | `pgdata` | PostgreSQL data | Database persistence |
 | `arsenale_drive` | `/guacd-drive` | RDP file drive redirection |
 | `arsenale_recordings` | `/recordings` | Session recordings |
+| `gocache_data` | `/data` | Cache sidecar persistence |
 
 ### Security Hardening
 
@@ -183,6 +187,19 @@ Go-based implementation of the MS-TSGU (Terminal Services Gateway) protocol. Ena
 ### Arsenale Connect CLI (`tools/arsenale-cli/`)
 
 Go CLI tool for native client orchestration. Authenticates via RFC 8628 device authorization, retrieves credentials from the vault, generates SSH proxy tokens or .rdp files, and launches native SSH/RDP clients.
+
+### Go Cache Sidecar (`infrastructure/gocache/Dockerfile`)
+
+Multi-stage build: Go 1.25-alpine (build) → Alpine 3.21 (runtime):
+
+1. Download Go modules and build static binary
+2. Create non-root `gocache` user (UID 10001)
+3. Create `/data` volume for persistence
+
+**Exposed ports:** 6380 (gRPC), 6381 (health HTTP)
+**Health check:** `wget /health` (10s interval, 5s start period)
+**User:** 10001:10001 (non-root)
+**Entry:** `/usr/local/bin/gocache`
 
 ### Guacenc (`gateways/guacenc/Dockerfile`)
 
@@ -290,6 +307,7 @@ All images are pushed to **GitHub Container Registry** (`ghcr.io/dnviti/arsenale
 | Service | Port | Purpose |
 |---------|------|---------|
 | postgres | 127.0.0.1:5432 | Local database |
+| gocache | 127.0.0.1:6380, 6381 | Cache sidecar (distributed state) |
 | guacenc | 3003 | Recording processor (optional) |
 
 Server and client run natively via `npm run dev`.
@@ -303,6 +321,7 @@ Server and client run natively via `npm run dev`.
 | Server | `wget /api/health` | 10s | 30s |
 | Client | Nginx `/health` | 10s | 5s |
 | SSH Gateway | `nc -z localhost $SSH_PORT` | 10s | — |
+| gocache | `wget /health` (HTTP :6381) | 10s | 5s |
 | DB Proxy | `/proc/1/status` | 30s | 10s |
 
 ## Production Checklist

--- a/docs/rag-summary.md
+++ b/docs/rag-summary.md
@@ -228,6 +228,66 @@ Both Docker and Podman are supported as container runtimes, with rootless Podman
 
 Configuration is handled through a single environment file with sensible defaults for development. Production deployment requires setting cryptographic secrets and connection parameters, all documented with generation commands.
 
+## Distributed State (Go Cache Sidecar)
+
+Arsenale includes a Go-based in-memory cache sidecar (`infrastructure/gocache/`) that enables multi-instance deployments by replacing per-process in-memory stores with distributed, cache-backed alternatives. The sidecar communicates with the TypeScript server over gRPC and provides four primitives: key-value storage with TTL, pub/sub messaging, distributed locks with fencing tokens, and named queues.
+
+### Architecture
+
+The sidecar runs as a separate container (`gocache`) alongside the server. The TypeScript client (`server/src/utils/cacheClient.ts`) connects via gRPC using a dynamically loaded proto definition. All operations gracefully degrade — when the sidecar is unavailable or disabled (`CACHE_SIDECAR_ENABLED=false`), each subsystem falls back to local in-memory behavior, making the sidecar optional for single-instance deployments.
+
+### Distributed Subsystems
+
+| Subsystem | Cache Primitive | Fallback |
+|-----------|----------------|----------|
+| Socket.IO cross-instance events | Pub/sub (custom adapter) | Default in-memory adapter |
+| Auth codes (OAuth/SAML callbacks) | KV with TTL + atomic GetDel | Local `Map<string, AuthCodeEntry>` |
+| Link codes (account linking) | KV with TTL + atomic GetDel | Local `Map<string, LinkCodeEntry>` |
+| Relay state (SAML/OAuth state) | KV with TTL + atomic GetDel | Local `Map<string, LinkCodeEntry>` |
+| Leader election (scheduled jobs) | Distributed locks + heartbeat renewal | Every instance runs every job |
+| Vault session index | KV (JSON arrays for prefix-based cleanup) | Local Map cleanup only |
+
+### Cache Key Patterns
+
+| Pattern | Purpose | TTL |
+|---------|---------|-----|
+| `auth:code:<hex>` | OAuth/SAML one-time auth code | 60s |
+| `link:code:<hex>` | Account-linking one-time code | 60s |
+| `relay:code:<hex>` | SAML/OAuth relay state | 5m |
+| `sio:<namespace>` | Socket.IO broadcast messages | None (pub/sub) |
+| `sio:server:<namespace>` | Socket.IO server-side emit | None (pub/sub) |
+| `sio:*` | Socket.IO subscription pattern | None (pub/sub) |
+
+### Leader Election
+
+In multi-instance deployments, background scheduled jobs (key rotation, cleanup tasks, LDAP sync, health monitors) must run on only one instance to prevent duplicate work. The leader election utility (`server/src/utils/leaderElection.ts`) provides two patterns:
+
+- **`runIfLeader(lockName, fn, ttlMs)`** — acquires a distributed lock, runs the function if acquired, releases on completion. Other instances skip the job.
+- **`startLeaderHeartbeat(lockName, ttlMs, intervalMs)`** — maintains continuous leadership via periodic lock renewal. If the leader loses the lock (crash, network partition), another instance re-acquires it.
+
+When the sidecar is disabled, both functions fall through and execute unconditionally (single-instance behavior).
+
+### Socket.IO Cross-Instance Adapter
+
+The `GoCacheAdapter` (`server/src/utils/cacheAdapter.ts`) replaces Socket.IO's default in-memory adapter with one backed by gocache pub/sub. Each server instance publishes broadcast and serverSideEmit packets to namespaced channels, and subscribes to `sio:*` using pattern matching. Messages include a source instance ID to prevent self-echo. This enables real-time notifications, gateway monitoring, and vault status updates to reach clients connected to any server instance.
+
+### Peer Replication
+
+The sidecar supports multi-instance clustering with peer discovery (Docker label-based, Kubernetes headless service, or manual peer list). KV mutations and pub/sub messages are replicated across peers using a streaming gRPC protocol with last-writer-wins (LWW) conflict resolution based on logical timestamps.
+
+### Configuration
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CACHE_SIDECAR_URL` | `localhost:6380` | gRPC endpoint of the sidecar |
+| `CACHE_SIDECAR_ENABLED` | `true` | Enable/disable sidecar integration |
+| `CACHE_PROTO_PATH` | `infrastructure/gocache/proto/cache.proto` | Proto file location |
+| `CACHE_LISTEN` | `tcp://localhost:6380` | Sidecar listen address |
+| `CACHE_HEALTH_ADDR` | `0.0.0.0:6381` | Sidecar health HTTP endpoint |
+| `CACHE_MAX_MEMORY` | `256mb` | Maximum memory for KV store |
+| `CACHE_DISCOVERY` | `manual` | Peer discovery mode (`docker`, `kubernetes`, `manual`) |
+| `CACHE_PEERS` | (empty) | Comma-separated peer addresses (manual mode) |
+
 ## Technology
 
-Arsenale is built on a modern open-source stack: a Node.js and TypeScript server with a layered Express architecture backed by PostgreSQL through Prisma ORM, and a React client with Zustand state management and Material UI components. The monorepo includes four npm workspaces: `server/`, `client/`, `gateways/tunnel-agent/`, and `extra-clients/browser-extensions/`, plus Go-based gateway components (`gateways/db-proxy/`, `gateways/rdgw/`) and a Go CLI tool (`tools/arsenale-cli/`). Remote desktop rendering uses the Guacamole protocol via guacamole-lite and guacamole-common-js. SSH terminals use XTerm.js with the ssh2 library. Real-time communication uses Socket.IO for terminal I/O, notifications, and monitoring updates. The zero-trust tunnel system uses raw `ws` WebSocket connections with a custom binary multiplexing protocol for proxying TCP streams through outbound-only gateway agent connections. The ABAC policy engine evaluates `AccessPolicy` Prisma records at session start time to enforce time-window, trusted-device, and MFA step-up constraints.
+Arsenale is built on a modern open-source stack: a Node.js and TypeScript server with a layered Express architecture backed by PostgreSQL through Prisma ORM, and a React client with Zustand state management and Material UI components. The monorepo includes four npm workspaces: `server/`, `client/`, `gateways/tunnel-agent/`, and `extra-clients/browser-extensions/`, plus Go-based gateway components (`gateways/db-proxy/`, `gateways/rdgw/`), a Go CLI tool (`tools/arsenale-cli/`), and the Go cache sidecar (`infrastructure/gocache/`). Remote desktop rendering uses the Guacamole protocol via guacamole-lite and guacamole-common-js. SSH terminals use XTerm.js with the ssh2 library. Real-time communication uses Socket.IO for terminal I/O, notifications, and monitoring updates, with optional cross-instance delivery via the gocache pub/sub adapter. The zero-trust tunnel system uses raw `ws` WebSocket connections with a custom binary multiplexing protocol for proxying TCP streams through outbound-only gateway agent connections. The ABAC policy engine evaluates `AccessPolicy` Prisma records at session start time to enforce time-window, trusted-device, and MFA step-up constraints.

--- a/infrastructure/gocache/grpc_service.go
+++ b/infrastructure/gocache/grpc_service.go
@@ -56,6 +56,14 @@ type GetDelResponse struct {
 	Found bool   `json:"found"`
 }
 
+type ExpireRequest struct {
+	Key   string `json:"key"`
+	TtlMs int64  `json:"ttl_ms"`
+}
+type ExpireResponse struct {
+	Ok bool `json:"ok"`
+}
+
 type PublishRequest struct {
 	Channel string `json:"channel"`
 	Message []byte `json:"message"`
@@ -152,6 +160,7 @@ type CacheServiceServer interface {
 	Delete(context.Context, *DeleteRequest) (*DeleteResponse, error)
 	Incr(context.Context, *IncrRequest) (*IncrResponse, error)
 	GetDel(context.Context, *GetDelRequest) (*GetDelResponse, error)
+	Expire(context.Context, *ExpireRequest) (*ExpireResponse, error)
 	Publish(context.Context, *PublishRequest) (*PublishResponse, error)
 	Subscribe(*SubscribeRequest, CacheService_SubscribeServer) error
 	AcquireLock(context.Context, *AcquireLockRequest) (*AcquireLockResponse, error)
@@ -181,6 +190,9 @@ func (UnimplementedCacheServiceServer) Incr(context.Context, *IncrRequest) (*Inc
 }
 func (UnimplementedCacheServiceServer) GetDel(context.Context, *GetDelRequest) (*GetDelResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDel not implemented")
+}
+func (UnimplementedCacheServiceServer) Expire(context.Context, *ExpireRequest) (*ExpireResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Expire not implemented")
 }
 func (UnimplementedCacheServiceServer) Publish(context.Context, *PublishRequest) (*PublishResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Publish not implemented")
@@ -283,6 +295,7 @@ var _CacheService_serviceDesc = grpc.ServiceDesc{
 		{MethodName: "Delete", Handler: _CacheService_Delete_Handler},
 		{MethodName: "Incr", Handler: _CacheService_Incr_Handler},
 		{MethodName: "GetDel", Handler: _CacheService_GetDel_Handler},
+		{MethodName: "Expire", Handler: _CacheService_Expire_Handler},
 		{MethodName: "Publish", Handler: _CacheService_Publish_Handler},
 		{MethodName: "AcquireLock", Handler: _CacheService_AcquireLock_Handler},
 		{MethodName: "ReleaseLock", Handler: _CacheService_ReleaseLock_Handler},
@@ -373,6 +386,20 @@ func _CacheService_GetDel_Handler(srv interface{}, ctx context.Context, dec func
 	info := &grpc.UnaryServerInfo{Server: srv, FullMethod: "/cache.CacheService/GetDel"}
 	return interceptor(ctx, in, info, func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(CacheServiceServer).GetDel(ctx, req.(*GetDelRequest))
+	})
+}
+
+func _CacheService_Expire_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExpireRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CacheServiceServer).Expire(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{Server: srv, FullMethod: "/cache.CacheService/Expire"}
+	return interceptor(ctx, in, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CacheServiceServer).Expire(ctx, req.(*ExpireRequest))
 	})
 }
 

--- a/infrastructure/gocache/main.go
+++ b/infrastructure/gocache/main.go
@@ -262,6 +262,13 @@ func (s *cacheServiceServer) GetDel(_ context.Context, req *GetDelRequest) (*Get
 	return &GetDelResponse{Value: val, Found: found}, nil
 }
 
+func (s *cacheServiceServer) Expire(_ context.Context, req *ExpireRequest) (*ExpireResponse, error) {
+	ttl := time.Duration(req.TtlMs) * time.Millisecond
+	ok := s.store.Expire(req.Key, ttl)
+	log.Printf("[kv] EXPIRE key=%q ttl=%v ok=%v", req.Key, ttl, ok)
+	return &ExpireResponse{Ok: ok}, nil
+}
+
 func (s *cacheServiceServer) Publish(_ context.Context, req *PublishRequest) (*PublishResponse, error) {
 	count, _ := s.broker.Publish(req.Channel, req.Message)
 	s.replication.ReplicatePubSub(req.Channel, req.Message)

--- a/infrastructure/gocache/proto/cache.proto
+++ b/infrastructure/gocache/proto/cache.proto
@@ -12,6 +12,7 @@ service CacheService {
   rpc Delete(DeleteRequest) returns (DeleteResponse);
   rpc Incr(IncrRequest) returns (IncrResponse);
   rpc GetDel(GetDelRequest) returns (GetDelResponse);
+  rpc Expire(ExpireRequest) returns (ExpireResponse);
 
   // PubSub
   rpc Publish(PublishRequest) returns (PublishResponse);
@@ -77,6 +78,15 @@ message GetDelRequest {
 message GetDelResponse {
   bytes value = 1;
   bool found = 2;
+}
+
+message ExpireRequest {
+  string key = 1;
+  int64 ttl_ms = 2;
+}
+
+message ExpireResponse {
+  bool ok = 1;
 }
 
 // PubSub Messages

--- a/server/src/cli/helpers/vault.ts
+++ b/server/src/cli/helpers/vault.ts
@@ -11,7 +11,7 @@ export async function unlockUserVault(identifier: string, password?: string): Pr
   }
 
   // Already unlocked in memory?
-  if (getVaultSession(user.id)) {
+  if (await getVaultSession(user.id)) {
     return user;
   }
 

--- a/server/src/controllers/oauth.controller.ts
+++ b/server/src/controllers/oauth.controller.ts
@@ -75,7 +75,7 @@ export function handleCallback(req: Request, res: Response, next: NextFunction) 
       // consumeRelayCode() does a server-side Map lookup keyed by the opaque token;
       // returns null for empty/invalid/expired codes. The returned userId is server-stored,
       // never derived from user input. No user-controlled condition guards the action.
-      const linkUserId = consumeRelayCode(String(req.query.state ?? ''));
+      const linkUserId = await consumeRelayCode(String(req.query.state ?? ''));
       if (linkUserId) {
         const linkUser = await prisma.user.findUnique({ where: { id: linkUserId }, select: { id: true } });
         if (linkUser) {
@@ -109,7 +109,7 @@ export function handleCallback(req: Request, res: Response, next: NextFunction) 
       const csrfToken = setCsrfCookie(res);
 
       // Use a short-lived one-time code instead of putting tokens in the URL
-      const code = generateAuthCode({
+      const code = await generateAuthCode({
         accessToken: tokens.accessToken,
         csrfToken,
         needsVaultSetup: !result.user.vaultSetupComplete,
@@ -144,14 +144,14 @@ export function getAvailableProviders(_req: Request, res: Response) {
   res.json(providers);
 }
 
-export function initiateLinkOAuth(req: Request, res: Response, next: NextFunction) {
+export async function initiateLinkOAuth(req: Request, res: Response, next: NextFunction) {
   // Accept a one-time link code (preferred) to avoid JWTs in URL params.
   // Falls back to Authorization header, then query param token for backward compat.
   let userId: string | undefined;
 
   const linkCode = req.query.code as string | undefined;
   if (linkCode) {
-    const resolved = consumeLinkCode(linkCode);
+    const resolved = await consumeLinkCode(linkCode);
     if (!resolved) return next(new AppError('Invalid or expired link code', 401));
     userId = resolved;
   } else {
@@ -173,7 +173,7 @@ export function initiateLinkOAuth(req: Request, res: Response, next: NextFunctio
     return next(new AppError('OAuth provider not available', 400));
   }
 
-  const state = generateRelayCode(userId);
+  const state = await generateRelayCode(userId);
 
   passport.authenticate(provider, {
     scope: getScopes(provider),
@@ -187,19 +187,19 @@ export function initiateLinkOAuth(req: Request, res: Response, next: NextFunctio
  * The client calls this via Axios (with Authorization header),
  * then redirects to the link endpoint with ?code=... instead of ?token=...
  */
-export function generateLinkCodeEndpoint(req: AuthRequest, res: Response) {
+export async function generateLinkCodeEndpoint(req: AuthRequest, res: Response) {
   assertAuthenticated(req);
-  const code = generateLinkCode(req.user.userId);
+  const code = await generateLinkCode(req.user.userId);
   res.json({ code });
 }
 
-export function exchangeCode(req: Request, res: Response, next: NextFunction) {
+export async function exchangeCode(req: Request, res: Response, next: NextFunction) {
   const { code } = req.body as { code?: string };
   if (!code || typeof code !== 'string') {
     return next(new AppError('Missing authorization code', 400));
   }
 
-  const data = consumeAuthCode(code);
+  const data = await consumeAuthCode(code);
   if (!data) {
     return next(new AppError('Invalid or expired authorization code', 400));
   }

--- a/server/src/controllers/saml.controller.ts
+++ b/server/src/controllers/saml.controller.ts
@@ -25,14 +25,14 @@ export function initiateSaml(req: Request, res: Response, next: NextFunction) {
   passport.authenticate('saml', { session: false })(req, res, next);
 }
 
-export function initiateSamlLink(req: Request, res: Response, next: NextFunction) {
+export async function initiateSamlLink(req: Request, res: Response, next: NextFunction) {
   // Accept a one-time link code (preferred) to avoid JWTs in URL params.
   // Falls back to Authorization header, then query param token for backward compat.
   let userId: string | undefined;
 
   const linkCode = req.query.code as string | undefined;
   if (linkCode) {
-    const resolved = consumeLinkCode(linkCode);
+    const resolved = await consumeLinkCode(linkCode);
     if (!resolved) return next(new AppError('Invalid or expired link code', 401));
     userId = resolved;
   } else {
@@ -53,7 +53,7 @@ export function initiateSamlLink(req: Request, res: Response, next: NextFunction
     return next(new AppError('SAML provider not available', 400));
   }
 
-  const relayState = generateRelayCode(userId);
+  const relayState = await generateRelayCode(userId);
 
   passport.authenticate('saml', {
     session: false,
@@ -83,7 +83,7 @@ export function handleSamlCallback(req: Request, res: Response, next: NextFuncti
       // consumeRelayCode() does a server-side Map lookup keyed by the opaque token;
       // returns null for empty/invalid/expired codes. The returned userId is server-stored,
       // never derived from user input. No user-controlled condition guards the action.
-      const linkUserId = consumeRelayCode(String(req.body?.RelayState ?? ''));
+      const linkUserId = await consumeRelayCode(String(req.body?.RelayState ?? ''));
       if (linkUserId) {
         const linkUser = await prisma.user.findUnique({ where: { id: linkUserId }, select: { id: true } });
         if (linkUser) {
@@ -123,7 +123,7 @@ export function handleSamlCallback(req: Request, res: Response, next: NextFuncti
       const csrfToken = setCsrfCookie(res);
 
       // Use a short-lived one-time code instead of putting tokens in the URL
-      const code = generateAuthCode({
+      const code = await generateAuthCode({
         accessToken: tokens.accessToken,
         csrfToken,
         needsVaultSetup: !result.user.vaultSetupComplete,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,7 +37,7 @@ import { rebuildLoginRateLimiter } from './middleware/loginRateLimit.middleware'
 import { rebuildOauthRateLimiters } from './middleware/oauthRateLimit.middleware';
 import { rebuildVaultRateLimiters } from './middleware/vaultRateLimit.middleware';
 import { rebuildSessionRateLimiter } from './middleware/sessionRateLimit.middleware';
-import { runIfLeader, startLeaderHeartbeat } from './utils/leaderElection';
+import { runIfLeader } from './utils/leaderElection';
 
 function freePort(port: number): void {
   try {
@@ -119,9 +119,6 @@ async function main() {
 
   // Initialize session cleanup with Socket.IO reference
   initSessionCleanup(io);
-
-  // Start leader heartbeat for distributed lock-based job coordination
-  const leaderHb = startLeaderHeartbeat('scheduler');
 
   // Start scheduled jobs
   startKeyRotationJob();
@@ -435,7 +432,6 @@ async function main() {
 
   const shutdown = async () => {
     logger.info('Shutting down...');
-    leaderHb.stop();
     stopAllMonitors();
     stopAllJobs();
     stopAllSyncJobs();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,7 @@ import { rebuildLoginRateLimiter } from './middleware/loginRateLimit.middleware'
 import { rebuildOauthRateLimiters } from './middleware/oauthRateLimit.middleware';
 import { rebuildVaultRateLimiters } from './middleware/vaultRateLimit.middleware';
 import { rebuildSessionRateLimiter } from './middleware/sessionRateLimit.middleware';
+import { runIfLeader, startLeaderHeartbeat } from './utils/leaderElection';
 
 function freePort(port: number): void {
   try {
@@ -119,6 +120,9 @@ async function main() {
   // Initialize session cleanup with Socket.IO reference
   initSessionCleanup(io);
 
+  // Start leader heartbeat for distributed lock-based job coordination
+  const leaderHb = startLeaderHeartbeat('scheduler');
+
   // Start scheduled jobs
   startKeyRotationJob();
   startLdapSyncJob();
@@ -156,20 +160,26 @@ async function main() {
   // Managed gateway health check and reconciliation (only if orchestrator available)
   if (orchestrator.type !== OrchestratorType.NONE) {
     setInterval(() => {
-      managedGatewayService.healthCheck().catch((err) => {
-        logger.error('Managed gateway health check failed:', err);
+      runIfLeader('scheduler', async () => {
+        await managedGatewayService.healthCheck();
+      }).catch((err) => {
+        logger.error('Managed gateway health check failed:', err instanceof Error ? err.message : 'Unknown error');
       });
     }, 30 * 1000);
 
     setInterval(() => {
-      managedGatewayService.reconcileAll().catch((err) => {
-        logger.error('Managed gateway reconciliation failed:', err);
+      runIfLeader('scheduler', async () => {
+        await managedGatewayService.reconcileAll();
+      }).catch((err) => {
+        logger.error('Managed gateway reconciliation failed:', err instanceof Error ? err.message : 'Unknown error');
       });
     }, 5 * 60 * 1000);
 
     setInterval(() => {
-      autoscalerService.evaluateScaling().catch((err) => {
-        logger.error('Auto-scaling evaluation failed:', err);
+      runIfLeader('scheduler', async () => {
+        await autoscalerService.evaluateScaling();
+      }).catch((err) => {
+        logger.error('Auto-scaling evaluation failed:', err instanceof Error ? err.message : 'Unknown error');
       });
     }, 30 * 1000);
 
@@ -178,77 +188,94 @@ async function main() {
 
   // Cleanup expired external shares every hour
   setInterval(() => {
-    cleanupExpiredShares().catch((err) => {
-      logger.error('Failed to cleanup expired external shares:', err);
+    runIfLeader('scheduler', async () => {
+      await cleanupExpiredShares();
+    }).catch((err) => {
+      logger.error('Failed to cleanup expired external shares:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 60 * 60 * 1000);
 
   // Cleanup expired refresh tokens every hour
   setInterval(() => {
-    cleanupExpiredTokens().catch((err) => {
-      logger.error('Failed to cleanup expired refresh tokens:', err);
+    runIfLeader('scheduler', async () => {
+      await cleanupExpiredTokens();
+    }).catch((err) => {
+      logger.error('Failed to cleanup expired refresh tokens:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 60 * 60 * 1000);
 
   // Cleanup token families that exceeded absolute session timeout (every 5 minutes)
   setInterval(() => {
-    cleanupAbsolutelyTimedOutFamilies().catch((err) => {
-      logger.error('Absolute timeout family cleanup failed:', err);
+    runIfLeader('scheduler', async () => {
+      await cleanupAbsolutelyTimedOutFamilies();
+    }).catch((err) => {
+      logger.error('Absolute timeout family cleanup failed:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 5 * 60 * 1000);
 
   // Check for expiring secrets every 6 hours
   setInterval(() => {
-    checkExpiringSecrets().catch((err) => {
-      logger.error('Secret expiry check failed:', err);
+    runIfLeader('scheduler', async () => {
+      await checkExpiringSecrets();
+    }).catch((err) => {
+      logger.error('Secret expiry check failed:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 6 * 60 * 60 * 1000);
 
   // Mark idle sessions every minute
   setInterval(() => {
-    sessionService.markIdleSessions(config.sessionIdleThresholdMinutes).then((count) => {
+    runIfLeader('scheduler', async () => {
+      const count = await sessionService.markIdleSessions(config.sessionIdleThresholdMinutes);
       if (count > 0) logger.info(`Marked ${count} session(s) as idle`);
     }).catch((err) => {
-      logger.error('Failed to mark idle sessions:', err);
+      logger.error('Failed to mark idle sessions:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 60 * 1000);
 
   // Close inactive sessions every minute
   setInterval(() => {
-    checkAndCloseInactiveSessions().then((count) => {
+    runIfLeader('scheduler', async () => {
+      const count = await checkAndCloseInactiveSessions();
       if (count > 0) logger.info(`Session cleanup: closed ${count} inactive session(s)`);
     }).catch((err) => {
-      logger.error('Session inactivity cleanup failed:', err);
+      logger.error('Session inactivity cleanup failed:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 60 * 1000);
 
   // Cleanup old closed sessions daily
   setInterval(() => {
-    sessionService.cleanupClosedSessions(config.sessionCleanupRetentionDays).then((count) => {
+    runIfLeader('scheduler', async () => {
+      const count = await sessionService.cleanupClosedSessions(config.sessionCleanupRetentionDays);
       if (count > 0) logger.info(`Cleaned up ${count} old closed session(s)`);
     }).catch((err) => {
-      logger.error('Failed to cleanup closed sessions:', err);
+      logger.error('Failed to cleanup closed sessions:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 24 * 60 * 60 * 1000);
 
   // Cleanup expired recordings daily
   setInterval(() => {
-    cleanupExpiredRecordings().catch((err) => {
-      logger.error('Recording cleanup failed:', err);
+    runIfLeader('scheduler', async () => {
+      await cleanupExpiredRecordings();
+    }).catch((err) => {
+      logger.error('Recording cleanup failed:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 24 * 60 * 60 * 1000);
 
   // Cleanup idle RD Gateway tunnels every minute
   setInterval(() => {
-    cleanupIdleTunnels(config.sessionInactivityTimeoutSeconds).catch((err) => {
-      logger.error('RD Gateway tunnel cleanup failed:', err);
+    runIfLeader('scheduler', async () => {
+      await cleanupIdleTunnels(config.sessionInactivityTimeoutSeconds);
+    }).catch((err) => {
+      logger.error('RD Gateway tunnel cleanup failed:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 60 * 1000);
 
   // Cleanup expired device auth codes every 5 minutes
   setInterval(() => {
-    cleanupExpiredDeviceCodes().catch((err) => {
-      logger.error('Device auth code cleanup failed:', err);
+    runIfLeader('scheduler', async () => {
+      await cleanupExpiredDeviceCodes();
+    }).catch((err) => {
+      logger.error('Device auth code cleanup failed:', err instanceof Error ? err.message : 'Unknown error');
     });
   }, 5 * 60 * 1000);
 
@@ -408,6 +435,7 @@ async function main() {
 
   const shutdown = async () => {
     logger.info('Shutting down...');
+    leaderHb.stop();
     stopAllMonitors();
     stopAllJobs();
     stopAllSyncJobs();

--- a/server/src/middleware/rateLimitFactory.ts
+++ b/server/src/middleware/rateLimitFactory.ts
@@ -24,23 +24,30 @@ class GoCacheRateLimitStore implements Store {
   constructor(private windowMs: number) {}
 
   async increment(key: string): Promise<IncrementResponse> {
-    const windowStart = Math.floor(Date.now() / this.windowMs) * this.windowMs;
+    const now = Date.now();
+    const windowStart = Math.floor(now / this.windowMs) * this.windowMs;
+    const windowEnd = windowStart + this.windowMs;
     const cacheKey = `rl:${key}:${windowStart}`;
-    // Atomic increment — no separate TTL set needed.
-    // Keys are timestamp-bucketed so stale windows are naturally ignored.
-    // The sidecar's background sweeper / LRU eviction handles cleanup.
     const count = await cache.incr(cacheKey, 1);
+    // Set TTL so counter keys don't accumulate indefinitely (+1s buffer)
+    const ttlMs = windowEnd - now + 1000;
+    cache.expire(cacheKey, ttlMs).catch(() => {}); // best-effort
 
     return {
       totalHits: count ?? 1,
-      resetTime: new Date(windowStart + this.windowMs),
+      resetTime: new Date(windowEnd),
     };
   }
 
   async decrement(key: string): Promise<void> {
-    const windowStart = Math.floor(Date.now() / this.windowMs) * this.windowMs;
+    const now = Date.now();
+    const windowStart = Math.floor(now / this.windowMs) * this.windowMs;
+    const windowEnd = windowStart + this.windowMs;
     const cacheKey = `rl:${key}:${windowStart}`;
     await cache.incr(cacheKey, -1);
+    // Set TTL so counter keys don't accumulate indefinitely (+1s buffer)
+    const ttlMs = windowEnd - now + 1000;
+    cache.expire(cacheKey, ttlMs).catch(() => {}); // best-effort
   }
 
   async resetKey(key: string): Promise<void> {

--- a/server/src/middleware/rateLimitFactory.ts
+++ b/server/src/middleware/rateLimitFactory.ts
@@ -1,4 +1,6 @@
-import rateLimit, { type Options, ipKeyGenerator } from 'express-rate-limit';
+import rateLimit, { type Options, type Store, type IncrementResponse, ipKeyGenerator } from 'express-rate-limit';
+import * as cache from '../utils/cacheClient';
+import { config } from '../config';
 
 interface RateLimitOpts {
   windowMs: number;
@@ -10,6 +12,43 @@ interface RateLimitOpts {
   extra?: Partial<Options>;
 }
 
+/**
+ * Distributed rate limit store backed by gocache.
+ *
+ * Uses fixed-window counters with timestamp-bucketed keys so that
+ * rate limits are shared across all server instances.
+ */
+class GoCacheRateLimitStore implements Store {
+  readonly localKeys = false;
+
+  constructor(private windowMs: number) {}
+
+  async increment(key: string): Promise<IncrementResponse> {
+    const windowStart = Math.floor(Date.now() / this.windowMs) * this.windowMs;
+    const cacheKey = `rl:${key}:${windowStart}`;
+    // Atomic increment — no separate TTL set needed.
+    // Keys are timestamp-bucketed so stale windows are naturally ignored.
+    // The sidecar's background sweeper / LRU eviction handles cleanup.
+    const count = await cache.incr(cacheKey, 1);
+
+    return {
+      totalHits: count ?? 1,
+      resetTime: new Date(windowStart + this.windowMs),
+    };
+  }
+
+  async decrement(key: string): Promise<void> {
+    const windowStart = Math.floor(Date.now() / this.windowMs) * this.windowMs;
+    const cacheKey = `rl:${key}:${windowStart}`;
+    await cache.incr(cacheKey, -1);
+  }
+
+  async resetKey(key: string): Promise<void> {
+    const windowStart = Math.floor(Date.now() / this.windowMs) * this.windowMs;
+    await cache.del(`rl:${key}:${windowStart}`);
+  }
+}
+
 /** Create a rate limiter with shared defaults (standardHeaders, legacyHeaders). */
 export function createRateLimiter({ windowMs, max, message, keyPrefix, extra }: RateLimitOpts) {
   return rateLimit({
@@ -18,6 +57,9 @@ export function createRateLimiter({ windowMs, max, message, keyPrefix, extra }: 
     message: { error: message },
     standardHeaders: true,
     legacyHeaders: false,
+    ...(config.cacheSidecarEnabled && {
+      store: new GoCacheRateLimitStore(windowMs),
+    }),
     ...(keyPrefix && {
       keyGenerator: (req) => {
         const authReq = req as { user?: { userId: string } };

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -643,7 +643,7 @@ export async function verifyTotp(tempToken: string, code: string, binding?: { ip
     throw new Error('2FA verification failed');
   }
 
-  const secret = getDecryptedSecret(user, user.id);
+  const secret = await getDecryptedSecret(user, user.id);
   if (!secret) {
     throw new Error('2FA verification failed');
   }
@@ -654,7 +654,7 @@ export async function verifyTotp(tempToken: string, code: string, binding?: { ip
 
   // Lazy migration: encrypt plaintext TOTP secret if not yet encrypted
   if (user.totpSecret && !user.encryptedTotpSecret) {
-    const masterKey = getMasterKey(user.id);
+    const masterKey = await getMasterKey(user.id);
     if (masterKey) {
       const enc = encrypt(user.totpSecret, masterKey);
       await prisma.user.update({

--- a/server/src/services/connection.service.ts
+++ b/server/src/services/connection.service.ts
@@ -105,7 +105,7 @@ export async function createConnection(userId: string, input: CreateConnectionIn
   if (input.username !== undefined && input.password !== undefined) {
     const encryptionKey = input.teamId
       ? await resolveTeamKey(input.teamId, userId)
-      : requireMasterKey(userId);
+      : await requireMasterKey(userId);
     encUsername = encrypt(input.username, encryptionKey);
     encPassword = encrypt(input.password, encryptionKey);
     if (input.domain) {
@@ -620,7 +620,7 @@ async function resolveCredentialsFromSecret(
       where: { secretId: credentialSecretId, sharedWithUserId: userId },
     });
     if (!sharedRecord) throw new AppError('Credential secret not found', 404);
-    const personalKey = requireMasterKey(userId);
+    const personalKey = await requireMasterKey(userId);
     decryptedData = JSON.parse(
       decrypt({ ciphertext: sharedRecord.encryptedData, iv: sharedRecord.dataIV, tag: sharedRecord.dataTag }, personalKey)
     );
@@ -696,7 +696,7 @@ export async function getConnectionCredentials(
     if (!creds.username && connection.encryptedUsername && connection.usernameIV && connection.usernameTag) {
       const key = access.accessType === 'team' && connection.teamId
         ? await resolveTeamKey(connection.teamId, userId)
-        : requireMasterKey(userId);
+        : await requireMasterKey(userId);
       creds.username = decrypt(
         { ciphertext: connection.encryptedUsername, iv: connection.usernameIV, tag: connection.usernameTag },
         key
@@ -706,7 +706,7 @@ export async function getConnectionCredentials(
     if (!creds.domain && connection.encryptedDomain && connection.domainIV && connection.domainTag) {
       const key = access.accessType === 'team' && connection.teamId
         ? await resolveTeamKey(connection.teamId, userId)
-        : requireMasterKey(userId);
+        : await requireMasterKey(userId);
       creds.domain = decryptDomain(connection, key);
     }
     return creds;
@@ -719,7 +719,7 @@ export async function getConnectionCredentials(
   }
 
   if (access.accessType === 'owner') {
-    const masterKey = requireMasterKey(userId);
+    const masterKey = await requireMasterKey(userId);
     return {
       username: decrypt(
         { ciphertext: connection.encryptedUsername, iv: connection.usernameIV, tag: connection.usernameTag },
@@ -749,7 +749,7 @@ export async function getConnectionCredentials(
   }
 
   // Shared: decrypt from SharedConnection re-encrypted copy
-  const masterKey = requireMasterKey(userId);
+  const masterKey = await requireMasterKey(userId);
   const shared = await prisma.sharedConnection.findFirst({
     where: { connectionId, sharedWithUserId: userId },
   });

--- a/server/src/services/crypto.service.ts
+++ b/server/src/services/crypto.service.ts
@@ -1,10 +1,10 @@
 import crypto, { createHmac } from 'crypto';
 import argon2 from 'argon2';
-import { EncryptedField, VaultSession } from '../types';
+import type { EncryptedField, VaultSession } from '../types';
 import { config } from '../config';
 import { AppError } from '../middleware/error.middleware';
 import { logger } from '../utils/logger';
-import * as auditService from './audit.service';
+import * as cache from '../utils/cacheClient';
 
 const log = logger.child('crypto');
 
@@ -13,37 +13,45 @@ const IV_LENGTH = 16;
 const KEY_LENGTH = 32;
 const SALT_LENGTH = 32;
 
-// In-memory vault store: userId -> VaultSession
+// In-memory vault store (local fallback): userId -> VaultSession
 const vaultStore = new Map<string, VaultSession>();
 
-// In-memory vault recovery store: userId -> server-encrypted master key.
+// In-memory vault recovery store (local fallback): userId -> server-encrypted master key.
 // Allows MFA-based re-unlock after vault TTL expiry without the user's password.
 // Cleared on logout, password change, or server restart.
 const vaultRecoveryStore = new Map<string, { encryptedKey: EncryptedField; expiresAt: number }>();
 
-// In-memory team vault store: "${teamId}:${userId}" -> decrypted team master key
+// In-memory team vault store (local fallback): "${teamId}:${userId}" -> decrypted team master key
 const teamVaultStore = new Map<string, { teamKey: Buffer; expiresAt: number }>();
 
-// In-memory tenant vault store: "${tenantId}:${userId}" -> decrypted tenant master key
+// In-memory tenant vault store (local fallback): "${tenantId}:${userId}" -> decrypted tenant master key
 const tenantVaultStore = new Map<string, { tenantKey: Buffer; expiresAt: number }>();
 
-// Cleanup expired sessions every minute
+// --- Cache index helpers (for prefix-based cleanup without scan) ---
+
+async function addToIndex(indexKey: string, value: string): Promise<void> {
+  const buf = await cache.get(indexKey);
+  const arr: string[] = buf ? JSON.parse(buf.toString()) : [];
+  if (!arr.includes(value)) arr.push(value);
+  await cache.set(indexKey, JSON.stringify(arr));
+}
+
+async function removeFromIndex(indexKey: string, value: string): Promise<void> {
+  const buf = await cache.get(indexKey);
+  if (!buf) return;
+  const arr: string[] = JSON.parse(buf.toString()).filter((v: string) => v !== value);
+  if (arr.length > 0) await cache.set(indexKey, JSON.stringify(arr));
+  else await cache.del(indexKey);
+}
+
+// Simplified local-only cleanup every minute.
+// Cache TTL handles expiry for cross-instance entries.
 setInterval(() => {
   const now = Date.now();
   for (const [userId, session] of vaultStore.entries()) {
-    if (session.expiresAt < now) {
-      session.masterKey.fill(0); // zero out the key
+    if (session.expiresAt !== Infinity && session.expiresAt < now) {
+      session.masterKey.fill(0);
       vaultStore.delete(userId);
-      // Soft lock: keep recovery entry so MFA can re-unlock
-      lockUserTeamVaults(userId);
-      lockUserTenantVaults(userId);
-      auditService.log({
-        userId,
-        action: 'VAULT_AUTO_LOCK',
-        targetType: 'User',
-        targetId: userId,
-        details: { reason: 'ttl_expired' },
-      });
     }
   }
   for (const [key, session] of teamVaultStore.entries()) {
@@ -117,12 +125,12 @@ export function decrypt(field: EncryptedField, key: Buffer): string {
   return plaintext;
 }
 
-export function requireMasterKey(
+export async function requireMasterKey(
   userId: string,
   message = 'Vault is locked. Please unlock it first.',
   statusCode = 403
-): Buffer {
-  const key = getMasterKey(userId);
+): Promise<Buffer> {
+  const key = await getMasterKey(userId);
   if (!key) throw new AppError(message, statusCode);
   return key;
 }
@@ -223,40 +231,72 @@ export function decryptWithServerKey(field: EncryptedField): string {
 export function storeVaultSession(userId: string, masterKey: Buffer, ttlMinutes?: number): void {
   const effective = ttlMinutes ?? config.vaultTtlMinutes;
   const expiresAt = effective === 0 ? Infinity : Date.now() + effective * 60 * 1000;
+  // Local map (sync, immediate)
   vaultStore.set(userId, {
     masterKey: Buffer.from(masterKey), // copy the buffer
     expiresAt,
   });
+  // Cache (async, fire-and-forget)
+  if (config.cacheSidecarEnabled && effective !== 0) {
+    const ttlMs = effective * 60 * 1000;
+    const encrypted = encrypt(masterKey.toString('hex'), config.serverEncryptionKey);
+    cache.set(`vault:user:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+  }
   log.debug(`Vault session stored for user ${userId} (TTL ${effective === 0 ? 'never' : effective + 'm'})`);
 }
 
-export function getVaultSession(userId: string): VaultSession | null {
-  const session = vaultStore.get(userId);
-  if (!session) return null;
+export async function getVaultSession(userId: string): Promise<VaultSession | null> {
+  // Check local map first (fast path)
+  const local = vaultStore.get(userId);
+  if (local) {
+    if (local.expiresAt !== Infinity && local.expiresAt < Date.now()) {
+      local.masterKey.fill(0);
+      vaultStore.delete(userId);
+      // Fall through to cache check
+    } else {
+      // Sliding window: reset TTL on every successful access (skip for "never" sessions)
+      if (local.expiresAt !== Infinity) {
+        const ttlMs = config.vaultTtlMinutes * 60 * 1000;
+        local.expiresAt = Date.now() + ttlMs;
+        // Refresh cache TTL (fire-and-forget)
+        if (config.cacheSidecarEnabled) {
+          const encrypted = encrypt(local.masterKey.toString('hex'), config.serverEncryptionKey);
+          cache.set(`vault:user:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+        }
+      }
+      return local;
+    }
+  }
 
-  if (session.expiresAt !== Infinity && session.expiresAt < Date.now()) {
-    session.masterKey.fill(0);
-    vaultStore.delete(userId);
+  // Cache fallback (cross-instance)
+  if (!config.cacheSidecarEnabled) return null;
+  const buf = await cache.get(`vault:user:${userId}`);
+  if (!buf) return null;
+  try {
+    const encrypted = JSON.parse(buf.toString()) as EncryptedField;
+    const hex = decrypt(encrypted, config.serverEncryptionKey);
+    const masterKey = Buffer.from(hex, 'hex');
+    const ttlMs = config.vaultTtlMinutes * 60 * 1000;
+    const session: VaultSession = { masterKey, expiresAt: Date.now() + ttlMs };
+    // Hydrate local map
+    vaultStore.set(userId, { masterKey: Buffer.from(masterKey), expiresAt: session.expiresAt });
+    // Refresh cache TTL (sliding window)
+    cache.set(`vault:user:${userId}`, buf.toString(), { ttl: ttlMs }).catch(() => {});
+    return session;
+  } catch {
     return null;
   }
-
-  // Sliding window: reset TTL on every successful access (skip for "never" sessions)
-  if (session.expiresAt !== Infinity) {
-    const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-    session.expiresAt = Date.now() + ttlMs;
-  }
-
-  return session;
 }
 
-export function getMasterKey(userId: string): Buffer | null {
-  const session = getVaultSession(userId);
+export async function getMasterKey(userId: string): Promise<Buffer | null> {
+  const session = await getVaultSession(userId);
   return session?.masterKey ?? null;
 }
 
 // Hard lock: clears vault session, team/tenant vaults, AND recovery entry.
 // Used by logout and password change.
 export function lockVault(userId: string): void {
+  // Sync local operations
   const session = vaultStore.get(userId);
   if (session) {
     session.masterKey.fill(0);
@@ -266,11 +306,19 @@ export function lockVault(userId: string): void {
   clearVaultRecovery(userId);
   lockUserTeamVaults(userId);
   lockUserTenantVaults(userId);
+  // Async cache cleanup (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.del(`vault:user:${userId}`).catch(() => {});
+    cache.del(`vault:recovery:${userId}`).catch(() => {});
+    // Publish vault lock event
+    cache.publish('vault:status', JSON.stringify({ userId, unlocked: false })).catch(() => {});
+  }
 }
 
 // Soft lock: clears vault session and team/tenant vaults but keeps
 // the recovery entry so MFA can re-unlock without the password.
 export function softLockVault(userId: string): void {
+  // Sync local operations
   const session = vaultStore.get(userId);
   if (session) {
     session.masterKey.fill(0);
@@ -279,46 +327,89 @@ export function softLockVault(userId: string): void {
   }
   lockUserTeamVaults(userId);
   lockUserTenantVaults(userId);
+  // Async cache cleanup (fire-and-forget) — keep recovery entry
+  if (config.cacheSidecarEnabled) {
+    cache.del(`vault:user:${userId}`).catch(() => {});
+    cache.publish('vault:status', JSON.stringify({ userId, unlocked: false })).catch(() => {});
+  }
 }
 
-export function isVaultUnlocked(userId: string): boolean {
-  return getVaultSession(userId) !== null;
+export async function isVaultUnlocked(userId: string): Promise<boolean> {
+  return (await getVaultSession(userId)) !== null;
 }
 
 // Vault recovery management (MFA-based re-unlock)
 
 export function storeVaultRecovery(userId: string, masterKey: Buffer): void {
   const encryptedKey = encrypt(masterKey.toString('hex'), config.serverEncryptionKey);
+  // Local map (sync, immediate)
   vaultRecoveryStore.set(userId, {
     encryptedKey,
     expiresAt: Date.now() + config.vaultRecoveryTtlMs,
   });
+  // Cache (async, fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.set(
+      `vault:recovery:${userId}`,
+      JSON.stringify(encryptedKey),
+      { ttl: config.vaultRecoveryTtlMs },
+    ).catch(() => {});
+  }
   log.debug(`Vault recovery stored for user ${userId}`);
 }
 
-export function getVaultRecovery(userId: string): Buffer | null {
+export async function getVaultRecovery(userId: string): Promise<Buffer | null> {
+  // Check local map first
   const entry = vaultRecoveryStore.get(userId);
-  if (!entry) return null;
-  if (entry.expiresAt < Date.now()) {
-    vaultRecoveryStore.delete(userId);
+  if (entry) {
+    if (entry.expiresAt < Date.now()) {
+      vaultRecoveryStore.delete(userId);
+      // Fall through to cache check
+    } else {
+      const hex = decrypt(entry.encryptedKey, config.serverEncryptionKey);
+      return Buffer.from(hex, 'hex');
+    }
+  }
+  // Cache fallback (cross-instance)
+  if (!config.cacheSidecarEnabled) return null;
+  const buf = await cache.get(`vault:recovery:${userId}`);
+  if (!buf) return null;
+  try {
+    const encryptedKey = JSON.parse(buf.toString()) as EncryptedField;
+    const hex = decrypt(encryptedKey, config.serverEncryptionKey);
+    // Hydrate local map
+    vaultRecoveryStore.set(userId, {
+      encryptedKey,
+      expiresAt: Date.now() + config.vaultRecoveryTtlMs,
+    });
+    return Buffer.from(hex, 'hex');
+  } catch {
     return null;
   }
-  const hex = decrypt(entry.encryptedKey, config.serverEncryptionKey);
-  return Buffer.from(hex, 'hex');
 }
 
-export function hasVaultRecovery(userId: string): boolean {
+export async function hasVaultRecovery(userId: string): Promise<boolean> {
+  // Check local map first
   const entry = vaultRecoveryStore.get(userId);
-  if (!entry) return false;
-  if (entry.expiresAt < Date.now()) {
-    vaultRecoveryStore.delete(userId);
-    return false;
+  if (entry) {
+    if (entry.expiresAt < Date.now()) {
+      vaultRecoveryStore.delete(userId);
+      // Fall through to cache check
+    } else {
+      return true;
+    }
   }
-  return true;
+  // Cache fallback
+  if (!config.cacheSidecarEnabled) return false;
+  const buf = await cache.get(`vault:recovery:${userId}`);
+  return buf !== null;
 }
 
 export function clearVaultRecovery(userId: string): void {
   vaultRecoveryStore.delete(userId);
+  if (config.cacheSidecarEnabled) {
+    cache.del(`vault:recovery:${userId}`).catch(() => {});
+  }
 }
 
 // Team vault session management
@@ -338,45 +429,102 @@ export function decryptTeamKey(encryptedField: EncryptedField, userMasterKey: Bu
 
 export function storeTeamVaultSession(teamId: string, userId: string, teamKey: Buffer): void {
   const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-  const key = `${teamId}:${userId}`;
-  teamVaultStore.set(key, {
+  const mapKey = `${teamId}:${userId}`;
+  // Local map (sync, immediate)
+  teamVaultStore.set(mapKey, {
     teamKey: Buffer.from(teamKey), // defensive copy
     expiresAt: Date.now() + ttlMs,
   });
+  // Cache (async, fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    const encrypted = encrypt(teamKey.toString('hex'), config.serverEncryptionKey);
+    cache.set(`vault:team:${teamId}:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+    // Update indexes for prefix-based cleanup
+    addToIndex(`vault:team-idx:${teamId}`, userId).catch(() => {});
+    addToIndex(`vault:user-teams:${userId}`, teamId).catch(() => {});
+  }
 }
 
-export function getTeamMasterKey(teamId: string, userId: string): Buffer | null {
-  const key = `${teamId}:${userId}`;
-  const session = teamVaultStore.get(key);
-  if (!session) return null;
-
-  if (session.expiresAt < Date.now()) {
-    session.teamKey.fill(0);
-    teamVaultStore.delete(key);
+export async function getTeamMasterKey(teamId: string, userId: string): Promise<Buffer | null> {
+  const mapKey = `${teamId}:${userId}`;
+  // Check local map first (fast path)
+  const session = teamVaultStore.get(mapKey);
+  if (session) {
+    if (session.expiresAt < Date.now()) {
+      session.teamKey.fill(0);
+      teamVaultStore.delete(mapKey);
+      // Fall through to cache check
+    } else {
+      // Sliding window
+      const ttlMs = config.vaultTtlMinutes * 60 * 1000;
+      session.expiresAt = Date.now() + ttlMs;
+      if (config.cacheSidecarEnabled) {
+        const encrypted = encrypt(session.teamKey.toString('hex'), config.serverEncryptionKey);
+        cache.set(`vault:team:${teamId}:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+      }
+      return session.teamKey;
+    }
+  }
+  // Cache fallback (cross-instance)
+  if (!config.cacheSidecarEnabled) return null;
+  const buf = await cache.get(`vault:team:${teamId}:${userId}`);
+  if (!buf) return null;
+  try {
+    const encrypted = JSON.parse(buf.toString()) as EncryptedField;
+    const hex = decrypt(encrypted, config.serverEncryptionKey);
+    const teamKey = Buffer.from(hex, 'hex');
+    const ttlMs = config.vaultTtlMinutes * 60 * 1000;
+    // Hydrate local map
+    teamVaultStore.set(mapKey, { teamKey: Buffer.from(teamKey), expiresAt: Date.now() + ttlMs });
+    // Refresh cache TTL (sliding window)
+    cache.set(`vault:team:${teamId}:${userId}`, buf.toString(), { ttl: ttlMs }).catch(() => {});
+    return teamKey;
+  } catch {
     return null;
   }
-
-  // Sliding window: reset TTL on every successful access
-  const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-  session.expiresAt = Date.now() + ttlMs;
-  return session.teamKey;
 }
 
 export function lockTeamVault(teamId: string): void {
+  // Sync local cleanup
   for (const [key, session] of teamVaultStore.entries()) {
     if (key.startsWith(`${teamId}:`)) {
       session.teamKey.fill(0);
       teamVaultStore.delete(key);
     }
   }
+  // Async cache cleanup via index (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.get(`vault:team-idx:${teamId}`).then(async (buf) => {
+      if (!buf) return;
+      const userIds: string[] = JSON.parse(buf.toString());
+      for (const uid of userIds) {
+        await cache.del(`vault:team:${teamId}:${uid}`);
+        removeFromIndex(`vault:user-teams:${uid}`, teamId).catch(() => {});
+      }
+      await cache.del(`vault:team-idx:${teamId}`);
+    }).catch(() => {});
+  }
 }
 
 export function lockUserTeamVaults(userId: string): void {
+  // Sync local cleanup
   for (const [key, session] of teamVaultStore.entries()) {
     if (key.endsWith(`:${userId}`)) {
       session.teamKey.fill(0);
       teamVaultStore.delete(key);
     }
+  }
+  // Async cache cleanup via reverse index (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.get(`vault:user-teams:${userId}`).then(async (buf) => {
+      if (!buf) return;
+      const teamIds: string[] = JSON.parse(buf.toString());
+      for (const tid of teamIds) {
+        await cache.del(`vault:team:${tid}:${userId}`);
+        removeFromIndex(`vault:team-idx:${tid}`, userId).catch(() => {});
+      }
+      await cache.del(`vault:user-teams:${userId}`);
+    }).catch(() => {});
   }
 }
 
@@ -397,45 +545,102 @@ export function decryptTenantKey(encryptedField: EncryptedField, userMasterKey: 
 
 export function storeTenantVaultSession(tenantId: string, userId: string, tenantKey: Buffer): void {
   const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-  const key = `${tenantId}:${userId}`;
-  tenantVaultStore.set(key, {
+  const mapKey = `${tenantId}:${userId}`;
+  // Local map (sync, immediate)
+  tenantVaultStore.set(mapKey, {
     tenantKey: Buffer.from(tenantKey), // defensive copy
     expiresAt: Date.now() + ttlMs,
   });
+  // Cache (async, fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    const encrypted = encrypt(tenantKey.toString('hex'), config.serverEncryptionKey);
+    cache.set(`vault:tenant:${tenantId}:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+    // Update indexes for prefix-based cleanup
+    addToIndex(`vault:tenant-idx:${tenantId}`, userId).catch(() => {});
+    addToIndex(`vault:user-tenants:${userId}`, tenantId).catch(() => {});
+  }
 }
 
-export function getTenantMasterKey(tenantId: string, userId: string): Buffer | null {
-  const key = `${tenantId}:${userId}`;
-  const session = tenantVaultStore.get(key);
-  if (!session) return null;
-
-  if (session.expiresAt < Date.now()) {
-    session.tenantKey.fill(0);
-    tenantVaultStore.delete(key);
+export async function getTenantMasterKey(tenantId: string, userId: string): Promise<Buffer | null> {
+  const mapKey = `${tenantId}:${userId}`;
+  // Check local map first (fast path)
+  const session = tenantVaultStore.get(mapKey);
+  if (session) {
+    if (session.expiresAt < Date.now()) {
+      session.tenantKey.fill(0);
+      tenantVaultStore.delete(mapKey);
+      // Fall through to cache check
+    } else {
+      // Sliding window
+      const ttlMs = config.vaultTtlMinutes * 60 * 1000;
+      session.expiresAt = Date.now() + ttlMs;
+      if (config.cacheSidecarEnabled) {
+        const encrypted = encrypt(session.tenantKey.toString('hex'), config.serverEncryptionKey);
+        cache.set(`vault:tenant:${tenantId}:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+      }
+      return session.tenantKey;
+    }
+  }
+  // Cache fallback (cross-instance)
+  if (!config.cacheSidecarEnabled) return null;
+  const buf = await cache.get(`vault:tenant:${tenantId}:${userId}`);
+  if (!buf) return null;
+  try {
+    const encrypted = JSON.parse(buf.toString()) as EncryptedField;
+    const hex = decrypt(encrypted, config.serverEncryptionKey);
+    const tenantKey = Buffer.from(hex, 'hex');
+    const ttlMs = config.vaultTtlMinutes * 60 * 1000;
+    // Hydrate local map
+    tenantVaultStore.set(mapKey, { tenantKey: Buffer.from(tenantKey), expiresAt: Date.now() + ttlMs });
+    // Refresh cache TTL (sliding window)
+    cache.set(`vault:tenant:${tenantId}:${userId}`, buf.toString(), { ttl: ttlMs }).catch(() => {});
+    return tenantKey;
+  } catch {
     return null;
   }
-
-  // Sliding window: reset TTL on every successful access
-  const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-  session.expiresAt = Date.now() + ttlMs;
-  return session.tenantKey;
 }
 
 export function lockTenantVault(tenantId: string): void {
+  // Sync local cleanup
   for (const [key, session] of tenantVaultStore.entries()) {
     if (key.startsWith(`${tenantId}:`)) {
       session.tenantKey.fill(0);
       tenantVaultStore.delete(key);
     }
   }
+  // Async cache cleanup via index (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.get(`vault:tenant-idx:${tenantId}`).then(async (buf) => {
+      if (!buf) return;
+      const userIds: string[] = JSON.parse(buf.toString());
+      for (const uid of userIds) {
+        await cache.del(`vault:tenant:${tenantId}:${uid}`);
+        removeFromIndex(`vault:user-tenants:${uid}`, tenantId).catch(() => {});
+      }
+      await cache.del(`vault:tenant-idx:${tenantId}`);
+    }).catch(() => {});
+  }
 }
 
 export function lockUserTenantVaults(userId: string): void {
+  // Sync local cleanup
   for (const [key, session] of tenantVaultStore.entries()) {
     if (key.endsWith(`:${userId}`)) {
       session.tenantKey.fill(0);
       tenantVaultStore.delete(key);
     }
+  }
+  // Async cache cleanup via reverse index (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.get(`vault:user-tenants:${userId}`).then(async (buf) => {
+      if (!buf) return;
+      const tenantIds: string[] = JSON.parse(buf.toString());
+      for (const tid of tenantIds) {
+        await cache.del(`vault:tenant:${tid}:${userId}`);
+        removeFromIndex(`vault:tenant-idx:${tid}`, userId).catch(() => {});
+      }
+      await cache.del(`vault:user-tenants:${userId}`);
+    }).catch(() => {});
   }
 }
 

--- a/server/src/services/crypto.service.ts
+++ b/server/src/services/crypto.service.ts
@@ -13,8 +13,14 @@ const IV_LENGTH = 16;
 const KEY_LENGTH = 32;
 const SALT_LENGTH = 32;
 
-// In-memory vault store (local fallback): userId -> VaultSession
-const vaultStore = new Map<string, VaultSession>();
+// Extended local vault session with stored TTL for correct sliding window renewal.
+// We don't modify the shared VaultSession type — this is local-only.
+interface LocalVaultSession extends VaultSession {
+  ttlMs: number; // 0 = never expires
+}
+
+// In-memory vault store (local fallback): userId -> LocalVaultSession
+const vaultStore = new Map<string, LocalVaultSession>();
 
 // In-memory vault recovery store (local fallback): userId -> server-encrypted master key.
 // Allows MFA-based re-unlock after vault TTL expiry without the user's password.
@@ -22,12 +28,21 @@ const vaultStore = new Map<string, VaultSession>();
 const vaultRecoveryStore = new Map<string, { encryptedKey: EncryptedField; expiresAt: number }>();
 
 // In-memory team vault store (local fallback): "${teamId}:${userId}" -> decrypted team master key
-const teamVaultStore = new Map<string, { teamKey: Buffer; expiresAt: number }>();
+const teamVaultStore = new Map<string, { teamKey: Buffer; expiresAt: number; ttlMs: number }>();
 
 // In-memory tenant vault store (local fallback): "${tenantId}:${userId}" -> decrypted tenant master key
-const tenantVaultStore = new Map<string, { tenantKey: Buffer; expiresAt: number }>();
+const tenantVaultStore = new Map<string, { tenantKey: Buffer; expiresAt: number; ttlMs: number }>();
 
-// --- Cache index helpers (for prefix-based cleanup without scan) ---
+/**
+ * Cache index helpers for team/tenant vault cleanup.
+ *
+ * These perform non-atomic read-modify-write on JSON arrays. Concurrent
+ * writers can lose entries, but the impact is limited: a lost entry means
+ * a team/tenant vault session may persist in cache until its TTL expires
+ * (typically 30 minutes) rather than being cleaned up immediately on lock.
+ * This is an acceptable trade-off given the low frequency of concurrent
+ * team vault operations and the TTL safety net.
+ */
 
 async function addToIndex(indexKey: string, value: string): Promise<void> {
   const buf = await cache.get(indexKey);
@@ -230,11 +245,13 @@ export function decryptWithServerKey(field: EncryptedField): string {
 // ttlMinutes: undefined = server default, 0 = never, >0 = custom
 export function storeVaultSession(userId: string, masterKey: Buffer, ttlMinutes?: number): void {
   const effective = ttlMinutes ?? config.vaultTtlMinutes;
-  const expiresAt = effective === 0 ? Infinity : Date.now() + effective * 60 * 1000;
+  const ttlMs = effective === 0 ? 0 : effective * 60 * 1000;
+  const expiresAt = effective === 0 ? Infinity : Date.now() + ttlMs;
   // Local map (sync, immediate)
   vaultStore.set(userId, {
     masterKey: Buffer.from(masterKey), // copy the buffer
     expiresAt,
+    ttlMs,
   });
   // Cache (async, fire-and-forget)
   if (config.cacheSidecarEnabled && effective !== 0) {
@@ -255,13 +272,12 @@ export async function getVaultSession(userId: string): Promise<VaultSession | nu
       // Fall through to cache check
     } else {
       // Sliding window: reset TTL on every successful access (skip for "never" sessions)
-      if (local.expiresAt !== Infinity) {
-        const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-        local.expiresAt = Date.now() + ttlMs;
+      if (local.expiresAt !== Infinity && local.ttlMs > 0) {
+        local.expiresAt = Date.now() + local.ttlMs;
         // Refresh cache TTL (fire-and-forget)
         if (config.cacheSidecarEnabled) {
           const encrypted = encrypt(local.masterKey.toString('hex'), config.serverEncryptionKey);
-          cache.set(`vault:user:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+          cache.set(`vault:user:${userId}`, JSON.stringify(encrypted), { ttl: local.ttlMs }).catch(() => {});
         }
       }
       return local;
@@ -276,10 +292,11 @@ export async function getVaultSession(userId: string): Promise<VaultSession | nu
     const encrypted = JSON.parse(buf.toString()) as EncryptedField;
     const hex = decrypt(encrypted, config.serverEncryptionKey);
     const masterKey = Buffer.from(hex, 'hex');
+    // When hydrating from cache, original TTL is unknown; use server default
     const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-    const session: VaultSession = { masterKey, expiresAt: Date.now() + ttlMs };
+    const session: LocalVaultSession = { masterKey, expiresAt: Date.now() + ttlMs, ttlMs };
     // Hydrate local map
-    vaultStore.set(userId, { masterKey: Buffer.from(masterKey), expiresAt: session.expiresAt });
+    vaultStore.set(userId, { masterKey: Buffer.from(masterKey), expiresAt: session.expiresAt, ttlMs });
     // Refresh cache TTL (sliding window)
     cache.set(`vault:user:${userId}`, buf.toString(), { ttl: ttlMs }).catch(() => {});
     return session;
@@ -434,6 +451,7 @@ export function storeTeamVaultSession(teamId: string, userId: string, teamKey: B
   teamVaultStore.set(mapKey, {
     teamKey: Buffer.from(teamKey), // defensive copy
     expiresAt: Date.now() + ttlMs,
+    ttlMs,
   });
   // Cache (async, fire-and-forget)
   if (config.cacheSidecarEnabled) {
@@ -455,12 +473,11 @@ export async function getTeamMasterKey(teamId: string, userId: string): Promise<
       teamVaultStore.delete(mapKey);
       // Fall through to cache check
     } else {
-      // Sliding window
-      const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-      session.expiresAt = Date.now() + ttlMs;
+      // Sliding window: use stored ttlMs instead of config default
+      session.expiresAt = Date.now() + session.ttlMs;
       if (config.cacheSidecarEnabled) {
         const encrypted = encrypt(session.teamKey.toString('hex'), config.serverEncryptionKey);
-        cache.set(`vault:team:${teamId}:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+        cache.set(`vault:team:${teamId}:${userId}`, JSON.stringify(encrypted), { ttl: session.ttlMs }).catch(() => {});
       }
       return session.teamKey;
     }
@@ -474,8 +491,8 @@ export async function getTeamMasterKey(teamId: string, userId: string): Promise<
     const hex = decrypt(encrypted, config.serverEncryptionKey);
     const teamKey = Buffer.from(hex, 'hex');
     const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-    // Hydrate local map
-    teamVaultStore.set(mapKey, { teamKey: Buffer.from(teamKey), expiresAt: Date.now() + ttlMs });
+    // Hydrate local map (use server default TTL since original is unknown)
+    teamVaultStore.set(mapKey, { teamKey: Buffer.from(teamKey), expiresAt: Date.now() + ttlMs, ttlMs });
     // Refresh cache TTL (sliding window)
     cache.set(`vault:team:${teamId}:${userId}`, buf.toString(), { ttl: ttlMs }).catch(() => {});
     return teamKey;
@@ -550,6 +567,7 @@ export function storeTenantVaultSession(tenantId: string, userId: string, tenant
   tenantVaultStore.set(mapKey, {
     tenantKey: Buffer.from(tenantKey), // defensive copy
     expiresAt: Date.now() + ttlMs,
+    ttlMs,
   });
   // Cache (async, fire-and-forget)
   if (config.cacheSidecarEnabled) {
@@ -571,12 +589,11 @@ export async function getTenantMasterKey(tenantId: string, userId: string): Prom
       tenantVaultStore.delete(mapKey);
       // Fall through to cache check
     } else {
-      // Sliding window
-      const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-      session.expiresAt = Date.now() + ttlMs;
+      // Sliding window: use stored ttlMs instead of config default
+      session.expiresAt = Date.now() + session.ttlMs;
       if (config.cacheSidecarEnabled) {
         const encrypted = encrypt(session.tenantKey.toString('hex'), config.serverEncryptionKey);
-        cache.set(`vault:tenant:${tenantId}:${userId}`, JSON.stringify(encrypted), { ttl: ttlMs }).catch(() => {});
+        cache.set(`vault:tenant:${tenantId}:${userId}`, JSON.stringify(encrypted), { ttl: session.ttlMs }).catch(() => {});
       }
       return session.tenantKey;
     }
@@ -590,8 +607,8 @@ export async function getTenantMasterKey(tenantId: string, userId: string): Prom
     const hex = decrypt(encrypted, config.serverEncryptionKey);
     const tenantKey = Buffer.from(hex, 'hex');
     const ttlMs = config.vaultTtlMinutes * 60 * 1000;
-    // Hydrate local map
-    tenantVaultStore.set(mapKey, { tenantKey: Buffer.from(tenantKey), expiresAt: Date.now() + ttlMs });
+    // Hydrate local map (use server default TTL since original is unknown)
+    tenantVaultStore.set(mapKey, { tenantKey: Buffer.from(tenantKey), expiresAt: Date.now() + ttlMs, ttlMs });
     // Refresh cache TTL (sliding window)
     cache.set(`vault:tenant:${tenantId}:${userId}`, buf.toString(), { ttl: ttlMs }).catch(() => {});
     return tenantKey;

--- a/server/src/services/domain.service.ts
+++ b/server/src/services/domain.service.ts
@@ -41,7 +41,7 @@ export async function updateDomainProfile(
       data.domainPasswordTag = null;
     } else {
       // Encrypt domain password with vault master key
-      const masterKey = getMasterKey(userId);
+      const masterKey = await getMasterKey(userId);
       if (!masterKey) throw new AppError('Vault must be unlocked to set domain password', 403);
 
       const enc = encrypt(input.domainPassword, masterKey);
@@ -98,7 +98,7 @@ export async function resolveDomainCredentials(
 
   let password: string | null = null;
   if (user.encryptedDomainPassword && user.domainPasswordIV && user.domainPasswordTag) {
-    const masterKey = getMasterKey(userId);
+    const masterKey = await getMasterKey(userId);
     if (!masterKey) throw new AppError('Vault must be unlocked to access domain credentials', 403);
 
     const field: EncryptedField = {

--- a/server/src/services/gateway.service.ts
+++ b/server/src/services/gateway.service.ts
@@ -142,7 +142,7 @@ export async function createGateway(
 
   if (input.type === 'SSH_BASTION') {
     if (input.username || input.password || input.sshPrivateKey) {
-      const masterKey = requireMasterKey(userId);
+      const masterKey = await requireMasterKey(userId);
       if (input.username) {
         const enc = encrypt(input.username, masterKey);
         encData.encryptedUsername = enc.ciphertext;
@@ -251,7 +251,7 @@ export async function updateGateway(
     if (existing.type !== 'SSH_BASTION') {
       throw new AppError('Credentials can only be set for SSH_BASTION gateways', 400);
     }
-    const masterKey = requireMasterKey(userId);
+    const masterKey = await requireMasterKey(userId);
     if (input.username !== undefined) {
       const enc = encrypt(input.username, masterKey);
       data.encryptedUsername = enc.ciphertext;
@@ -367,7 +367,7 @@ export async function getGatewayCredentials(
     return { username: null, password: null, sshPrivateKey: null };
   }
 
-  const masterKey = requireMasterKey(userId);
+  const masterKey = await requireMasterKey(userId);
 
   const username =
     gateway.encryptedUsername && gateway.usernameIV && gateway.usernameTag

--- a/server/src/services/identityVerification.service.ts
+++ b/server/src/services/identityVerification.service.ts
@@ -218,7 +218,7 @@ export async function confirmVerification(
         },
       });
       if (!user) throw new AppError('User not found', 404);
-      const secret = getDecryptedSecret(user, userId);
+      const secret = await getDecryptedSecret(user, userId);
       if (!secret) throw new AppError('TOTP is not configured properly.', 400);
       valid = verifyTotpCode(secret, payload.code);
       break;

--- a/server/src/services/importExport.service.ts
+++ b/server/src/services/importExport.service.ts
@@ -76,7 +76,7 @@ async function prepareJsonExport(
   userId: string,
   includeCredentials: boolean
 ): Promise<unknown> {
-  const masterKey = includeCredentials ? getMasterKey(userId) : null;
+  const masterKey = includeCredentials ? await getMasterKey(userId) : null;
   if (includeCredentials && !masterKey) {
     throw new AppError('Vault is locked. Cannot export credentials.', 403);
   }
@@ -155,7 +155,7 @@ async function prepareCsvExport(
   userId: string,
   includeCredentials: boolean
 ): Promise<string> {
-  const masterKey = includeCredentials ? getMasterKey(userId) : null;
+  const masterKey = includeCredentials ? await getMasterKey(userId) : null;
   if (includeCredentials && !masterKey) {
     throw new AppError('Vault is locked. Cannot export credentials.', 403);
   }
@@ -251,7 +251,7 @@ export async function importConnectionsFromCsv(
   const { parseCSV } = await import('../utils/csvParser');
   const { headers, rows } = parseCSV(csvData);
 
-  const masterKey = getMasterKey(userId);
+  const masterKey = await getMasterKey(userId);
   if (!masterKey) {
     throw new AppError('Vault is locked. Cannot import connections with credentials.', 403);
   }
@@ -355,7 +355,7 @@ export async function importConnectionsFromJson(
   const { userId, tenantId, duplicateStrategy } = options;
   const result: ImportResult = { imported: 0, skipped: 0, failed: 0, errors: [] };
 
-  const masterKey = getMasterKey(userId);
+  const masterKey = await getMasterKey(userId);
   if (!masterKey) {
     throw new AppError('Vault is locked. Cannot import connections with credentials.', 403);
   }
@@ -457,7 +457,7 @@ export async function importConnectionsFromMremoteng(
   const { userId, tenantId, duplicateStrategy } = options;
   const result: ImportResult = { imported: 0, skipped: 0, failed: 0, errors: [] };
 
-  const masterKey = getMasterKey(userId);
+  const masterKey = await getMasterKey(userId);
   if (!masterKey) {
     throw new AppError('Vault is locked. Cannot import connections with credentials.', 403);
   }
@@ -544,7 +544,7 @@ export async function importConnectionsFromRdp(
   const { userId, tenantId, duplicateStrategy } = options;
   const result: ImportResult = { imported: 0, skipped: 0, failed: 0, errors: [] };
 
-  const masterKey = getMasterKey(userId);
+  const masterKey = await getMasterKey(userId);
   if (!masterKey) {
     throw new AppError('Vault is locked. Cannot import connections with credentials.', 403);
   }

--- a/server/src/services/permission.service.ts
+++ b/server/src/services/permission.service.ts
@@ -353,7 +353,7 @@ export async function resolveEncryptionKey(
   if (teamId) {
     return resolveTeamKey(teamId, userId);
   }
-  const key = getMasterKey(userId);
+  const key = await getMasterKey(userId);
   if (!key) throw new AppError('Vault is locked. Please unlock it first.', 403);
   return key;
 }

--- a/server/src/services/secret.service.ts
+++ b/server/src/services/secret.service.ts
@@ -61,11 +61,11 @@ export interface SecretListFilters {
 
 export async function resolveTenantKey(tenantId: string, userId: string): Promise<Buffer> {
   // Try cache first
-  const cached = getCachedTenantKey(tenantId, userId);
+  const cached = await getCachedTenantKey(tenantId, userId);
   if (cached) return cached;
 
   // Get user's personal master key
-  const userMasterKey = requireMasterKey(userId);
+  const userMasterKey = await requireMasterKey(userId);
 
   // Load from DB and decrypt
   const membership = await prisma.tenantVaultMember.findUnique({
@@ -98,7 +98,7 @@ export async function resolveSecretEncryptionKey(
 ): Promise<Buffer> {
   switch (scope) {
     case 'PERSONAL': {
-      return requireMasterKey(userId);
+      return await requireMasterKey(userId);
     }
     case 'TEAM': {
       if (!teamId) throw new AppError('teamId is required for team-scoped secrets', 400);
@@ -123,7 +123,7 @@ export async function initTenantVault(
     throw new AppError('Tenant vault is already initialized', 400);
   }
 
-  const initiatorMasterKey = requireMasterKey(initiatorUserId);
+  const initiatorMasterKey = await requireMasterKey(initiatorUserId);
 
   const tenantKey = generateTenantMasterKey();
   const encKeyForInitiator = encryptTenantKey(tenantKey, initiatorMasterKey);
@@ -153,7 +153,7 @@ export async function initTenantVault(
 
     // Distribute to other users whose vaults are currently unlocked
     for (const user of tenantUsers) {
-      const userMasterKey = getMasterKey(user.id);
+      const userMasterKey = await getMasterKey(user.id);
       if (userMasterKey) {
         const encKey = encryptTenantKey(tenantKey, userMasterKey);
         await tx.tenantVaultMember.create({
@@ -217,7 +217,7 @@ export async function distributeTenantKeyToUser(
   const tenantKey = await resolveTenantKey(tenantId, distributorUserId);
 
   // Check if target vault is unlocked
-  const targetMasterKey = getMasterKey(targetUserId);
+  const targetMasterKey = await getMasterKey(targetUserId);
 
   if (targetMasterKey) {
     // Direct distribution — target vault is open
@@ -266,7 +266,7 @@ export async function processPendingDistributions(userId: string): Promise<numbe
 
   if (pending.length === 0) return 0;
 
-  const userMasterKey = requireMasterKey(userId);
+  const userMasterKey = await requireMasterKey(userId);
   let processed = 0;
 
   for (const record of pending) {
@@ -480,7 +480,7 @@ export async function getSecret(
     });
     if (!sharedRecord) throw new AppError('Secret not found', 404);
 
-    const personalKey = requireMasterKey(userId);
+    const personalKey = await requireMasterKey(userId);
 
     const decryptedJson = decrypt(
       { ciphertext: sharedRecord.encryptedData, iv: sharedRecord.dataIV, tag: sharedRecord.dataTag },
@@ -869,7 +869,7 @@ export async function checkSecretBreach(
     });
     if (!sharedRecord) throw new AppError('Secret not found', 404);
 
-    const personalKey = requireMasterKey(userId);
+    const personalKey = await requireMasterKey(userId);
     decryptedJson = decrypt(
       { ciphertext: sharedRecord.encryptedData, iv: sharedRecord.dataIV, tag: sharedRecord.dataTag },
       personalKey

--- a/server/src/services/secretSharing.service.ts
+++ b/server/src/services/secretSharing.service.ts
@@ -37,7 +37,7 @@ export async function shareSecret(
 
   await assertShareableTenantBoundary(actingUserId, targetUser.id);
 
-  const targetKey = requireMasterKey(targetUser.id, 'Unable to share with this user at this time.', 400);
+  const targetKey = await requireMasterKey(targetUser.id, 'Unable to share with this user at this time.', 400);
 
   // Decrypt with scope-appropriate key and re-encrypt for target user
   const decryptionKey = await resolveSecretEncryptionKey(

--- a/server/src/services/sharing.service.ts
+++ b/server/src/services/sharing.service.ts
@@ -37,7 +37,7 @@ export async function shareConnection(
 
   await assertShareableTenantBoundary(actingUserId, targetUser.id);
 
-  const targetKey = requireMasterKey(targetUser.id, 'Unable to share with this user at this time.', 400);
+  const targetKey = await requireMasterKey(targetUser.id, 'Unable to share with this user at this time.', 400);
 
   // Vault-backed connections: credentials resolved at session time from the vault secret.
   // No inline credential re-encryption needed — the shared user must have access to the vault secret.
@@ -93,7 +93,7 @@ export async function shareConnection(
 
   const decryptionKey = connection.teamId
     ? await resolveTeamKey(connection.teamId, actingUserId)
-    : requireMasterKey(actingUserId);
+    : await requireMasterKey(actingUserId);
 
   const encUsername = reEncryptField(
     { ciphertext: connection.encryptedUsername, iv: connection.usernameIV, tag: connection.usernameTag },

--- a/server/src/services/team.service.ts
+++ b/server/src/services/team.service.ts
@@ -24,7 +24,7 @@ export async function createTeam(
   description?: string
 ) {
   // Require creator's vault to be unlocked
-  const userMasterKey = requireMasterKey(creatorUserId);
+  const userMasterKey = await requireMasterKey(creatorUserId);
 
   // Generate and encrypt the team master key
   const teamKey = generateTeamMasterKey();
@@ -220,11 +220,11 @@ export async function addMember(
   if (existing) throw new AppError('User is already a team member', 400);
 
   // Both vaults must be unlocked
-  const adderMasterKey = requireMasterKey(addedByUserId, 'Your vault is locked. Please unlock it first.');
-  const targetMasterKey = requireMasterKey(targetUserId, "Target user's vault is locked. They must unlock their vault first.");
+  const adderMasterKey = await requireMasterKey(addedByUserId, 'Your vault is locked. Please unlock it first.');
+  const targetMasterKey = await requireMasterKey(targetUserId, "Target user's vault is locked. They must unlock their vault first.");
 
   // Get team key: try cache first, then decrypt from DB
-  let teamKey = getCachedTeamKey(teamId, addedByUserId);
+  let teamKey = await getCachedTeamKey(teamId, addedByUserId);
   let decryptedFromDb = false;
 
   if (!teamKey) {
@@ -351,11 +351,11 @@ export async function updateMemberExpiry(
 
 export async function resolveTeamKey(teamId: string, userId: string): Promise<Buffer> {
   // Try cache first
-  const cached = getCachedTeamKey(teamId, userId);
+  const cached = await getCachedTeamKey(teamId, userId);
   if (cached) return cached;
 
   // Get user's personal master key
-  const userMasterKey = requireMasterKey(userId);
+  const userMasterKey = await requireMasterKey(userId);
 
   // Load from DB and decrypt
   const membership = await prisma.teamMember.findUnique({

--- a/server/src/services/totp.service.ts
+++ b/server/src/services/totp.service.ts
@@ -45,7 +45,7 @@ export function generateSetup(email: string): { secret: string; otpauthUri: stri
 }
 
 export async function storeSetupSecret(userId: string, secret: string): Promise<void> {
-  const masterKey = requireMasterKey(userId);
+  const masterKey = await requireMasterKey(userId);
   const enc = encrypt(secret, masterKey);
   await prisma.user.update({
     where: { id: userId },
@@ -72,7 +72,7 @@ export async function verifyAndEnable(userId: string, code: string): Promise<voi
   if (!user) throw new AppError('User not found', 404);
   if (user.totpEnabled) throw new AppError('2FA is already enabled', 400);
 
-  const masterKey = requireMasterKey(userId);
+  const masterKey = await requireMasterKey(userId);
   const secret = resolveSecret(user, masterKey);
   if (!secret) throw new AppError('2FA setup not initiated', 400);
 
@@ -107,7 +107,7 @@ export async function disable(userId: string, code: string): Promise<void> {
   if (!user) throw new AppError('User not found', 404);
   if (!user.totpEnabled) throw new AppError('2FA is not enabled', 400);
 
-  const masterKey = requireMasterKey(userId);
+  const masterKey = await requireMasterKey(userId);
   const secret = resolveSecret(user, masterKey);
   if (!secret) throw new AppError('2FA is not enabled', 400);
 
@@ -131,7 +131,7 @@ export async function disable(userId: string, code: string): Promise<void> {
  * Decrypt and return the TOTP secret for a given user.
  * Used by auth.service for login-time TOTP verification.
  */
-export function getDecryptedSecret(
+export async function getDecryptedSecret(
   user: {
     encryptedTotpSecret: string | null;
     totpSecretIV: string | null;
@@ -139,8 +139,8 @@ export function getDecryptedSecret(
     totpSecret: string | null;
   },
   userId: string,
-): string | null {
-  const masterKey = getMasterKey(userId);
+): Promise<string | null> {
+  const masterKey = await getMasterKey(userId);
   if (!masterKey) {
     // Vault not unlocked — fall back to legacy plaintext if available
     return user.totpSecret;

--- a/server/src/services/user.service.ts
+++ b/server/src/services/user.service.ts
@@ -242,7 +242,7 @@ export async function changePassword(
     identityVerification.consumeVerification(verificationId, userId, 'password-change');
 
     // Get master key from in-memory vault session (already unlocked)
-    const sessionKey = getMasterKey(userId);
+    const sessionKey = await getMasterKey(userId);
     if (!sessionKey) throw new AppError('Vault is locked. Please unlock it first.', 403);
     masterKey = Buffer.from(sessionKey);
   } else {

--- a/server/src/services/vault.service.ts
+++ b/server/src/services/vault.service.ts
@@ -22,6 +22,7 @@ import {
 import { verifyCode as verifyTotpCode, getDecryptedSecret } from './totp.service';
 import { AppError } from '../middleware/error.middleware';
 import { processPendingDistributions } from './secret.service';
+import * as cache from '../utils/cacheClient';
 
 // Resolve the effective vault auto-lock TTL for a user (in minutes, 0 = never)
 async function resolveVaultTtl(userId: string): Promise<number> {
@@ -78,6 +79,10 @@ export async function unlockVault(userId: string, password: string) {
     const ttl = await resolveVaultTtl(userId);
     storeVaultSession(userId, masterKey, ttl);
     storeVaultRecovery(userId, masterKey);
+    // Publish vault unlock event (fire-and-forget)
+    if (config.cacheSidecarEnabled) {
+      cache.publish('vault:status', JSON.stringify({ userId, unlocked: true })).catch(() => {});
+    }
     // Process any pending tenant vault key distributions
     processPendingDistributions(userId).catch(() => {/* non-blocking */});
     masterKey.fill(0);
@@ -91,12 +96,13 @@ export async function unlockVault(userId: string, password: string) {
 
 export function lockVault(userId: string) {
   softLockVault(userId);
+  // softLockVault already publishes vault:status event via cache
   return { unlocked: false };
 }
 
 export async function getVaultStatus(userId: string) {
-  const unlocked = checkVaultUnlocked(userId);
-  const recoveryAvailable = hasVaultRecovery(userId);
+  const unlocked = await checkVaultUnlocked(userId);
+  const recoveryAvailable = await hasVaultRecovery(userId);
 
   const user = await prisma.user.findUnique({
     where: { id: userId },
@@ -133,7 +139,7 @@ export async function getVaultStatus(userId: string) {
 // MFA-based vault unlock
 
 export async function unlockVaultWithTotp(userId: string, code: string) {
-  const masterKey = getVaultRecovery(userId);
+  const masterKey = await getVaultRecovery(userId);
   if (!masterKey) throw new AppError('MFA vault recovery unavailable. Please use your password.', 403);
 
   const user = await prisma.user.findUnique({
@@ -151,7 +157,7 @@ export async function unlockVaultWithTotp(userId: string, code: string) {
   // Temporarily store so getDecryptedSecret can access the master key
   const ttl = await resolveVaultTtl(userId);
   storeVaultSession(userId, masterKey, ttl);
-  const secret = getDecryptedSecret(user, userId);
+  const secret = await getDecryptedSecret(user, userId);
   if (!secret) {
     softLockVault(userId);
     masterKey.fill(0);
@@ -164,13 +170,17 @@ export async function unlockVaultWithTotp(userId: string, code: string) {
     throw new AppError('Invalid TOTP code', 401);
   }
 
+  // Publish vault unlock event (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.publish('vault:status', JSON.stringify({ userId, unlocked: true })).catch(() => {});
+  }
   processPendingDistributions(userId).catch(() => {/* non-blocking */});
   masterKey.fill(0);
   return { unlocked: true };
 }
 
 export async function requestVaultWebAuthnOptions(userId: string) {
-  if (!hasVaultRecovery(userId)) {
+  if (!(await hasVaultRecovery(userId))) {
     throw new AppError('MFA vault recovery unavailable. Please use your password.', 403);
   }
 
@@ -179,25 +189,29 @@ export async function requestVaultWebAuthnOptions(userId: string) {
 }
 
 export async function unlockVaultWithWebAuthn(userId: string, credential: Record<string, unknown>) {
-  if (!hasVaultRecovery(userId)) {
+  if (!(await hasVaultRecovery(userId))) {
     throw new AppError('MFA vault recovery unavailable. Please use your password.', 403);
   }
 
   const { verifyAuthentication } = await import('./webauthn.service');
   await verifyAuthentication(userId, credential as unknown as Parameters<typeof verifyAuthentication>[1]);
 
-  const masterKey = getVaultRecovery(userId);
+  const masterKey = await getVaultRecovery(userId);
   if (!masterKey) throw new AppError('MFA vault recovery unavailable. Please use your password.', 403);
 
   const ttl = await resolveVaultTtl(userId);
   storeVaultSession(userId, masterKey, ttl);
+  // Publish vault unlock event (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.publish('vault:status', JSON.stringify({ userId, unlocked: true })).catch(() => {});
+  }
   processPendingDistributions(userId).catch(() => {/* non-blocking */});
   masterKey.fill(0);
   return { unlocked: true };
 }
 
 export async function requestVaultSmsCode(userId: string) {
-  if (!hasVaultRecovery(userId)) {
+  if (!(await hasVaultRecovery(userId))) {
     throw new AppError('MFA vault recovery unavailable. Please use your password.', 403);
   }
 
@@ -214,7 +228,7 @@ export async function requestVaultSmsCode(userId: string) {
 }
 
 export async function unlockVaultWithSms(userId: string, code: string) {
-  const masterKey = getVaultRecovery(userId);
+  const masterKey = await getVaultRecovery(userId);
   if (!masterKey) throw new AppError('MFA vault recovery unavailable. Please use your password.', 403);
 
   const { verifyOtp } = await import('./smsOtp.service');
@@ -226,6 +240,10 @@ export async function unlockVaultWithSms(userId: string, code: string) {
 
   const ttl = await resolveVaultTtl(userId);
   storeVaultSession(userId, masterKey, ttl);
+  // Publish vault unlock event (fire-and-forget)
+  if (config.cacheSidecarEnabled) {
+    cache.publish('vault:status', JSON.stringify({ userId, unlocked: true })).catch(() => {});
+  }
   processPendingDistributions(userId).catch(() => {/* non-blocking */});
   masterKey.fill(0);
   return { unlocked: true };
@@ -300,7 +318,7 @@ export async function revealPassword(
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user) throw new AppError('User not found', 404);
 
-  let masterKey = getMasterKey(userId);
+  let masterKey = await getMasterKey(userId);
 
   if (!masterKey) {
     if (!user.vaultSalt || !user.encryptedVaultKey || !user.vaultKeyIV || !user.vaultKeyTag) {

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -5,6 +5,8 @@ import { verifyJwt } from '../utils/jwt';
 import { setupSshHandler } from './ssh.handler';
 import { setupNotificationHandler } from './notification.handler';
 import { setupGatewayMonitorHandler } from './gatewayMonitor.handler';
+import { createGoCacheAdapterFactory } from '../utils/cacheAdapter';
+import { logger } from '../utils/logger';
 
 export function setupSocketIO(httpServer: HttpServer): Server {
   const io = new Server(httpServer, {
@@ -13,6 +15,13 @@ export function setupSocketIO(httpServer: HttpServer): Server {
       methods: ['GET', 'POST'],
     },
   });
+
+  // Use distributed adapter when cache sidecar is available
+  const adapterFactory = createGoCacheAdapterFactory();
+  if (adapterFactory) {
+    io.adapter(adapterFactory);
+    logger.info('Socket.IO using GoCacheAdapter for cross-instance events');
+  }
 
   // Server-level auth middleware: reject unauthenticated connections
   // before they reach any namespace-specific middleware

--- a/server/src/utils/authCodeStore.ts
+++ b/server/src/utils/authCodeStore.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto';
+import * as cache from './cacheClient';
+import { config } from '../config';
 
 /**
  * Short-lived one-time authorization code store.
@@ -6,6 +8,10 @@ import crypto from 'crypto';
  * Used by OAuth/SAML callback flows to avoid putting access tokens
  * in URL parameters. The callback redirects with a one-time `code`
  * that the client exchanges via POST for the actual token data.
+ *
+ * When the cache sidecar is available, codes are stored in the
+ * distributed cache with TTL-based expiry. Falls back to an
+ * in-memory Map when the sidecar is unavailable.
  */
 
 export interface AuthCodeEntry {
@@ -21,11 +27,12 @@ export interface AuthCodeEntry {
   expiresAt: number;
 }
 
+/** In-memory fallback when the sidecar is unavailable */
 const authCodeStore = new Map<string, AuthCodeEntry>();
 
 const AUTH_CODE_TTL_MS = 60_000; // 60 seconds
 
-export function cleanupExpiredCodes(): void {
+function cleanupExpiredCodes(): void {
   const now = Date.now();
   for (const [code, entry] of authCodeStore) {
     if (entry.expiresAt <= now) authCodeStore.delete(code);
@@ -33,15 +40,40 @@ export function cleanupExpiredCodes(): void {
 }
 
 /** Generate a one-time code and store the token data with a 60-second TTL */
-export function generateAuthCode(data: Omit<AuthCodeEntry, 'expiresAt'>): string {
-  cleanupExpiredCodes();
+export async function generateAuthCode(data: Omit<AuthCodeEntry, 'expiresAt'>): Promise<string> {
   const code = crypto.randomBytes(32).toString('hex');
-  authCodeStore.set(code, { ...data, expiresAt: Date.now() + AUTH_CODE_TTL_MS });
+  const expiresAt = Date.now() + AUTH_CODE_TTL_MS;
+
+  if (config.cacheSidecarEnabled) {
+    const stored = await cache.set(
+      `auth:code:${code}`,
+      JSON.stringify({ ...data, expiresAt }),
+      { ttl: AUTH_CODE_TTL_MS },
+    );
+    if (stored) return code;
+  }
+
+  // Fallback to in-memory
+  cleanupExpiredCodes();
+  authCodeStore.set(code, { ...data, expiresAt });
   return code;
 }
 
 /** Consume a one-time code, returning the stored data or null if invalid/expired */
-export function consumeAuthCode(code: string): Omit<AuthCodeEntry, 'expiresAt'> | null {
+export async function consumeAuthCode(code: string): Promise<Omit<AuthCodeEntry, 'expiresAt'> | null> {
+  if (config.cacheSidecarEnabled) {
+    const buf = await cache.getdel(`auth:code:${code}`);
+    if (buf) {
+      const entry: AuthCodeEntry = JSON.parse(buf.toString());
+      if (entry.expiresAt <= Date.now()) return null;
+      const { expiresAt: _, ...data } = entry;
+      return data;
+    }
+    // If cache returned null, try in-memory fallback (code may have been stored
+    // there if sidecar was temporarily unavailable at generation time)
+  }
+
+  // In-memory fallback
   cleanupExpiredCodes();
   const entry = authCodeStore.get(code);
   if (!entry) return null;

--- a/server/src/utils/cache.proto
+++ b/server/src/utils/cache.proto
@@ -1,0 +1,187 @@
+syntax = "proto3";
+
+package cache;
+
+option go_package = "github.com/dnviti/arsenale/infrastructure/gocache/proto";
+
+// CacheService exposes KV, PubSub, Locks, and Queue over gRPC.
+service CacheService {
+  // KV operations
+  rpc Get(GetRequest) returns (GetResponse);
+  rpc Set(SetRequest) returns (SetResponse);
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
+  rpc Incr(IncrRequest) returns (IncrResponse);
+  rpc GetDel(GetDelRequest) returns (GetDelResponse);
+
+  // PubSub
+  rpc Publish(PublishRequest) returns (PublishResponse);
+  rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
+
+  // Distributed Locks
+  rpc AcquireLock(AcquireLockRequest) returns (AcquireLockResponse);
+  rpc ReleaseLock(ReleaseLockRequest) returns (ReleaseLockResponse);
+  rpc RenewLock(RenewLockRequest) returns (RenewLockResponse);
+
+  // Queue
+  rpc Enqueue(EnqueueRequest) returns (EnqueueResponse);
+  rpc Dequeue(DequeueRequest) returns (DequeueResponse);
+
+  // Internal peer replication
+  rpc ReplicateKV(stream ReplicateKVRequest) returns (ReplicateKVResponse);
+  rpc ReplicatePubSub(stream ReplicatePubSubRequest) returns (ReplicatePubSubResponse);
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+}
+
+// KV Messages
+
+message GetRequest {
+  string key = 1;
+}
+
+message GetResponse {
+  bytes value = 1;
+  bool found = 2;
+}
+
+message SetRequest {
+  string key = 1;
+  bytes value = 2;
+  int64 ttl_ms = 3; // 0 means no expiry
+}
+
+message SetResponse {
+  bool ok = 1;
+}
+
+message DeleteRequest {
+  string key = 1;
+}
+
+message DeleteResponse {
+  bool deleted = 1;
+}
+
+message IncrRequest {
+  string key = 1;
+  int64 delta = 2;
+}
+
+message IncrResponse {
+  int64 value = 1;
+}
+
+message GetDelRequest {
+  string key = 1;
+}
+
+message GetDelResponse {
+  bytes value = 1;
+  bool found = 2;
+}
+
+// PubSub Messages
+
+message PublishRequest {
+  string channel = 1;
+  bytes message = 2;
+}
+
+message PublishResponse {
+  int32 receivers = 1;
+}
+
+message SubscribeRequest {
+  string channel = 1;
+  bool pattern = 2; // if true, treat channel as a glob pattern
+}
+
+message SubscribeResponse {
+  string channel = 1;
+  bytes message = 2;
+}
+
+// Lock Messages
+
+message AcquireLockRequest {
+  string name = 1;
+  int64 ttl_ms = 2;
+  string holder_id = 3;
+}
+
+message AcquireLockResponse {
+  bool acquired = 1;
+  uint64 fencing_token = 2;
+}
+
+message ReleaseLockRequest {
+  string name = 1;
+  string holder_id = 2;
+}
+
+message ReleaseLockResponse {
+  bool released = 1;
+}
+
+message RenewLockRequest {
+  string name = 1;
+  int64 ttl_ms = 2;
+  string holder_id = 3;
+}
+
+message RenewLockResponse {
+  bool renewed = 1;
+}
+
+// Queue Messages
+
+message EnqueueRequest {
+  string queue_name = 1;
+  bytes message = 2;
+}
+
+message EnqueueResponse {
+  bool ok = 1;
+}
+
+message DequeueRequest {
+  string queue_name = 1;
+  int64 timeout_ms = 2;
+}
+
+message DequeueResponse {
+  bytes message = 1;
+  bool found = 2;
+}
+
+// Replication Messages
+
+message ReplicateKVRequest {
+  string key = 1;
+  bytes value = 2;
+  int64 ttl_ms = 3;
+  bool deleted = 4;
+  uint64 timestamp = 5; // logical timestamp for LWW
+}
+
+message ReplicateKVResponse {
+  int32 applied = 1;
+}
+
+message ReplicatePubSubRequest {
+  string channel = 1;
+  bytes message = 2;
+}
+
+message ReplicatePubSubResponse {
+  int32 delivered = 1;
+}
+
+message HeartbeatRequest {
+  string peer_id = 1;
+  string address = 2;
+}
+
+message HeartbeatResponse {
+  string peer_id = 1;
+  bool ok = 2;
+}

--- a/server/src/utils/cache.proto
+++ b/server/src/utils/cache.proto
@@ -12,6 +12,7 @@ service CacheService {
   rpc Delete(DeleteRequest) returns (DeleteResponse);
   rpc Incr(IncrRequest) returns (IncrResponse);
   rpc GetDel(GetDelRequest) returns (GetDelResponse);
+  rpc Expire(ExpireRequest) returns (ExpireResponse);
 
   // PubSub
   rpc Publish(PublishRequest) returns (PublishResponse);
@@ -77,6 +78,15 @@ message GetDelRequest {
 message GetDelResponse {
   bytes value = 1;
   bool found = 2;
+}
+
+message ExpireRequest {
+  string key = 1;
+  int64 ttl_ms = 2;
+}
+
+message ExpireResponse {
+  bool ok = 1;
 }
 
 // PubSub Messages

--- a/server/src/utils/cacheAdapter.ts
+++ b/server/src/utils/cacheAdapter.ts
@@ -47,6 +47,7 @@ export function createGoCacheAdapterFactory(): ((nsp: { name: string }) => Adapt
 
 class GoCacheAdapter extends Adapter {
   private unsubscribe: (() => void) | null = null;
+  private closed = false;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(nsp: any) {
@@ -56,19 +57,23 @@ class GoCacheAdapter extends Adapter {
 
   private setupSubscription(): void {
     const channel = 'sio:*';
-    cache.subscribe(channel, (_ch: string, message: Buffer) => {
+    const expectedBroadcast = `sio:${this.nsp.name}`;
+    const expectedServer = `sio:server:${this.nsp.name}`;
+
+    const pending = cache.subscribe(channel, (ch: string, message: Buffer) => {
+      if (this.closed) return;
       try {
         const msg: AdapterMessage = JSON.parse(message.toString());
         // Skip messages from this instance
         if (msg.src === instanceId) return;
 
-        if (msg.type === 'broadcast') {
+        if (msg.type === 'broadcast' && ch === expectedBroadcast) {
           const opts = {
             rooms: new Set(msg.opts?.rooms ?? []),
             except: new Set(msg.opts?.except ?? []),
           };
           super.broadcast(msg.packet, opts);
-        } else if (msg.type === 'serverSideEmit') {
+        } else if (msg.type === 'serverSideEmit' && ch === expectedServer) {
           super.serverSideEmit(msg.packet);
         }
       } catch (err) {
@@ -77,8 +82,15 @@ class GoCacheAdapter extends Adapter {
           err instanceof Error ? err.message : 'Unknown error',
         );
       }
-    }, true).then((unsub) => {
-      this.unsubscribe = unsub;
+    }, true);
+
+    pending.then((unsub) => {
+      if (this.closed && unsub) {
+        // Already closed before subscription resolved — clean up immediately
+        unsub();
+      } else {
+        this.unsubscribe = unsub;
+      }
     }).catch((err) => {
       logger.warn(
         'GoCacheAdapter: subscription setup failed: %s',
@@ -123,6 +135,7 @@ class GoCacheAdapter extends Adapter {
   }
 
   close(): void {
+    this.closed = true;
     if (this.unsubscribe) {
       this.unsubscribe();
       this.unsubscribe = null;

--- a/server/src/utils/cacheAdapter.ts
+++ b/server/src/utils/cacheAdapter.ts
@@ -1,0 +1,131 @@
+/**
+ * Socket.IO cross-instance adapter backed by gocache pub/sub.
+ *
+ * When multiple Arsenale server instances share the same gocache sidecar,
+ * this adapter relays broadcast and serverSideEmit packets across instances
+ * so that connected clients on any node receive the events.
+ *
+ * Falls back to the default in-memory adapter when the sidecar is unavailable
+ * or when `config.cacheSidecarEnabled` is false.
+ */
+
+import { Adapter } from 'socket.io-adapter';
+import * as cache from './cacheClient';
+import { logger } from './logger';
+import { config } from '../config';
+
+const instanceId = `${process.pid}-${Date.now()}`;
+
+interface AdapterMessage {
+  /** Originating instance — used to skip self-echo */
+  src: string;
+  /** 'broadcast' | 'serverSideEmit' */
+  type: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  packet: any;
+  /** Serialized broadcast options (rooms + except as arrays) */
+  opts?: { rooms: string[]; except: string[] };
+}
+
+/**
+ * Returns a factory function (adapter constructor) for Socket.IO that uses
+ * gocache pub/sub for cross-instance event delivery.
+ *
+ * Returns `null` if the sidecar is disabled or unavailable — caller should
+ * fall back to the default in-memory adapter.
+ */
+export function createGoCacheAdapterFactory(): ((nsp: { name: string }) => Adapter) | null {
+  if (!config.cacheSidecarEnabled) {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function goCacheAdapterFactory(nsp: any): Adapter {
+    return new GoCacheAdapter(nsp);
+  };
+}
+
+class GoCacheAdapter extends Adapter {
+  private unsubscribe: (() => void) | null = null;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(nsp: any) {
+    super(nsp);
+    this.setupSubscription();
+  }
+
+  private setupSubscription(): void {
+    const channel = 'sio:*';
+    cache.subscribe(channel, (_ch: string, message: Buffer) => {
+      try {
+        const msg: AdapterMessage = JSON.parse(message.toString());
+        // Skip messages from this instance
+        if (msg.src === instanceId) return;
+
+        if (msg.type === 'broadcast') {
+          const opts = {
+            rooms: new Set(msg.opts?.rooms ?? []),
+            except: new Set(msg.opts?.except ?? []),
+          };
+          super.broadcast(msg.packet, opts);
+        } else if (msg.type === 'serverSideEmit') {
+          super.serverSideEmit(msg.packet);
+        }
+      } catch (err) {
+        logger.warn(
+          'GoCacheAdapter: failed to process message: %s',
+          err instanceof Error ? err.message : 'Unknown error',
+        );
+      }
+    }, true).then((unsub) => {
+      this.unsubscribe = unsub;
+    }).catch((err) => {
+      logger.warn(
+        'GoCacheAdapter: subscription setup failed: %s',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  broadcast(packet: any, opts: any): void {
+    const channel = `sio:${this.nsp.name}`;
+    const msg: AdapterMessage = {
+      src: instanceId,
+      type: 'broadcast',
+      packet,
+      opts: {
+        rooms: Array.from(opts?.rooms ?? []),
+        except: Array.from(opts?.except ?? []),
+      },
+    };
+    cache.publish(channel, Buffer.from(JSON.stringify(msg))).catch((err) => {
+      logger.warn(
+        'GoCacheAdapter: publish failed: %s',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    });
+    // Always deliver locally
+    super.broadcast(packet, opts);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  serverSideEmit(packet: any[]): void {
+    const channel = `sio:server:${this.nsp.name}`;
+    const msg: AdapterMessage = { src: instanceId, type: 'serverSideEmit', packet };
+    cache.publish(channel, Buffer.from(JSON.stringify(msg))).catch((err) => {
+      logger.warn(
+        'GoCacheAdapter: serverSideEmit publish failed: %s',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    });
+    super.serverSideEmit(packet);
+  }
+
+  close(): void {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+  }
+}

--- a/server/src/utils/cacheClient.ts
+++ b/server/src/utils/cacheClient.ts
@@ -1,15 +1,17 @@
 /**
  * TypeScript gRPC client for the gocache sidecar.
  *
- * Uses @grpc/proto-loader for dynamic proto loading — no code generation required.
+ * The Go sidecar uses a custom JSON codec (registered as "proto") so all gRPC
+ * messages are JSON-encoded, NOT standard protobuf binary. This client matches
+ * that by using a manual service definition with JSON serialize/deserialize.
+ *
  * Graceful fallback: if the sidecar is unavailable, operations return null/false
  * and log a warning rather than crashing the application.
  */
 
-import path from 'path';
 import { logger } from './logger';
 
-// Types are dynamically loaded, but we define the shape for TypeScript usage.
+// Types matching the gRPC service definition (JSON-encoded on the wire).
 interface CacheClient {
   Get(
     req: { key: string },
@@ -60,25 +62,16 @@ interface CacheClient {
 
 let client: CacheClient | null = null;
 let grpcModule: typeof import('@grpc/grpc-js') | null = null;
-let protoLoaderModule: typeof import('@grpc/proto-loader') | null = null;
 
 const SIDECAR_URL = process.env.CACHE_SIDECAR_URL || 'localhost:6380';
-// CACHE_PROTO_PATH allows overriding the proto file location for Docker/production
-// where the infrastructure/ directory is not available. Copy cache.proto into the
-// server build context or set this env var to the correct path.
-const DEFAULT_PROTO_PATH = path.resolve(__dirname, 'cache.proto');
-const PROTO_PATH = process.env.CACHE_PROTO_PATH
-  ? path.resolve(process.env.CACHE_PROTO_PATH)
-  : DEFAULT_PROTO_PATH;
 
 /**
  * Lazily loads gRPC dependencies. Returns false if packages are not installed.
  */
 async function loadGrpcModules(): Promise<boolean> {
-  if (grpcModule && protoLoaderModule) return true;
+  if (grpcModule) return true;
   try {
     grpcModule = await import('@grpc/grpc-js');
-    protoLoaderModule = await import('@grpc/proto-loader');
     return true;
   } catch {
     logger.warn('gRPC packages not installed — cache sidecar client unavailable');
@@ -86,33 +79,79 @@ async function loadGrpcModules(): Promise<boolean> {
   }
 }
 
+// --- JSON codec helpers ---
+// The Go sidecar registers a JSON codec under the name "proto", so all gRPC
+// messages are JSON-encoded. Go's encoding/json encodes []byte as base64.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function jsonRequestSerialize(value: any): Buffer {
+  const processed = { ...value };
+  for (const key of Object.keys(processed)) {
+    if (Buffer.isBuffer(processed[key])) {
+      processed[key] = processed[key].toString('base64');
+    }
+  }
+  return Buffer.from(JSON.stringify(processed));
+}
+
+function makeResponseDeserialize(bytesFields: string[]) {
+  return (buffer: Buffer) => {
+    const obj = JSON.parse(buffer.toString());
+    for (const field of bytesFields) {
+      if (typeof obj[field] === 'string' && obj[field]) {
+        obj[field] = Buffer.from(obj[field], 'base64');
+      }
+    }
+    return obj;
+  };
+}
+
+function makeMethodDef(
+  rpcPath: string,
+  responseStream: boolean,
+  bytesFields: string[],
+) {
+  return {
+    path: rpcPath,
+    requestStream: false,
+    responseStream,
+    requestSerialize: jsonRequestSerialize,
+    requestDeserialize: (buf: Buffer) => JSON.parse(buf.toString()),
+    responseSerialize: (value: unknown) => Buffer.from(JSON.stringify(value)),
+    responseDeserialize: makeResponseDeserialize(bytesFields),
+  };
+}
+
 /**
  * Returns the singleton cache client, creating it on first call.
- * Returns null if gRPC packages are not installed or the proto file is missing.
+ * Returns null if gRPC packages are not installed.
  */
 export async function getCacheClient(): Promise<CacheClient | null> {
   if (client) return client;
 
   const loaded = await loadGrpcModules();
-  if (!loaded || !grpcModule || !protoLoaderModule) return null;
+  if (!loaded || !grpcModule) return null;
 
   try {
-    const packageDefinition = await protoLoaderModule.load(PROTO_PATH, {
-      keepCase: true,
-      longs: Number,
-      enums: String,
-      defaults: true,
-      oneofs: true,
-    });
+    // Manual service definition with JSON serialization to match the Go sidecar's
+    // custom JSON codec (see infrastructure/gocache/codec.go).
+    const serviceDef = {
+      Get: makeMethodDef('/cache.CacheService/Get', false, ['value']),
+      Set: makeMethodDef('/cache.CacheService/Set', false, []),
+      Delete: makeMethodDef('/cache.CacheService/Delete', false, []),
+      Incr: makeMethodDef('/cache.CacheService/Incr', false, []),
+      GetDel: makeMethodDef('/cache.CacheService/GetDel', false, ['value']),
+      Publish: makeMethodDef('/cache.CacheService/Publish', false, []),
+      Subscribe: makeMethodDef('/cache.CacheService/Subscribe', true, ['message']),
+      AcquireLock: makeMethodDef('/cache.CacheService/AcquireLock', false, []),
+      ReleaseLock: makeMethodDef('/cache.CacheService/ReleaseLock', false, []),
+      RenewLock: makeMethodDef('/cache.CacheService/RenewLock', false, []),
+      Enqueue: makeMethodDef('/cache.CacheService/Enqueue', false, []),
+      Dequeue: makeMethodDef('/cache.CacheService/Dequeue', false, ['message']),
+    };
 
-    const proto = grpcModule.loadPackageDefinition(packageDefinition) as Record<string, unknown>;
-    const cachePackage = proto.cache as Record<string, unknown>;
-    const CacheService = cachePackage.CacheService as new (
-      address: string,
-      credentials: ReturnType<typeof import('@grpc/grpc-js').credentials.createInsecure>
-    ) => CacheClient;
-
-    client = new CacheService(SIDECAR_URL, grpcModule.credentials.createInsecure());
+    const CacheService = grpcModule.makeGenericClientConstructor(serviceDef, 'CacheService');
+    client = new CacheService(SIDECAR_URL, grpcModule.credentials.createInsecure()) as unknown as CacheClient;
     logger.info('Cache sidecar client connected to [REDACTED]');
     return client;
   } catch (err) {

--- a/server/src/utils/cacheClient.ts
+++ b/server/src/utils/cacheClient.ts
@@ -33,6 +33,10 @@ interface CacheClient {
     req: { key: string },
     callback: (err: Error | null, res: { value: Buffer; found: boolean }) => void
   ): void;
+  Expire(
+    req: { key: string; ttl_ms: number },
+    callback: (err: Error | null, res: { ok: boolean }) => void
+  ): void;
   Publish(
     req: { channel: string; message: Buffer },
     callback: (err: Error | null, res: { receivers: number }) => void
@@ -141,6 +145,7 @@ export async function getCacheClient(): Promise<CacheClient | null> {
       Delete: makeMethodDef('/cache.CacheService/Delete', false, []),
       Incr: makeMethodDef('/cache.CacheService/Incr', false, []),
       GetDel: makeMethodDef('/cache.CacheService/GetDel', false, ['value']),
+      Expire: makeMethodDef('/cache.CacheService/Expire', false, []),
       Publish: makeMethodDef('/cache.CacheService/Publish', false, []),
       Subscribe: makeMethodDef('/cache.CacheService/Subscribe', true, ['message']),
       AcquireLock: makeMethodDef('/cache.CacheService/AcquireLock', false, []),
@@ -234,6 +239,16 @@ export async function incr(key: string, delta = 1): Promise<number | null> {
   if (!c) return null;
   const res = await promisify(c.Incr, { key, delta }, c);
   return res?.value ?? null;
+}
+
+/**
+ * Set a TTL on an existing key. Returns true if the key existed.
+ */
+export async function expire(key: string, ttlMs: number): Promise<boolean> {
+  const c = await getCacheClient();
+  if (!c) return false;
+  const res = await promisify(c.Expire, { key, ttl_ms: ttlMs }, c);
+  return res?.ok ?? false;
 }
 
 /**

--- a/server/src/utils/leaderElection.ts
+++ b/server/src/utils/leaderElection.ts
@@ -44,10 +44,19 @@ export async function runIfLeader(
     return;
   }
 
+  let heartbeatTimer: NodeJS.Timeout | null = null;
   try {
+    // Renew lock periodically to prevent expiry during long-running fn()
+    const heartbeatInterval = Math.max(1000, Math.floor(ttlMs / 3));
+    heartbeatTimer = setInterval(() => {
+      cache.renewLock(lockName, ttlMs, result.holderId).catch((err) => {
+        logger.warn('Leader lock renew failed: %s', err instanceof Error ? err.message : 'Unknown error');
+      });
+    }, heartbeatInterval);
     await fn();
   } finally {
-    await cache.releaseLock(lockName, instanceId);
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    await cache.releaseLock(lockName, result.holderId);
   }
 }
 

--- a/server/src/utils/leaderElection.ts
+++ b/server/src/utils/leaderElection.ts
@@ -1,0 +1,99 @@
+/**
+ * Distributed leader election using gocache distributed locks.
+ *
+ * In a multi-instance deployment, only the leader instance should run
+ * scheduled jobs (cleanup, rotation, etc.) to prevent duplicate work.
+ *
+ * When the sidecar is unavailable, all functions fall back to
+ * single-instance behavior (every instance runs every job).
+ */
+
+import * as cache from './cacheClient';
+import { logger } from './logger';
+import { config } from '../config';
+
+export const instanceId = `node-${process.pid}-${Date.now()}`;
+
+/**
+ * Acquire a distributed lock, run the given function if acquired, and release
+ * the lock in the `finally` block.
+ *
+ * If the sidecar is unavailable or disabled, the function runs unconditionally
+ * (single-instance fallback).
+ */
+export async function runIfLeader(
+  lockName: string,
+  fn: () => Promise<void>,
+  ttlMs = 30_000,
+): Promise<void> {
+  if (!config.cacheSidecarEnabled) {
+    await fn();
+    return;
+  }
+
+  const result = await cache.acquireLock(lockName, ttlMs, instanceId);
+
+  // Sidecar unavailable — run anyway (single-instance fallback)
+  if (result === null) {
+    await fn();
+    return;
+  }
+
+  if (!result.acquired) {
+    // Another instance holds the lock — skip
+    return;
+  }
+
+  try {
+    await fn();
+  } finally {
+    await cache.releaseLock(lockName, instanceId);
+  }
+}
+
+/**
+ * Start a periodic heartbeat that renews a distributed lock, keeping this
+ * instance as the leader. Returns a `stop` function for cleanup on shutdown.
+ */
+export function startLeaderHeartbeat(
+  lockName: string,
+  ttlMs = 30_000,
+  intervalMs = 10_000,
+): { stop: () => void } {
+  if (!config.cacheSidecarEnabled) {
+    return { stop: () => {} };
+  }
+
+  // Try to acquire on first call
+  cache.acquireLock(lockName, ttlMs, instanceId).catch((err) => {
+    logger.warn(
+      'Leader heartbeat initial acquire failed: %s',
+      err instanceof Error ? err.message : 'Unknown error',
+    );
+  });
+
+  const timer = setInterval(() => {
+    cache.renewLock(lockName, ttlMs, instanceId).then((renewed) => {
+      if (!renewed) {
+        // Lost leadership — try to re-acquire
+        cache.acquireLock(lockName, ttlMs, instanceId).catch(() => {
+          // Ignore — another instance may hold the lock
+        });
+      }
+    }).catch((err) => {
+      logger.warn(
+        'Leader heartbeat renew failed: %s',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    });
+  }, intervalMs);
+
+  return {
+    stop: () => {
+      clearInterval(timer);
+      cache.releaseLock(lockName, instanceId).catch(() => {
+        // Best-effort release on shutdown
+      });
+    },
+  };
+}

--- a/server/src/utils/linkCodeStore.ts
+++ b/server/src/utils/linkCodeStore.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto';
+import * as cache from './cacheClient';
+import { config } from '../config';
 
 /**
  * Short-lived one-time link authorization code store.
@@ -7,6 +9,10 @@ import crypto from 'crypto';
  * in URL query parameters. The client first POSTs to get a one-time
  * `code` (via Axios with Authorization header), then redirects to
  * the link endpoint with `?code=...` instead of `?token=...`.
+ *
+ * When the cache sidecar is available, codes are stored in the
+ * distributed cache with TTL-based expiry. Falls back to an
+ * in-memory Map when the sidecar is unavailable.
  */
 
 export interface LinkCodeEntry {
@@ -14,27 +20,59 @@ export interface LinkCodeEntry {
   expiresAt: number;
 }
 
+/** In-memory fallback stores */
 const linkCodeStore = new Map<string, LinkCodeEntry>();
+const relayStateStore = new Map<string, LinkCodeEntry>();
 
 const LINK_CODE_TTL_MS = 60_000; // 60 seconds
+const RELAY_STATE_TTL_MS = 300_000; // 5 minutes — allows time for IdP authentication
 
-export function cleanupExpiredLinkCodes(): void {
+function cleanupExpiredLinkCodes(): void {
   const now = Date.now();
   for (const [code, entry] of linkCodeStore) {
     if (entry.expiresAt <= now) linkCodeStore.delete(code);
   }
 }
 
+function cleanupExpiredRelayCodes(): void {
+  const now = Date.now();
+  for (const [code, entry] of relayStateStore) {
+    if (entry.expiresAt <= now) relayStateStore.delete(code);
+  }
+}
+
 /** Generate a one-time code that maps to a userId, valid for 60 seconds */
-export function generateLinkCode(userId: string): string {
-  cleanupExpiredLinkCodes();
+export async function generateLinkCode(userId: string): Promise<string> {
   const code = crypto.randomBytes(32).toString('hex');
-  linkCodeStore.set(code, { userId, expiresAt: Date.now() + LINK_CODE_TTL_MS });
+  const expiresAt = Date.now() + LINK_CODE_TTL_MS;
+
+  if (config.cacheSidecarEnabled) {
+    const stored = await cache.set(
+      `link:code:${code}`,
+      JSON.stringify({ userId, expiresAt }),
+      { ttl: LINK_CODE_TTL_MS },
+    );
+    if (stored) return code;
+  }
+
+  // Fallback to in-memory
+  cleanupExpiredLinkCodes();
+  linkCodeStore.set(code, { userId, expiresAt });
   return code;
 }
 
 /** Consume a one-time link code, returning the userId or null if invalid/expired */
-export function consumeLinkCode(code: string): string | null {
+export async function consumeLinkCode(code: string): Promise<string | null> {
+  if (config.cacheSidecarEnabled) {
+    const buf = await cache.getdel(`link:code:${code}`);
+    if (buf) {
+      const entry: LinkCodeEntry = JSON.parse(buf.toString());
+      if (entry.expiresAt <= Date.now()) return null;
+      return entry.userId;
+    }
+  }
+
+  // In-memory fallback
   cleanupExpiredLinkCodes();
   const entry = linkCodeStore.get(code);
   if (!entry) return null;
@@ -43,7 +81,6 @@ export function consumeLinkCode(code: string): string | null {
   linkCodeStore.delete(code);
 
   if (entry.expiresAt <= Date.now()) return null;
-
   return entry.userId;
 }
 
@@ -57,28 +94,41 @@ export function consumeLinkCode(code: string): string | null {
 // decisions, breaking the taint chain entirely.
 // ---------------------------------------------------------------------------
 
-const relayStateStore = new Map<string, LinkCodeEntry>();
-const RELAY_STATE_TTL_MS = 300_000; // 5 minutes — allows time for IdP authentication
-
-function cleanupExpiredRelayCodes(): void {
-  const now = Date.now();
-  for (const [code, entry] of relayStateStore) {
-    if (entry.expiresAt <= now) relayStateStore.delete(code);
-  }
-}
-
 /** Generate a random relay code that maps to a userId (5-minute TTL, one-time use) */
-export function generateRelayCode(userId: string): string {
-  cleanupExpiredRelayCodes();
+export async function generateRelayCode(userId: string): Promise<string> {
   const code = crypto.randomBytes(32).toString('hex');
-  relayStateStore.set(code, { userId, expiresAt: Date.now() + RELAY_STATE_TTL_MS });
+  const expiresAt = Date.now() + RELAY_STATE_TTL_MS;
+
+  if (config.cacheSidecarEnabled) {
+    const stored = await cache.set(
+      `relay:code:${code}`,
+      JSON.stringify({ userId, expiresAt }),
+      { ttl: RELAY_STATE_TTL_MS },
+    );
+    if (stored) return code;
+  }
+
+  // Fallback to in-memory
+  cleanupExpiredRelayCodes();
+  relayStateStore.set(code, { userId, expiresAt });
   return code;
 }
 
 /** Consume a relay code, returning the server-stored userId or null */
-export function consumeRelayCode(code: string): string | null {
-  cleanupExpiredRelayCodes();
+export async function consumeRelayCode(code: string): Promise<string | null> {
   if (typeof code !== 'string') return null;
+
+  if (config.cacheSidecarEnabled) {
+    const buf = await cache.getdel(`relay:code:${code}`);
+    if (buf) {
+      const entry: LinkCodeEntry = JSON.parse(buf.toString());
+      if (entry.expiresAt <= Date.now()) return null;
+      return entry.userId;
+    }
+  }
+
+  // In-memory fallback
+  cleanupExpiredRelayCodes();
   const entry = relayStateStore.get(code);
   if (!entry) return null;
   relayStateStore.delete(code);


### PR DESCRIPTION
## Summary

- **Socket.IO cross-instance adapter** using cache pub/sub with room targeting — enables multi-instance Socket.IO event propagation
- **Vault sessions** (4 stores: user, recovery, team, tenant) encrypted with server key before cache storage, dual-layer with local Map fallback, sliding-window TTL
- **Auth/link/relay code stores** using atomic `getdel` for one-time consumption across instances
- **Distributed rate limiting** with fixed-window timestamp-bucketed counters shared across instances
- **Leader election** via distributed locks — only one instance runs scheduled jobs (11 intervals wrapped)
- **Vault status push** via pub/sub replaces client-side 60s polling
- **Async cascade**: ~42 call sites across 14 service files updated for async `getMasterKey`/`requireMasterKey`
- All operations gracefully degrade when sidecar is unavailable — single-instance mode works exactly as before

Supersedes: SCALE-2074, SCALE-2075, SCALE-2076, SCALE-2078, SCALE-2079, SCALE-2082, SCALE-2084

### Files Changed (30 files, +978/-204)
- **Created**: `cacheAdapter.ts`, `leaderElection.ts`
- **Core**: `crypto.service.ts`, `vault.service.ts`, `authCodeStore.ts`, `linkCodeStore.ts`, `rateLimitFactory.ts`, `socket/index.ts`, `index.ts`
- **Callers**: 14 service/controller files for async cascade
- **Client**: `vaultStore.ts` (Socket.IO handler)
- **Docs**: `rag-summary.md`, `architecture.md`, `deployment.md`, `configuration.md`

## Test plan

- [x] Start dev environment with `npm run predev && npm run dev` — verify server starts with "Cache sidecar client connected" log
- [x] Unlock vault — verify vault session works (credentials accessible)
- [x] Lock vault — verify vault locks correctly
- [x] Test OAuth/SAML login — verify auth codes work (one-time consumption)
- [x] Test rate limiting — verify rate limits apply correctly
- [x] Verify `npm run verify` passes (typecheck + lint + audit + build)
- [x] Test with `CACHE_SIDECAR_ENABLED=false` — verify single-instance fallback works identically

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)