### PR TITLE
[codex] Harden DB firewall regex validation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -46,6 +46,52 @@ For gateway and session debugging, these commands are especially useful:
 /tmp/arsenale-cli --server https://localhost:3000 rdgw status
 ```
 
+## Red/Green On Real Infrastructure
+When the change needs more than isolated unit coverage, run the Red/Green loop against the local stack at `https://localhost:3000` and treat the CLI as the default smoke client:
+
+1. Write or update the narrow regression test first and make it fail locally.
+2. Build the CLI, confirm the stack is up, and refresh auth if needed.
+3. Reproduce the bug against the live stack with `/tmp/arsenale-cli ... -o json` or a narrow API call.
+4. If the change touches frontend behavior, reproduce it in a real browser with Selenium/WebDriver against `https://localhost:3000`.
+5. Implement the fix.
+6. Rerun the focused test until it is green.
+7. Rerun the same live-stack smoke path to confirm the behavior end-to-end.
+8. For frontend changes, rerun the Selenium/WebDriver browser path and the matching `arsenale-cli` smoke.
+9. Finish with `npm run verify`.
+
+Use this baseline sequence:
+
+```bash
+go test ./tools/arsenale-cli/...
+go build -o /tmp/arsenale-cli ./tools/arsenale-cli
+/tmp/arsenale-cli --server https://localhost:3000 health
+/tmp/arsenale-cli --server https://localhost:3000 login
+/tmp/arsenale-cli --server https://localhost:3000 whoami
+npm run verify
+```
+
+Notes:
+
+- The local seeded credentials are `admin@example.com` / `DevAdmin123!` for tenant `Development Environment`.
+- The CLI stores auth in `~/.arsenale/config.yaml`. If that file is stale, refresh it with `arsenale-cli login` instead of hand-editing tokens.
+- If you need non-interactive CLI auth for automation, use the device flow endpoints already exposed by the platform, especially `POST /api/cli/auth/device/authorize`, from an already authenticated browser session.
+- Prefer `-o json` for assertions and keep the live-stack check narrowly scoped to the behavior you changed.
+- Frontend acceptance should use Selenium/WebDriver against the real local stack, not only component-level mocks.
+- Frontend browser checks do not replace platform smoke. Run the matching `arsenale-cli` assertion as well so the UI path and backend contract are both covered.
+
+Example live-stack pattern for an end-to-end change:
+
+```bash
+# Red: focused tests fail first
+npm run test -w client -- dbFirewallPattern.test.ts
+go test ./backend/internal/dbauditapi -run TestValidateSafeRegex -count=1
+
+# Real-stack reproduction and green verification
+/tmp/arsenale-cli --server https://localhost:3000 health
+/tmp/arsenale-cli --server https://localhost:3000 whoami
+/tmp/arsenale-cli --server https://localhost:3000 db-audit firewall-rule list -o json
+```
+
 ## Alignment Rule
 Any change that affects API routes, response fields, auth flows, config defaults, server URLs, tenant selection, or deployment wiring must be reflected in `tools/arsenale-cli` in the same change set.
 

