### PR TITLE
harden secret loader validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ Key variables — see [docs/environment.md](docs/environment.md) for the full re
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | `postgresql://arsenale:arsenale_password@127.0.0.1:5432/arsenale` | PostgreSQL connection string |
-| `JWT_SECRET` | `dev-secret-change-me` | Secret key for signing JWT tokens (**must be strong in production**) |
+| `JWT_SECRET` | — | Secret key for signing JWT tokens. Provide via `JWT_SECRET` or `JWT_SECRET_FILE`. |
 | `JWT_EXPIRES_IN` | `15m` | Access token TTL |
 | `JWT_REFRESH_EXPIRES_IN` | `7d` | Refresh token TTL |
 | `GUACD_HOST` | `localhost` | Guacamole daemon hostname |
 | `GUACD_PORT` | `4822` | Guacamole daemon port |
-| `GUACAMOLE_SECRET` | `dev-guac-secret` | Guacamole token encryption key (**must be strong in production**) |
+| `GUACAMOLE_SECRET` | — | Guacamole token encryption key. Provide via `GUACAMOLE_SECRET` or `GUACAMOLE_SECRET_FILE`. |
 | `SERVER_ENCRYPTION_KEY` | Auto-generated | 32-byte hex key for server-level encryption (**required in production**) |
 | `NODE_ENV` | `development` | Environment mode |
 | `VAULT_TTL_MINUTES` | `30` | Vault session auto-lock timeout (minutes) |

--- a/backend/internal/authn/middleware_test.go
+++ b/backend/internal/authn/middleware_test.go
@@ -157,6 +157,44 @@ func TestNewAuthenticatorUsesConfiguredBindingCutoff(t *testing.T) {
 	}
 }
 