--- a/backend/internal/dbauditapi/helpers_test.go
+++ b/backend/internal/dbauditapi/helpers_test.go
@@ -1,0 +1,48 @@
+package dbauditapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSafeRegex(t *testing.T) {
+	t.Run("accepts safe patterns after trimming", func(t *testing.T) {
+		got, err := validateSafeRegex(` \bDROP\s+TABLE\b `, "firewall rule")
+		if err != nil {
+			t.Fatalf("validateSafeRegex() returned error: %v", err)
+		}
+		if got != `\bDROP\s+TABLE\b` {
+			t.Fatalf("validateSafeRegex() = %q, want trimmed safe pattern", got)
+		}
+	})
+
+	t.Run("rejects nested quantifiers", func(t *testing.T) {
+		_, err := validateSafeRegex(`(a+)+$`, "firewall rule")
+		if err == nil {
+			t.Fatal("validateSafeRegex() unexpectedly accepted nested quantifiers")
+		}
+		if !strings.Contains(err.Error(), "pattern too long or contains nested quantifiers") {
+			t.Fatalf("validateSafeRegex() error = %q", err.Error())
+		}
+	})
+
+	t.Run("rejects invalid syntax", func(t *testing.T) {
+		_, err := validateSafeRegex(`(`, "firewall rule")
+		if err == nil {
+			t.Fatal("validateSafeRegex() unexpectedly accepted invalid syntax")
+		}
+		if !strings.Contains(err.Error(), "Invalid regex firewall rule") {
+			t.Fatalf("validateSafeRegex() error = %q", err.Error())
+		}
+	})
+
+	t.Run("rejects overly long patterns", func(t *testing.T) {
+		_, err := validateSafeRegex(strings.Repeat("a", maxRegexLength+1), "firewall rule")
+		if err == nil {
+			t.Fatal("validateSafeRegex() unexpectedly accepted oversized pattern")
+		}
+		if !strings.Contains(err.Error(), "pattern too long or contains nested quantifiers") {
+			t.Fatalf("validateSafeRegex() error = %q", err.Error())
+		}
+	})
+}

--- a/client/src/components/Settings/DbFirewallSection.tsx
+++ b/client/src/components/Settings/DbFirewallSection.tsx
@@ -18,6 +18,7 @@ import {
   FirewallRule, FirewallRuleInput, FirewallAction,
 } from '../../api/dbAudit.api';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