+func TestNewAuthenticatorLoadsTrimmedSecretFromFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "jwt-secret-*")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	if _, err := file.WriteString("  file-secret \n"); err != nil {
+		t.Fatalf("WriteString() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	_ = os.Unsetenv("JWT_SECRET")
+	t.Setenv("JWT_SECRET_FILE", file.Name())
+	_ = os.Unsetenv("TOKEN_BINDING_ENFORCEMENT_TIMESTAMP")
+
+	authenticator, err := NewAuthenticator()
+	if err != nil {
+		t.Fatalf("NewAuthenticator() error = %v", err)
+	}
+	if got := string(authenticator.secret); got != "file-secret" {
+		t.Fatalf("secret = %q, want %q", got, "file-secret")
+	}
+}
+
+func TestNewAuthenticatorRejectsWhitespaceOnlySecret(t *testing.T) {
+	t.Setenv("JWT_SECRET", " \t\r\n ")
+	_ = os.Unsetenv("JWT_SECRET_FILE")
+
+	_, err := NewAuthenticator()
+	if err == nil {
+		t.Fatal("NewAuthenticator() error = nil, want invalid secret error")
+	}
+	if !strings.Contains(err.Error(), "JWT_SECRET is set but empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func newAuthenticatedRequest(t *testing.T, secret []byte, claims Claims, remoteAddr, userAgent string) *http.Request {
 	t.Helper()
 

--- a/backend/internal/desktopbroker/token.go
+++ b/backend/internal/desktopbroker/token.go
@@ -18,6 +18,8 @@ import (
 
 const guacamoleSalt = "arsenale-guac-salt"
 
+var ErrSecretNotConfigured = errors.New("secret not configured")
+
 type TokenEnvelope struct {
 	IV    string `json:"iv"`
 	Value string `json:"value"`
@@ -36,21 +38,34 @@ type ConnectionToken struct {
 }
 
 func LoadSecret(envKey, fileEnvKey string) (string, error) {
-	if value := os.Getenv(envKey); value != "" {
+	if rawValue, ok := os.LookupEnv(envKey); ok {
+		value := strings.TrimSpace(rawValue)
+		if value == "" {
+			return "", fmt.Errorf("%s is set but empty", envKey)
+		}
 		return value, nil
 	}
 
-	filePath := os.Getenv(fileEnvKey)
-	if filePath == "" {
-		return "", fmt.Errorf("missing %s or %s", envKey, fileEnvKey)
+	if rawPath, ok := os.LookupEnv(fileEnvKey); ok {
+		filePath := strings.TrimSpace(rawPath)
+		if filePath == "" {
+			return "", fmt.Errorf("%s is set but empty", fileEnvKey)
+		}
+
+		payload, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", fileEnvKey, err)
+		}
+
+		value := strings.TrimSpace(string(payload))
+		if value == "" {
+			return "", fmt.Errorf("%s points to an empty secret", fileEnvKey)
+		}
+
+		return value, nil
 	}
 
-	payload, err := os.ReadFile(filePath)
-	if err != nil {
-		return "", fmt.Errorf("read %s: %w", fileEnvKey, err)
-	}
-
-	return strings.TrimRight(string(payload), "\r\n"), nil
+	return "", fmt.Errorf("%w: missing %s or %s", ErrSecretNotConfigured, envKey, fileEnvKey)
 }
 
 func EncryptToken(secret string, token ConnectionToken) (string, error) {

--- a/backend/internal/desktopbroker/token_test.go
+++ b/backend/internal/desktopbroker/token_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -100,7 +101,7 @@ func TestLoadSecretTrimsTrailingNewlineFromFile(t *testing.T) {
 		t.Fatalf("close temp secret: %v", err)
 	}
 
-	t.Setenv("ARSENALE_TEST_SECRET", "")
+	_ = os.Unsetenv("ARSENALE_TEST_SECRET")
 	t.Setenv("ARSENALE_TEST_SECRET_FILE", file.Name())
 
 	value, err := LoadSecret("ARSENALE_TEST_SECRET", "ARSENALE_TEST_SECRET_FILE")
@@ -109,6 +110,103 @@ func TestLoadSecretTrimsTrailingNewlineFromFile(t *testing.T) {
 	}
 	if value != "integration-secret" {
 		t.Fatalf("unexpected secret value: %q", value)
+	}
+}
+
+func TestLoadSecretTrimsWhitespaceFromEnv(t *testing.T) {
+	t.Setenv("ARSENALE_TEST_SECRET_ENV", "  integration-secret \n")
+	_ = os.Unsetenv("ARSENALE_TEST_SECRET_ENV_FILE")
+
+	value, err := LoadSecret("ARSENALE_TEST_SECRET_ENV", "ARSENALE_TEST_SECRET_ENV_FILE")
+	if err != nil {
+		t.Fatalf("load secret: %v", err)
+	}
+	if value != "integration-secret" {
+		t.Fatalf("unexpected secret value: %q", value)
+	}
+}
+
+func TestLoadSecretPrefersEnvOverFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "secret-*")
+	if err != nil {
+		t.Fatalf("create temp secret: %v", err)
+	}
+	if _, err := file.WriteString("file-secret"); err != nil {
+		t.Fatalf("write temp secret: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close temp secret: %v", err)
+	}
+
+	t.Setenv("ARSENALE_TEST_SECRET_ENV_FIRST", " env-secret ")
+	t.Setenv("ARSENALE_TEST_SECRET_ENV_FIRST_FILE", file.Name())
+
+	value, err := LoadSecret("ARSENALE_TEST_SECRET_ENV_FIRST", "ARSENALE_TEST_SECRET_ENV_FIRST_FILE")
+	if err != nil {
+		t.Fatalf("load secret: %v", err)
+	}
+	if value != "env-secret" {
+		t.Fatalf("unexpected secret value: %q", value)
+	}
+}
+
+func TestLoadSecretRejectsWhitespaceOnlyEnv(t *testing.T) {
+	t.Setenv("ARSENALE_TEST_SECRET_ENV", " \t\r\n ")
+	_ = os.Unsetenv("ARSENALE_TEST_SECRET_ENV_FILE")
+
+	_, err := LoadSecret("ARSENALE_TEST_SECRET_ENV", "ARSENALE_TEST_SECRET_ENV_FILE")
+	if err == nil {
+		t.Fatal("load secret: expected error for whitespace-only env secret")
+	}
+	if !strings.Contains(err.Error(), "ARSENALE_TEST_SECRET_ENV is set but empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadSecretRejectsWhitespaceOnlyFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "secret-*")
+	if err != nil {
+		t.Fatalf("create temp secret: %v", err)
+	}
+	if _, err := file.WriteString("  \r\n\t"); err != nil {
+		t.Fatalf("write temp secret: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close temp secret: %v", err)
+	}
+
+	_ = os.Unsetenv("ARSENALE_TEST_SECRET_FILE_ONLY")
+	t.Setenv("ARSENALE_TEST_SECRET_FILE_ONLY_FILE", file.Name())
+
+	_, err = LoadSecret("ARSENALE_TEST_SECRET_FILE_ONLY", "ARSENALE_TEST_SECRET_FILE_ONLY_FILE")
+	if err == nil {
+		t.Fatal("load secret: expected error for whitespace-only secret file")
+	}
+	if !strings.Contains(err.Error(), "ARSENALE_TEST_SECRET_FILE_ONLY_FILE points to an empty secret") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadSecretRejectsWhitespaceOnlyFilePathEnv(t *testing.T) {
+	_ = os.Unsetenv("ARSENALE_TEST_SECRET_FILE_PATH")
+	t.Setenv("ARSENALE_TEST_SECRET_FILE_PATH_FILE", " \t ")
+
+	_, err := LoadSecret("ARSENALE_TEST_SECRET_FILE_PATH", "ARSENALE_TEST_SECRET_FILE_PATH_FILE")
+	if err == nil {
+		t.Fatal("load secret: expected error for whitespace-only file path env")
+	}
+	if !strings.Contains(err.Error(), "ARSENALE_TEST_SECRET_FILE_PATH_FILE is set but empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadSecretMissingReturnsSentinel(t *testing.T) {
+	_ = os.Unsetenv("ARSENALE_TEST_SECRET_MISSING")
+	_ = os.Unsetenv("ARSENALE_TEST_SECRET_MISSING_FILE")
+
+	_, err := LoadSecret("ARSENALE_TEST_SECRET_MISSING", "ARSENALE_TEST_SECRET_MISSING_FILE")
+	if !errors.Is(err, ErrSecretNotConfigured) {
+		t.Fatalf("expected ErrSecretNotConfigured, got %v", err)
 	}
 }
 

--- a/backend/internal/terminalbroker/token.go
+++ b/backend/internal/terminalbroker/token.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -27,15 +26,12 @@ type tokenEnvelope struct {
 }
 
 func LoadSecret() (string, error) {
-	if value := os.Getenv("TERMINAL_BROKER_SECRET"); value != "" {
-		return value, nil
+	secret, err := desktopbroker.LoadSecret("TERMINAL_BROKER_SECRET", "TERMINAL_BROKER_SECRET_FILE")
+	if err == nil {
+		return secret, nil
 	}
-	if filePath := os.Getenv("TERMINAL_BROKER_SECRET_FILE"); filePath != "" {
-		payload, err := os.ReadFile(filePath)
-		if err != nil {
-			return "", fmt.Errorf("read TERMINAL_BROKER_SECRET_FILE: %w", err)
-		}
-		return string(payload), nil
+	if !errors.Is(err, desktopbroker.ErrSecretNotConfigured) {
+		return "", err
 	}
 
 	return desktopbroker.LoadSecret("GUACAMOLE_SECRET", "GUACAMOLE_SECRET_FILE")

--- a/backend/internal/terminalbroker/token_test.go
+++ b/backend/internal/terminalbroker/token_test.go
@@ -1,6 +1,8 @@
 package terminalbroker
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,5 +60,106 @@ func TestValidateGrantRejectsExpired(t *testing.T) {
 
 	if _, err := ValidateGrant("secret", token, time.Now().UTC()); err == nil {
 		t.Fatal("ValidateGrant() error = nil, want expired grant error")
+	}
+}
+
+func TestLoadSecretUsesTrimmedTerminalBrokerSecret(t *testing.T) {
+	t.Setenv("TERMINAL_BROKER_SECRET", "  terminal-secret \n")
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET_FILE")
+	_ = os.Unsetenv("GUACAMOLE_SECRET")
+	_ = os.Unsetenv("GUACAMOLE_SECRET_FILE")
+
+	secret, err := LoadSecret()
+	if err != nil {
+		t.Fatalf("LoadSecret() error = %v", err)
+	}
+	if secret != "terminal-secret" {
+		t.Fatalf("LoadSecret() = %q, want terminal-secret", secret)
+	}
+}
+
+func TestLoadSecretFallsBackToGuacamoleSecret(t *testing.T) {
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET")
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET_FILE")
+	t.Setenv("GUACAMOLE_SECRET", "  guac-secret \n")
+	_ = os.Unsetenv("GUACAMOLE_SECRET_FILE")
+
+	secret, err := LoadSecret()
+	if err != nil {
+		t.Fatalf("LoadSecret() error = %v", err)
+	}
+	if secret != "guac-secret" {
+		t.Fatalf("LoadSecret() = %q, want guac-secret", secret)
+	}
+}
+
+func TestLoadSecretPrefersTerminalBrokerSecretOverFallback(t *testing.T) {
+	t.Setenv("TERMINAL_BROKER_SECRET", " terminal-secret ")
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET_FILE")
+	t.Setenv("GUACAMOLE_SECRET", "guac-secret")
+	_ = os.Unsetenv("GUACAMOLE_SECRET_FILE")
+
+	secret, err := LoadSecret()
+	if err != nil {
+		t.Fatalf("LoadSecret() error = %v", err)
+	}
+	if secret != "terminal-secret" {
+		t.Fatalf("LoadSecret() = %q, want terminal-secret", secret)
+	}
+}
+
+func TestLoadSecretRejectsWhitespaceOnlyTerminalBrokerSecret(t *testing.T) {
+	t.Setenv("TERMINAL_BROKER_SECRET", " \t\r\n ")
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET_FILE")
+	t.Setenv("GUACAMOLE_SECRET", "guac-secret")
+	_ = os.Unsetenv("GUACAMOLE_SECRET_FILE")
+
+	_, err := LoadSecret()
+	if err == nil {
+		t.Fatal("LoadSecret() error = nil, want invalid terminal secret error")
+	}
+	if !strings.Contains(err.Error(), "TERMINAL_BROKER_SECRET is set but empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadSecretRejectsWhitespaceOnlyTerminalBrokerSecretFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "terminal-secret-*")
+	if err != nil {
+		t.Fatalf("CreateTemp() error = %v", err)
+	}
+	if _, err := file.WriteString(" \r\n\t "); err != nil {
+		t.Fatalf("WriteString() error = %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET")
+	t.Setenv("TERMINAL_BROKER_SECRET_FILE", file.Name())
+	t.Setenv("GUACAMOLE_SECRET", "guac-secret")
+	_ = os.Unsetenv("GUACAMOLE_SECRET_FILE")
+
+	_, err = LoadSecret()
+	if err == nil {
+		t.Fatal("LoadSecret() error = nil, want invalid terminal secret file error")
+	}
+	if !strings.Contains(err.Error(), "TERMINAL_BROKER_SECRET_FILE points to an empty secret") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadSecretRejectsWhitespaceOnlyFallbackGuacamoleSecret(t *testing.T) {
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET")
+	_ = os.Unsetenv("TERMINAL_BROKER_SECRET_FILE")
+	t.Setenv("GUACAMOLE_SECRET", " \t\r\n ")
+	_ = os.Unsetenv("GUACAMOLE_SECRET_FILE")
+
+	_, err := LoadSecret()
+	if err == nil {
+		t.Fatal("LoadSecret() error = nil, want invalid fallback secret error")
+	}
+	if !strings.Contains(err.Error(), "GUACAMOLE_SECRET is set but empty") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/docs/.docs-manifest.json
+++ b/docs/.docs-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-03T16:00:00.000000Z",
+  "generated_at": "2026-04-03T23:46:33.000000Z",
   "visual_richness": "tiny",
   "sections": [
     {

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -30,7 +30,7 @@ In production, the Docker Compose stack uses `.env.prod` (via `env_file`).
 
 | Variable | Type | Default | Required | Env | Description | Security Notes |
 |----------|------|---------|----------|-----|-------------|---------------|
-| `JWT_SECRET` | string | `dev-secret-change-me` | **Prod** | Both | JWT signing secret | **Must be strong random in production** |
+| `JWT_SECRET` | string | — | **Prod** | Both | JWT signing secret | **Must be provided via `JWT_SECRET` or `JWT_SECRET_FILE` and use a strong random value in production** |
 | `JWT_EXPIRES_IN` | string | `15m` | No | Both | Access token lifetime (e.g., `15m`, `1h`) | |
 | `JWT_REFRESH_EXPIRES_IN` | string | `7d` | No | Both | Refresh token lifetime (e.g., `7d`, `30d`) | |
 | `TOKEN_BINDING_ENABLED` | boolean | `true` | No | Both | Bind JWT tokens to client IP + User-Agent. Set `false` for environments with dynamic IPs. | |
@@ -42,7 +42,7 @@ In production, the Docker Compose stack uses `.env.prod` (via `env_file`).
 |----------|------|---------|----------|-----|-------------|---------------|
 | `GUACD_HOST` | string | `localhost` | No | Both | Guacamole daemon hostname | |
 | `GUACD_PORT` | number | `4822` | No | Both | Guacamole daemon port | |
-| `GUACAMOLE_SECRET` | string | `dev-guac-secret` | **Prod** | Both | Token encryption key for guacamole-lite | **Must be strong random in production** |
+| `GUACAMOLE_SECRET` | string | — | **Prod** | Both | Token encryption key for guacamole-lite | **Must be provided via `GUACAMOLE_SECRET` or `GUACAMOLE_SECRET_FILE` and use a strong random value in production** |
 
 ### Vault & Encryption
 
@@ -314,8 +314,7 @@ These flags are converted to a runtime manifest in `backend/internal/runtimefeat
 
 In development (`NODE_ENV=development`):
 
-- `JWT_SECRET` defaults to `dev-secret-change-me`
-- `GUACAMOLE_SECRET` defaults to `dev-guac-secret`
+- `JWT_SECRET` and `GUACAMOLE_SECRET` must still be provisioned via `.env` or the corresponding `_FILE` variables; the Go services do not ship built-in development secrets
 - `SERVER_ENCRYPTION_KEY` is auto-generated (not persisted)
 - Email verification links are logged to console (no SMTP required)
 - SMS OTP codes are logged to console (no SMS provider required)


### PR DESCRIPTION
## Summary
- harden Go secret loading so env and file-based secrets are trimmed before use and rejected when empty after normalization
- cover startup-adjacent auth and terminal-broker secret loading paths with deeper regression tests, including precedence and malformed configuration cases
- remove stale documentation that claimed built-in development defaults for `JWT_SECRET` and `GUACAMOLE_SECRET`

## Why
Issue #589 described an old TypeScript fallback that no longer exists in the active Go runtime. The real security gap in the current codebase was narrower but still relevant: whitespace-only secret configuration could pass loader checks and then collapse to an empty secret after later trimming. This change fails those misconfigurations early and makes the docs match the live runtime.

## Validation
- `cd backend && go test -count=1 ./internal/authn ./internal/desktopbroker ./internal/terminalbroker`
- `cd backend && go test -race -count=1 ./internal/authn ./internal/desktopbroker ./internal/terminalbroker`
- `npm run verify`

## Impact
- control-plane and broker startup now reject explicitly blank secret values instead of accepting them
- terminal-broker fallback to `GUACAMOLE_SECRET` still works when terminal-specific configuration is absent, but not when it is present and malformed
- operator docs now describe the current Go behavior instead of legacy defaults

Closes #589