+import { validateDbFirewallPattern } from '../../utils/dbFirewallPattern';
 
 const ACTION_COLORS: Record<FirewallAction, 'error' | 'warning' | 'info'> = {
   BLOCK: 'error',
@@ -36,9 +37,6 @@ interface RuleTemplate {
   description: string;
   category: string;
 }
-
-const MAX_REGEX_LENGTH = 500;
-const NESTED_QUANTIFIER_RE = /(\+|\*|\{[^}]+\})\s*\)?\s*(\+|\*|\?|\{[^}]+\})/;
 
 const RULE_TEMPLATES: RuleTemplate[] = [
   // --- Destructive DDL ---
@@ -154,26 +152,6 @@ const RULE_TEMPLATES: RuleTemplate[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Regex validation helper
-// ---------------------------------------------------------------------------
-
-function validateRegex(pattern: string): string | null {
-  const trimmed = pattern.trim();
-  if (!trimmed) return 'Pattern is required';
-  if (trimmed.length > MAX_REGEX_LENGTH || NESTED_QUANTIFIER_RE.test(trimmed)) {
-    return 'Pattern is too complex or too long';
-  }
-  try {
-    // Intentional validation of user-authored regex before it is sent to the API.
-    // eslint-disable-next-line security/detect-non-literal-regexp
-    new RegExp(trimmed, 'i');
-    return null;
-  } catch (err) {
-    return err instanceof SyntaxError ? err.message : 'Invalid regular expression';
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -237,7 +215,7 @@ export default function DbFirewallSection() {
   const handlePatternChange = (value: string) => {
     setFormData({ ...formData, pattern: value });
     if (value.trim()) {
-      setPatternError(validateRegex(value));
+      setPatternError(validateDbFirewallPattern(value));
     } else {
       setPatternError(null);
     }
@@ -253,12 +231,12 @@ export default function DbFirewallSection() {
       action: template.action,
       description: template.description,
     });
-    setPatternError(validateRegex(template.pattern));
+    setPatternError(validateDbFirewallPattern(template.pattern));
   };
 
   const handleSave = async () => {
     // Validate regex before saving
-    const regexErr = validateRegex(formData.pattern);
+    const regexErr = validateDbFirewallPattern(formData.pattern);
     if (regexErr) {
       setPatternError(regexErr);
       return;
@@ -407,7 +385,7 @@ export default function DbFirewallSection() {
               value={formData.pattern}
               onChange={(e) => handlePatternChange(e.target.value)}
               error={!!patternError}
-              helperText={patternError || 'Regular expression pattern to match against SQL queries (case-insensitive)'}
+              helperText={patternError || 'Basic safety checks run locally. Full regex syntax is validated on save by the backend.'}
               slotProps={{ htmlInput: { style: { fontFamily: 'monospace' } } }}
             />
             <FormControl size="small" fullWidth>

--- a/client/src/utils/dbFirewallPattern.test.ts
+++ b/client/src/utils/dbFirewallPattern.test.ts
@@ -1,0 +1,30 @@
+import { validateDbFirewallPattern } from './dbFirewallPattern';
+
+describe('validateDbFirewallPattern', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects nested quantifiers without compiling the pattern', () => {
+    const nativeRegExp = globalThis.RegExp;
+    const regExpSpy = vi.fn(function RegExpSpy(pattern: string | RegExp, flags?: string) {
+      return new nativeRegExp(pattern, flags);
+    });
+    vi.stubGlobal('RegExp', regExpSpy);
+
+    expect(validateDbFirewallPattern('(a+)+$')).toBe('Pattern is too complex or too long');
+    expect(regExpSpy).not.toHaveBeenCalled();
+  });
+
+  it('defers full regex syntax validation to the backend', () => {
+    const nativeRegExp = globalThis.RegExp;
+    const regExpSpy = vi.fn(function RegExpSpy(pattern: string | RegExp, flags?: string) {
+      return new nativeRegExp(pattern, flags);
+    });
+    vi.stubGlobal('RegExp', regExpSpy);
+
+    expect(validateDbFirewallPattern('(')).toBeNull();
+    expect(regExpSpy).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/utils/dbFirewallPattern.ts
+++ b/client/src/utils/dbFirewallPattern.ts
@@ -1,0 +1,15 @@
+export const MAX_DB_FIREWALL_REGEX_LENGTH = 500;
+
+const NESTED_DB_FIREWALL_QUANTIFIER_RE = /(\+|\*|\{[^}]+\})\s*\)?\s*(\+|\*|\?|\{[^}]+\})/;
+
+export function validateDbFirewallPattern(pattern: string): string | null {
+  const trimmed = pattern.trim();
+  if (!trimmed) return 'Pattern is required';
+  if (trimmed.length > MAX_DB_FIREWALL_REGEX_LENGTH || NESTED_DB_FIREWALL_QUANTIFIER_RE.test(trimmed)) {
+    return 'Pattern is too complex or too long';
+  }
+
+  // Keep browser-side validation cheap so a malicious pattern cannot lock up the
+  // admin tab before the backend performs the authoritative syntax check.
+  return null;
+}


### PR DESCRIPTION
## Summary
- move SQL firewall pattern preflight checks into a dedicated client utility that avoids browser-side regex compilation
- keep the backend as the authoritative regex syntax validator and add backend coverage for safe, invalid, nested, and oversized patterns
- document the repo Red/Green real-infrastructure flow in `AGENT.md`, including Selenium/WebDriver plus matching `arsenale-cli` smoke for frontend changes

## Why
The admin firewall form compiled user-authored regexes in the browser with `new RegExp(...)`. That could stall the admin tab on pathological patterns even though the backend already performs authoritative validation and execution in Go.

## Impact
The UI now performs only cheap deterministic checks before save, defers full syntax validation to the backend, and preserves the existing rejection of obviously complex nested-quantifier patterns. This reduces browser-side ReDoS exposure without changing backend acceptance rules.

## Root Cause
Client-side validation duplicated regex parsing in the browser instead of limiting itself to cheap guards and relying on the backend validator.

## Validation
- `npm run test -w client -- dbFirewallPattern.test.ts`
- `go test ./backend/internal/dbauditapi -count=1`
- `npm run verify`
- live-stack `arsenale-cli` smoke on `https://localhost:3000` for invalid syntax rejection, nested quantifier rejection, and safe rule create/delete

Refs #590