### PR TITLE
[codex] Add per-connection DB policy overrides and AI backends

### DIFF
--- a/backend/internal/agents/dbgen/models.go
+++ b/backend/internal/agents/dbgen/models.go
@@ -2285,20 +2285,41 @@ type Tenant struct {
 	UserDriveQuotaBytes           pgtype.Int4
 }
 
+type TenantAiBackend struct {
+	ID              string
+	TenantId        string
+	Name            string
+	Provider        string
+	EncryptedApiKey pgtype.Text
+	ApiKeyIV        pgtype.Text
+	ApiKeyTag       pgtype.Text
+	BaseUrl         pgtype.Text
+	DefaultModel    pgtype.Text
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
 type TenantAiConfig struct {
-	ID                  string
-	TenantId            string
-	Provider            string
-	EncryptedApiKey     pgtype.Text
-	ApiKeyIV            pgtype.Text
-	ApiKeyTag           pgtype.Text
-	ModelId             string
-	BaseUrl             pgtype.Text
-	MaxTokensPerRequest int32
-	DailyRequestLimit   int32
-	Enabled             bool
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                     string
+	TenantId               string
+	Provider               string
+	EncryptedApiKey        pgtype.Text
+	ApiKeyIV               pgtype.Text
+	ApiKeyTag              pgtype.Text
+	ModelId                string
+	BaseUrl                pgtype.Text
+	MaxTokensPerRequest    int32
+	DailyRequestLimit      int32
+	Enabled                bool
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	QueryGenerationBackend pgtype.Text
+	QueryGenerationModel   pgtype.Text
+	QueryOptimizerEnabled  bool
+	QueryOptimizerBackend  pgtype.Text
+	QueryOptimizerModel    pgtype.Text
+	Temperature            float64
+	TimeoutMs              int32
 }
 
 type TenantMember struct {

--- a/backend/internal/connections/gateway_routing.go
+++ b/backend/internal/connections/gateway_routing.go
@@ -27,9 +27,11 @@ func compatibleGatewayTypes(connType string) []string {
 	switch strings.ToUpper(strings.TrimSpace(connType)) {
 	case "SSH":
 		return []string{"MANAGED_SSH", "SSH_BASTION"}
+	case "DB_TUNNEL":
+		return []string{"MANAGED_SSH", "SSH_BASTION"}
 	case "RDP", "VNC":
 		return []string{"GUACD"}
-	case "DATABASE", "DB_TUNNEL":
+	case "DATABASE":
 		return []string{"DB_PROXY"}
 	default:
 		return nil
@@ -40,9 +42,11 @@ func friendlyGatewayRequirement(connType string) string {
 	switch strings.ToUpper(strings.TrimSpace(connType)) {
 	case "SSH":
 		return "SSH_BASTION or MANAGED_SSH"
+	case "DB_TUNNEL":
+		return "SSH_BASTION or MANAGED_SSH"
 	case "RDP", "VNC":
 		return "GUACD"
-	case "DATABASE", "DB_TUNNEL":
+	case "DATABASE":
 		return "DB_PROXY"
 	default:
 		return "a compatible gateway"

--- a/backend/internal/connections/gateway_routing_test.go
+++ b/backend/internal/connections/gateway_routing_test.go
@@ -1,0 +1,28 @@
+package connections
+
+import "testing"
+
+func TestCompatibleGatewayTypesForDatabaseConnections(t *testing.T) {
+	t.Run("database connections use db proxy gateways", func(t *testing.T) {
+		got := compatibleGatewayTypes("DATABASE")
+		if len(got) != 1 || got[0] != "DB_PROXY" {
+			t.Fatalf("expected DATABASE to require DB_PROXY, got %#v", got)
+		}
+	})
+
+	t.Run("db tunnel connections use ssh gateways", func(t *testing.T) {
+		got := compatibleGatewayTypes("DB_TUNNEL")
+		if len(got) != 2 || got[0] != "MANAGED_SSH" || got[1] != "SSH_BASTION" {
+			t.Fatalf("expected DB_TUNNEL to require SSH gateways, got %#v", got)
+		}
+	})
+}
+
+func TestFriendlyGatewayRequirementForDatabaseConnections(t *testing.T) {
+	if got := friendlyGatewayRequirement("DATABASE"); got != "DB_PROXY" {
+		t.Fatalf("expected DATABASE gateway hint to be DB_PROXY, got %q", got)
+	}
+	if got := friendlyGatewayRequirement("DB_TUNNEL"); got != "SSH_BASTION or MANAGED_SSH" {
+		t.Fatalf("expected DB_TUNNEL gateway hint to mention SSH gateways, got %q", got)
+	}
+}

--- a/backend/internal/dbsessions/create_types.go
+++ b/backend/internal/dbsessions/create_types.go
@@ -24,20 +24,69 @@ type createRequest struct {
 }
 
 type databaseSettings struct {
-	Protocol             string `json:"protocol"`
-	DatabaseName         string `json:"databaseName"`
-	PersistExecutionPlan bool   `json:"persistExecutionPlan"`
-	SSLMode              string `json:"sslMode"`
-	OracleConnectionType string `json:"oracleConnectionType"`
-	OracleSID            string `json:"oracleSid"`
-	OracleServiceName    string `json:"oracleServiceName"`
-	OracleRole           string `json:"oracleRole"`
-	OracleTNSAlias       string `json:"oracleTnsAlias"`
-	OracleTNSDescriptor  string `json:"oracleTnsDescriptor"`
-	OracleConnectString  string `json:"oracleConnectString"`
-	MSSQLInstanceName    string `json:"mssqlInstanceName"`
-	MSSQLAuthMode        string `json:"mssqlAuthMode"`
-	DB2DatabaseAlias     string `json:"db2DatabaseAlias"`
+	Protocol                 string                            `json:"protocol"`
+	DatabaseName             string                            `json:"databaseName"`
+	PersistExecutionPlan     bool                              `json:"persistExecutionPlan"`
+	SSLMode                  string                            `json:"sslMode"`
+	FirewallEnabled          *bool                             `json:"firewallEnabled,omitempty"`
+	FirewallPolicyMode       string                            `json:"firewallPolicyMode,omitempty"`
+	FirewallRules            []databaseFirewallRuleSettings    `json:"firewallRules,omitempty"`
+	MaskingEnabled           *bool                             `json:"maskingEnabled,omitempty"`
+	MaskingPolicyMode        string                            `json:"maskingPolicyMode,omitempty"`
+	MaskingPolicies          []databaseMaskingPolicySettings   `json:"maskingPolicies,omitempty"`
+	RateLimitEnabled         *bool                             `json:"rateLimitEnabled,omitempty"`
+	RateLimitPolicyMode      string                            `json:"rateLimitPolicyMode,omitempty"`
+	RateLimitPolicies        []databaseRateLimitPolicySettings `json:"rateLimitPolicies,omitempty"`
+	AIQueryGenerationEnabled *bool                             `json:"aiQueryGenerationEnabled,omitempty"`
+	AIQueryGenerationBackend string                            `json:"aiQueryGenerationBackend,omitempty"`
+	AIQueryGenerationModel   string                            `json:"aiQueryGenerationModel,omitempty"`
+	AIQueryOptimizerEnabled  *bool                             `json:"aiQueryOptimizerEnabled,omitempty"`
+	AIQueryOptimizerBackend  string                            `json:"aiQueryOptimizerBackend,omitempty"`
+	AIQueryOptimizerModel    string                            `json:"aiQueryOptimizerModel,omitempty"`
+	OracleConnectionType     string                            `json:"oracleConnectionType"`
+	OracleSID                string                            `json:"oracleSid"`
+	OracleServiceName        string                            `json:"oracleServiceName"`
+	OracleRole               string                            `json:"oracleRole"`
+	OracleTNSAlias           string                            `json:"oracleTnsAlias"`
+	OracleTNSDescriptor      string                            `json:"oracleTnsDescriptor"`
+	OracleConnectString      string                            `json:"oracleConnectString"`
+	MSSQLInstanceName        string                            `json:"mssqlInstanceName"`
+	MSSQLAuthMode            string                            `json:"mssqlAuthMode"`
+	DB2DatabaseAlias         string                            `json:"db2DatabaseAlias"`
+}
+
+type databaseFirewallRuleSettings struct {
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name"`
+	Pattern  string `json:"pattern"`
+	Action   string `json:"action"`
+	Scope    string `json:"scope,omitempty"`
+	Enabled  *bool  `json:"enabled,omitempty"`
+	Priority int    `json:"priority,omitempty"`
+}
+
+type databaseMaskingPolicySettings struct {
+	ID            string   `json:"id,omitempty"`
+	Name          string   `json:"name"`
+	ColumnPattern string   `json:"columnPattern"`
+	Strategy      string   `json:"strategy"`
+	ExemptRoles   []string `json:"exemptRoles,omitempty"`
+	Scope         string   `json:"scope,omitempty"`
+	Enabled       *bool    `json:"enabled,omitempty"`
+}
+
+type databaseRateLimitPolicySettings struct {
+	ID          string   `json:"id,omitempty"`
+	Name        string   `json:"name"`
+	QueryType   string   `json:"queryType,omitempty"`
+	WindowMS    int      `json:"windowMs,omitempty"`
+	MaxQueries  int      `json:"maxQueries,omitempty"`
+	BurstMax    int      `json:"burstMax,omitempty"`
+	ExemptRoles []string `json:"exemptRoles,omitempty"`
+	Scope       string   `json:"scope,omitempty"`
+	Action      string   `json:"action,omitempty"`
+	Enabled     *bool    `json:"enabled,omitempty"`
+	Priority    int      `json:"priority,omitempty"`
 }
 
 type gatewaySnapshot struct {

--- a/backend/internal/dbsessions/database_settings.go
+++ b/backend/internal/dbsessions/database_settings.go
@@ -1,0 +1,54 @@
+package dbsessions
+
+import (
+	"context"
+	"strings"
+)
+
+type OwnedAIContext struct {
+	ConnectionID             string
+	Protocol                 string
+	DatabaseName             string
+	FirewallEnabled          *bool
+	MaskingEnabled           *bool
+	RateLimitEnabled         *bool
+	AIQueryGenerationEnabled *bool
+	AIQueryGenerationBackend string
+	AIQueryGenerationModel   string
+	AIQueryOptimizerEnabled  *bool
+	AIQueryOptimizerBackend  string
+	AIQueryOptimizerModel    string
+}
+
+func settingBoolOrDefault(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func trimSetting(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func (s Service) ResolveOwnedAIContext(ctx context.Context, userID, tenantID, sessionID string) (OwnedAIContext, error) {
+	runtime, err := s.resolveOwnedQueryRuntime(ctx, userID, tenantID, sessionID)
+	if err != nil {
+		return OwnedAIContext{}, err
+	}
+
+	return OwnedAIContext{
+		ConnectionID:             runtime.Connection.ID,
+		Protocol:                 runtime.Protocol,
+		DatabaseName:             runtime.DatabaseName,
+		FirewallEnabled:          runtime.Settings.FirewallEnabled,
+		MaskingEnabled:           runtime.Settings.MaskingEnabled,
+		RateLimitEnabled:         runtime.Settings.RateLimitEnabled,
+		AIQueryGenerationEnabled: runtime.Settings.AIQueryGenerationEnabled,
+		AIQueryGenerationBackend: trimSetting(runtime.Settings.AIQueryGenerationBackend),
+		AIQueryGenerationModel:   trimSetting(runtime.Settings.AIQueryGenerationModel),
+		AIQueryOptimizerEnabled:  runtime.Settings.AIQueryOptimizerEnabled,
+		AIQueryOptimizerBackend:  trimSetting(runtime.Settings.AIQueryOptimizerBackend),
+		AIQueryOptimizerModel:    trimSetting(runtime.Settings.AIQueryOptimizerModel),
+	}, nil
+}

--- a/backend/internal/dbsessions/query_policy_connection_overrides.go
+++ b/backend/internal/dbsessions/query_policy_connection_overrides.go
@@ -1,0 +1,208 @@
+package dbsessions
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type connectionPolicyMode string
+
+const (
+	connectionPolicyModeInherit  connectionPolicyMode = "inherit"
+	connectionPolicyModeMerge    connectionPolicyMode = "merge"
+	connectionPolicyModeOverride connectionPolicyMode = "override"
+)
+
+func normalizeConnectionPolicyMode(value string) connectionPolicyMode {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(connectionPolicyModeMerge):
+		return connectionPolicyModeMerge
+	case string(connectionPolicyModeOverride):
+		return connectionPolicyModeOverride
+	default:
+		return connectionPolicyModeInherit
+	}
+}
+
+func resolveFirewallRules(tenantRules []firewallRuleRecord, settings databaseSettings) []firewallRuleRecord {
+	connectionRules := buildConnectionFirewallRules(settings.FirewallRules)
+
+	switch normalizeConnectionPolicyMode(settings.FirewallPolicyMode) {
+	case connectionPolicyModeOverride:
+		return sortFirewallRules(connectionRules)
+	case connectionPolicyModeMerge:
+		return sortFirewallRules(append(connectionRules, tenantRules...))
+	default:
+		return tenantRules
+	}
+}
+
+func buildConnectionFirewallRules(items []databaseFirewallRuleSettings) []firewallRuleRecord {
+	rules := make([]firewallRuleRecord, 0, len(items))
+	for _, item := range items {
+		if !settingBoolOrDefault(item.Enabled, true) {
+			continue
+		}
+
+		name := strings.TrimSpace(item.Name)
+		pattern := strings.TrimSpace(item.Pattern)
+		if name == "" || pattern == "" {
+			continue
+		}
+
+		action := strings.ToUpper(strings.TrimSpace(item.Action))
+		if action == "" {
+			action = "BLOCK"
+		}
+
+		scope := strings.TrimSpace(item.Scope)
+		rules = append(rules, firewallRuleRecord{
+			Name:     name,
+			Pattern:  pattern,
+			Action:   action,
+			Scope:    sql.NullString{String: scope, Valid: scope != ""},
+			Priority: item.Priority,
+		})
+	}
+	return rules
+}
+
+func sortFirewallRules(items []firewallRuleRecord) []firewallRuleRecord {
+	if len(items) < 2 {
+		return items
+	}
+
+	sorted := append([]firewallRuleRecord(nil), items...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Priority > sorted[j].Priority
+	})
+	return sorted
+}
+
+func resolveMaskingPolicies(tenantPolicies []maskingPolicyRecord, settings databaseSettings) []maskingPolicyRecord {
+	connectionPolicies := buildConnectionMaskingPolicies(settings.MaskingPolicies)
+
+	switch normalizeConnectionPolicyMode(settings.MaskingPolicyMode) {
+	case connectionPolicyModeOverride:
+		return connectionPolicies
+	case connectionPolicyModeMerge:
+		return append(connectionPolicies, tenantPolicies...)
+	default:
+		return tenantPolicies
+	}
+}
+
+func buildConnectionMaskingPolicies(items []databaseMaskingPolicySettings) []maskingPolicyRecord {
+	policies := make([]maskingPolicyRecord, 0, len(items))
+	for _, item := range items {
+		if !settingBoolOrDefault(item.Enabled, true) {
+			continue
+		}
+
+		name := strings.TrimSpace(item.Name)
+		columnPattern := strings.TrimSpace(item.ColumnPattern)
+		if name == "" || columnPattern == "" {
+			continue
+		}
+
+		strategy := strings.ToUpper(strings.TrimSpace(item.Strategy))
+		if strategy == "" {
+			strategy = "REDACT"
+		}
+
+		scope := strings.TrimSpace(item.Scope)
+		policies = append(policies, maskingPolicyRecord{
+			Name:          name,
+			ColumnPattern: columnPattern,
+			Strategy:      strategy,
+			ExemptRoles:   item.ExemptRoles,
+			Scope:         sql.NullString{String: scope, Valid: scope != ""},
+		})
+	}
+	return policies
+}
+
+func resolveRateLimitPolicies(tenantPolicies []rateLimitPolicyRecord, connectionID string, settings databaseSettings) []rateLimitPolicyRecord {
+	connectionPolicies := buildConnectionRateLimitPolicies(connectionID, settings.RateLimitPolicies)
+
+	switch normalizeConnectionPolicyMode(settings.RateLimitPolicyMode) {
+	case connectionPolicyModeOverride:
+		return sortRateLimitPolicies(connectionPolicies)
+	case connectionPolicyModeMerge:
+		return sortRateLimitPolicies(append(connectionPolicies, tenantPolicies...))
+	default:
+		return tenantPolicies
+	}
+}
+
+func buildConnectionRateLimitPolicies(connectionID string, items []databaseRateLimitPolicySettings) []rateLimitPolicyRecord {
+	policies := make([]rateLimitPolicyRecord, 0, len(items))
+	connectionKey := strings.TrimSpace(connectionID)
+	if connectionKey == "" {
+		connectionKey = "unknown-connection"
+	}
+
+	for index, item := range items {
+		if !settingBoolOrDefault(item.Enabled, true) {
+			continue
+		}
+
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+
+		windowMS := item.WindowMS
+		if windowMS <= 0 {
+			windowMS = 60000
+		}
+		maxQueries := item.MaxQueries
+		if maxQueries <= 0 {
+			maxQueries = 100
+		}
+		burstMax := item.BurstMax
+		if burstMax <= 0 {
+			burstMax = maxQueries
+		}
+
+		queryType := strings.ToUpper(strings.TrimSpace(item.QueryType))
+		scope := strings.TrimSpace(item.Scope)
+		action := strings.ToUpper(strings.TrimSpace(item.Action))
+		if action == "" {
+			action = "REJECT"
+		}
+
+		localID := strings.TrimSpace(item.ID)
+		if localID == "" {
+			localID = fmt.Sprintf("policy-%d", index)
+		}
+
+		policies = append(policies, rateLimitPolicyRecord{
+			ID:          fmt.Sprintf("conn:%s:%s", connectionKey, localID),
+			Name:        name,
+			QueryType:   sql.NullString{String: queryType, Valid: queryType != ""},
+			WindowMS:    windowMS,
+			MaxQueries:  maxQueries,
+			BurstMax:    burstMax,
+			ExemptRoles: item.ExemptRoles,
+			Scope:       sql.NullString{String: scope, Valid: scope != ""},
+			Action:      action,
+			Priority:    item.Priority,
+		})
+	}
+	return policies
+}
+
+func sortRateLimitPolicies(items []rateLimitPolicyRecord) []rateLimitPolicyRecord {
+	if len(items) < 2 {
+		return items
+	}
+
+	sorted := append([]rateLimitPolicyRecord(nil), items...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Priority > sorted[j].Priority
+	})
+	return sorted
+}

--- a/backend/internal/dbsessions/query_policy_connection_overrides_test.go
+++ b/backend/internal/dbsessions/query_policy_connection_overrides_test.go
@@ -1,0 +1,155 @@
+package dbsessions
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+func TestResolveFirewallRulesModes(t *testing.T) {
+	tenantRules := []firewallRuleRecord{
+		{Name: "Tenant low", Pattern: "tenant_low", Action: "BLOCK", Priority: 10},
+		{Name: "Tenant high", Pattern: "tenant_high", Action: "BLOCK", Priority: 80},
+	}
+	connectionEnabled := true
+	connectionRules := []databaseFirewallRuleSettings{
+		{Name: "Connection top", Pattern: "conn_top", Action: "ALERT", Priority: 100, Enabled: &connectionEnabled},
+		{Name: "Connection mid", Pattern: "conn_mid", Action: "BLOCK", Priority: 50},
+	}
+
+	if got := resolveFirewallRules(tenantRules, databaseSettings{FirewallPolicyMode: "inherit", FirewallRules: connectionRules}); len(got) != 2 || got[0].Name != "Tenant low" || got[1].Name != "Tenant high" {
+		t.Fatalf("inherit mode returned %+v", got)
+	}
+
+	merged := resolveFirewallRules(tenantRules, databaseSettings{FirewallPolicyMode: "merge", FirewallRules: connectionRules})
+	if len(merged) != 4 {
+		t.Fatalf("merge mode returned %d rules, want 4", len(merged))
+	}
+	if merged[0].Name != "Connection top" || merged[1].Name != "Tenant high" || merged[2].Name != "Connection mid" {
+		t.Fatalf("merge mode order = %#v", merged)
+	}
+
+	override := resolveFirewallRules(tenantRules, databaseSettings{FirewallPolicyMode: "override", FirewallRules: connectionRules})
+	if len(override) != 2 || override[0].Name != "Connection top" || override[1].Name != "Connection mid" {
+		t.Fatalf("override mode returned %#v", override)
+	}
+}
+
+func TestLoadMaskingPoliciesWithSettingsUsesConnectionOverridesWithoutDB(t *testing.T) {
+	service := Service{}
+	settings := databaseSettings{
+		MaskingPolicyMode: "override",
+		MaskingPolicies: []databaseMaskingPolicySettings{
+			{Name: "Local email", ColumnPattern: "email", Strategy: "PARTIAL"},
+		},
+	}
+
+	policies := service.loadMaskingPoliciesWithSettings(context.Background(), "", settings)
+	if len(policies) != 1 {
+		t.Fatalf("loadMaskingPoliciesWithSettings() returned %d policies, want 1", len(policies))
+	}
+	if policies[0].Name != "Local email" || policies[0].Strategy != "PARTIAL" {
+		t.Fatalf("unexpected masking policy: %#v", policies[0])
+	}
+}
+
+func TestEvaluateFirewallWithSettingsUsesConnectionRulesWithoutDB(t *testing.T) {
+	service := Service{}
+	settings := databaseSettings{
+		FirewallPolicyMode: "override",
+		FirewallRules: []databaseFirewallRuleSettings{
+			{Name: "Blocked probe", Pattern: "blocked_probe", Action: "BLOCK"},
+		},
+	}
+
+	result := service.evaluateFirewallWithSettings(context.Background(), "", settings, "select 1 as blocked_probe", "", "")
+	if result.Allowed {
+		t.Fatalf("evaluateFirewallWithSettings() allowed query, want blocked result: %#v", result)
+	}
+	if result.RuleName != "Blocked probe" {
+		t.Fatalf("evaluateFirewallWithSettings() rule = %q, want Blocked probe", result.RuleName)
+	}
+}
+
+func TestResolveRateLimitPoliciesNamespacesConnectionPolicies(t *testing.T) {
+	tenantPolicies := []rateLimitPolicyRecord{
+		{ID: "tenant-policy", Name: "Tenant", Priority: 10},
+	}
+	settings := databaseSettings{
+		RateLimitPolicyMode: "merge",
+		RateLimitPolicies: []databaseRateLimitPolicySettings{
+			{ID: "local-limit", Name: "Local", WindowMS: 1000, MaxQueries: 5, BurstMax: 2, Priority: 50},
+		},
+	}
+
+	policies := resolveRateLimitPolicies(tenantPolicies, "conn-123", settings)
+	if len(policies) != 2 {
+		t.Fatalf("resolveRateLimitPolicies() returned %d policies, want 2", len(policies))
+	}
+	if policies[0].Name != "Local" || !strings.HasPrefix(policies[0].ID, "conn:conn-123:local-limit") {
+		t.Fatalf("unexpected connection policy %#v", policies[0])
+	}
+	if policies[1].ID != "tenant-policy" {
+		t.Fatalf("tenant policy id = %q, want tenant-policy", policies[1].ID)
+	}
+}
+
+func TestEvaluateRateLimitWithSettingsUsesConnectionPoliciesWithoutDB(t *testing.T) {
+	service := Service{}
+	connectionEnabled := true
+
+	dbRateLimitBucketsMu.Lock()
+	dbRateLimitBuckets = map[string]*tokenBucket{}
+	dbRateLimitBucketsMu.Unlock()
+
+	settings := databaseSettings{
+		RateLimitPolicyMode: "override",
+		RateLimitPolicies: []databaseRateLimitPolicySettings{
+			{
+				ID:         "local",
+				Name:       "Local throttle",
+				QueryType:  string(dbQueryTypeSelect),
+				WindowMS:   60000,
+				MaxQueries: 1,
+				BurstMax:   1,
+				Action:     "REJECT",
+				Enabled:    &connectionEnabled,
+			},
+		},
+	}
+
+	first := service.evaluateRateLimitWithSettings(context.Background(), "user-1", "tenant-1", "conn-1", settings, dbQueryTypeSelect, "OPERATOR", "", "")
+	if !first.Allowed || !first.Matched {
+		t.Fatalf("first evaluation = %#v, want allowed matched result", first)
+	}
+
+	second := service.evaluateRateLimitWithSettings(context.Background(), "user-1", "tenant-1", "conn-1", settings, dbQueryTypeSelect, "OPERATOR", "", "")
+	if second.Allowed {
+		t.Fatalf("second evaluation = %#v, want blocked result", second)
+	}
+	if second.PolicyName != "Local throttle" {
+		t.Fatalf("second policy = %q, want Local throttle", second.PolicyName)
+	}
+}
+
+func TestResolveMaskingPoliciesMergePrefersConnectionPolicies(t *testing.T) {
+	tenantPolicies := []maskingPolicyRecord{
+		{Name: "Tenant email", ColumnPattern: "email", Strategy: "REDACT", Scope: sql.NullString{}},
+	}
+	settings := databaseSettings{
+		MaskingPolicyMode: "merge",
+		MaskingPolicies: []databaseMaskingPolicySettings{
+			{Name: "Connection email", ColumnPattern: "email", Strategy: "HASH"},
+		},
+	}
+
+	policies := resolveMaskingPolicies(tenantPolicies, settings)
+	masked := findMaskedColumns(policies, []string{"email"}, "", "", "")
+	if len(masked) != 1 {
+		t.Fatalf("findMaskedColumns() returned %d columns, want 1", len(masked))
+	}
+	if masked[0].PolicyName != "Connection email" || masked[0].Strategy != "HASH" {
+		t.Fatalf("masked column = %#v", masked[0])
+	}
+}

--- a/backend/internal/dbsessions/query_policy_firewall.go
+++ b/backend/internal/dbsessions/query_policy_firewall.go
@@ -6,32 +6,23 @@ import (
 )
 
 func (s Service) evaluateFirewall(ctx context.Context, tenantID, queryText, database, table string) firewallEvaluation {
-	if s.DB == nil || strings.TrimSpace(tenantID) == "" {
+	return s.evaluateFirewallWithSettings(ctx, tenantID, databaseSettings{}, queryText, database, table)
+}
+
+func (s Service) evaluateFirewallWithSettings(ctx context.Context, tenantID string, settings databaseSettings, queryText, database, table string) firewallEvaluation {
+	if !settingBoolOrDefault(settings.FirewallEnabled, true) {
 		return firewallEvaluation{Allowed: true}
 	}
 
-	rows, err := s.DB.Query(ctx, `
-SELECT name, pattern, action::text, scope
-FROM "DbFirewallRule"
-WHERE "tenantId" = $1 AND enabled = true
-ORDER BY priority DESC, "createdAt" DESC
-`, tenantID)
-	if err == nil {
-		defer rows.Close()
-
-		for rows.Next() {
-			var rule firewallRuleRecord
-			if scanErr := rows.Scan(&rule.Name, &rule.Pattern, &rule.Action, &rule.Scope); scanErr != nil {
-				break
-			}
-			if matchesScopedRegex(rule.Pattern, rule.Scope.String, queryText, database, table) {
-				action := strings.ToUpper(strings.TrimSpace(rule.Action))
-				return firewallEvaluation{
-					Allowed:  action != "BLOCK",
-					Action:   action,
-					RuleName: rule.Name,
-					Matched:  true,
-				}
+	rules := resolveFirewallRules(s.loadTenantFirewallRules(ctx, tenantID), settings)
+	for _, rule := range rules {
+		if matchesScopedRegex(rule.Pattern, rule.Scope.String, queryText, database, table) {
+			action := strings.ToUpper(strings.TrimSpace(rule.Action))
+			return firewallEvaluation{
+				Allowed:  action != "BLOCK",
+				Action:   action,
+				RuleName: rule.Name,
+				Matched:  true,
 			}
 		}
 	}
@@ -52,6 +43,33 @@ ORDER BY priority DESC, "createdAt" DESC
 	}
 
 	return firewallEvaluation{Allowed: true}
+}
+
+func (s Service) loadTenantFirewallRules(ctx context.Context, tenantID string) []firewallRuleRecord {
+	if s.DB == nil || strings.TrimSpace(tenantID) == "" {
+		return nil
+	}
+
+	rows, err := s.DB.Query(ctx, `
+SELECT name, pattern, action::text, scope, priority
+FROM "DbFirewallRule"
+WHERE "tenantId" = $1 AND enabled = true
+ORDER BY priority DESC, "createdAt" DESC
+`, tenantID)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	rules := make([]firewallRuleRecord, 0)
+	for rows.Next() {
+		var rule firewallRuleRecord
+		if scanErr := rows.Scan(&rule.Name, &rule.Pattern, &rule.Action, &rule.Scope, &rule.Priority); scanErr != nil {
+			return nil
+		}
+		rules = append(rules, rule)
+	}
+	return rules
 }
 
 func matchesScopedRegex(pattern, scope, queryText, database, table string) bool {

--- a/backend/internal/dbsessions/query_policy_masking.go
+++ b/backend/internal/dbsessions/query_policy_masking.go
@@ -10,10 +10,20 @@ import (
 )
 
 func (s Service) loadMaskingPolicies(ctx context.Context, tenantID string) []maskingPolicyRecord {
+	return s.loadMaskingPoliciesWithSettings(ctx, tenantID, databaseSettings{})
+}
+
+func (s Service) loadMaskingPoliciesWithSettings(ctx context.Context, tenantID string, settings databaseSettings) []maskingPolicyRecord {
+	if !settingBoolOrDefault(settings.MaskingEnabled, true) {
+		return nil
+	}
+	return resolveMaskingPolicies(s.loadTenantMaskingPolicies(ctx, tenantID), settings)
+}
+
+func (s Service) loadTenantMaskingPolicies(ctx context.Context, tenantID string) []maskingPolicyRecord {
 	if s.DB == nil || strings.TrimSpace(tenantID) == "" {
 		return nil
 	}
-
 	rows, err := s.DB.Query(ctx, `
 SELECT name, "columnPattern", strategy::text, "exemptRoles", scope
 FROM "DbMaskingPolicy"

--- a/backend/internal/dbsessions/query_policy_rate_limit.go
+++ b/backend/internal/dbsessions/query_policy_rate_limit.go
@@ -8,32 +8,29 @@ import (
 )
 
 func (s Service) evaluateRateLimit(ctx context.Context, userID, tenantID string, queryType dbQueryType, tenantRole, database, table string) rateLimitEvaluation {
-	if s.DB == nil || strings.TrimSpace(tenantID) == "" || strings.TrimSpace(userID) == "" {
-		return rateLimitEvaluation{Allowed: true, Remaining: -1}
-	}
+	return s.evaluateRateLimitWithSettings(ctx, userID, tenantID, "", databaseSettings{}, queryType, tenantRole, database, table)
+}
 
-	rows, err := s.DB.Query(ctx, `
-SELECT id, name, "queryType"::text, "windowMs", "maxQueries", "burstMax", "exemptRoles", scope, action::text
-FROM "DbRateLimitPolicy"
-WHERE "tenantId" = $1 AND enabled = true
-ORDER BY priority DESC, "createdAt" DESC
-`, tenantID)
-	if err != nil {
+func (s Service) evaluateRateLimitWithSettings(ctx context.Context, userID, tenantID, connectionID string, settings databaseSettings, queryType dbQueryType, tenantRole, database, table string) rateLimitEvaluation {
+	if !settingBoolOrDefault(settings.RateLimitEnabled, true) {
 		return rateLimitEvaluation{Allowed: true, Remaining: -1}
 	}
-	defer rows.Close()
+	if strings.TrimSpace(userID) == "" {
+		return rateLimitEvaluation{Allowed: true, Remaining: -1}
+	}
 
 	database = strings.ToLower(strings.TrimSpace(database))
 	table = strings.ToLower(strings.TrimSpace(table))
 	tenantRole = strings.ToUpper(strings.TrimSpace(tenantRole))
+	tenantKey := strings.TrimSpace(tenantID)
+	if tenantKey == "" {
+		tenantKey = "no-tenant"
+	}
 
 	now := time.Now()
+	policies := resolveRateLimitPolicies(s.loadTenantRateLimitPolicies(ctx, tenantID), connectionID, settings)
 
-	for rows.Next() {
-		var policy rateLimitPolicyRecord
-		if scanErr := rows.Scan(&policy.ID, &policy.Name, &policy.QueryType, &policy.WindowMS, &policy.MaxQueries, &policy.BurstMax, &policy.ExemptRoles, &policy.Scope, &policy.Action); scanErr != nil {
-			return rateLimitEvaluation{Allowed: true, Remaining: -1}
-		}
+	for _, policy := range policies {
 		if policy.QueryType.Valid && !strings.EqualFold(policy.QueryType.String, string(queryType)) {
 			continue
 		}
@@ -51,7 +48,7 @@ ORDER BY priority DESC, "createdAt" DESC
 		}
 		bucketKey := strings.Join([]string{
 			strings.TrimSpace(userID),
-			strings.TrimSpace(tenantID),
+			tenantKey,
 			keyType,
 			strings.TrimSpace(policy.ID),
 		}, ":")
@@ -91,6 +88,33 @@ ORDER BY priority DESC, "createdAt" DESC
 	}
 
 	return rateLimitEvaluation{Allowed: true, Remaining: -1}
+}
+
+func (s Service) loadTenantRateLimitPolicies(ctx context.Context, tenantID string) []rateLimitPolicyRecord {
+	if s.DB == nil || strings.TrimSpace(tenantID) == "" {
+		return nil
+	}
+
+	rows, err := s.DB.Query(ctx, `
+SELECT id, name, "queryType"::text, "windowMs", "maxQueries", "burstMax", "exemptRoles", scope, action::text, priority
+FROM "DbRateLimitPolicy"
+WHERE "tenantId" = $1 AND enabled = true
+ORDER BY priority DESC, "createdAt" DESC
+`, tenantID)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	policies := make([]rateLimitPolicyRecord, 0)
+	for rows.Next() {
+		var policy rateLimitPolicyRecord
+		if scanErr := rows.Scan(&policy.ID, &policy.Name, &policy.QueryType, &policy.WindowMS, &policy.MaxQueries, &policy.BurstMax, &policy.ExemptRoles, &policy.Scope, &policy.Action, &policy.Priority); scanErr != nil {
+			return nil
+		}
+		policies = append(policies, policy)
+	}
+	return policies
 }
 
 func cleanupExpiredBucketsLocked(now time.Time) {

--- a/backend/internal/dbsessions/query_policy_types.go
+++ b/backend/internal/dbsessions/query_policy_types.go
@@ -25,10 +25,11 @@ type firewallEvaluation struct {
 }
 
 type firewallRuleRecord struct {
-	Name    string
-	Pattern string
-	Action  string
-	Scope   sql.NullString
+	Name     string
+	Pattern  string
+	Action   string
+	Scope    sql.NullString
+	Priority int
 }
 
 type maskingPolicyRecord struct {
@@ -55,6 +56,7 @@ type rateLimitPolicyRecord struct {
 	ExemptRoles []string
 	Scope       sql.NullString
 	Action      string
+	Priority    int
 }
 
 type rateLimitEvaluation struct {

--- a/backend/internal/dbsessions/query_runtime_execute.go
+++ b/backend/internal/dbsessions/query_runtime_execute.go
@@ -33,7 +33,7 @@ func (s Service) executeOwnedQuery(ctx context.Context, userID, tenantID, tenant
 		return contracts.QueryExecutionResponse{}, err
 	}
 
-	firewallResult := s.evaluateFirewall(ctx, tenantID, sqlText, runtime.DatabaseName, primaryTable)
+	firewallResult := s.evaluateFirewallWithSettings(ctx, tenantID, runtime.Settings, sqlText, runtime.DatabaseName, primaryTable)
 	if !firewallResult.Allowed {
 		blockReason := "Blocked by SQL firewall"
 		if strings.TrimSpace(firewallResult.RuleName) != "" {
@@ -61,7 +61,7 @@ func (s Service) executeOwnedQuery(ctx context.Context, userID, tenantID, tenant
 		}, ipAddress)
 	}
 
-	rateLimit := s.evaluateRateLimit(ctx, userID, tenantID, queryType, tenantRole, runtime.DatabaseName, primaryTable)
+	rateLimit := s.evaluateRateLimitWithSettings(ctx, userID, tenantID, runtime.Connection.ID, runtime.Settings, queryType, tenantRole, runtime.DatabaseName, primaryTable)
 	if rateLimit.Matched && !rateLimit.Allowed {
 		blockReason := "Rate limit exceeded: " + rateLimit.PolicyName
 		s.interceptQuery(ctx, userID, runtime.Connection.ID, tenantID, sessionID, sqlText, nil, nil, true, blockReason, nil)
@@ -97,7 +97,7 @@ func (s Service) executeOwnedQuery(ctx context.Context, userID, tenantID, tenant
 
 	executionPlan := s.captureStoredExecutionPlan(ctx, runtime, sqlText)
 
-	policies := s.loadMaskingPolicies(ctx, tenantID)
+	policies := s.loadMaskingPoliciesWithSettings(ctx, tenantID, runtime.Settings)
 	maskedColumns := findMaskedColumns(policies, result.Columns, tenantRole, runtime.DatabaseName, primaryTable)
 	if len(maskedColumns) > 0 {
 		result.Rows = applyMasking(result.Rows, maskedColumns)
@@ -162,7 +162,7 @@ func (s Service) explainOwnedQuery(ctx context.Context, userID, tenantID, tenant
 		return contracts.QueryPlanResponse{}, err
 	}
 
-	firewallResult := s.evaluateFirewall(ctx, tenantID, sqlText, runtime.DatabaseName, primaryTable)
+	firewallResult := s.evaluateFirewallWithSettings(ctx, tenantID, runtime.Settings, sqlText, runtime.DatabaseName, primaryTable)
 	if !firewallResult.Allowed {
 		blockReason := "Blocked by SQL firewall"
 		if strings.TrimSpace(firewallResult.RuleName) != "" {

--- a/backend/internal/dbsessions/query_runtime_resolution.go
+++ b/backend/internal/dbsessions/query_runtime_resolution.go
@@ -84,6 +84,7 @@ WHERE id = $1
 	return &ownedQueryRuntime{
 		State:                   state,
 		Connection:              connection,
+		Settings:                settings,
 		Target:                  target,
 		Protocol:                dbProtocol,
 		PersistExecutionPlan:    settings.PersistExecutionPlan,

--- a/backend/internal/dbsessions/query_runtime_types.go
+++ b/backend/internal/dbsessions/query_runtime_types.go
@@ -29,6 +29,7 @@ type ownedConnectionSnapshot struct {
 type ownedQueryRuntime struct {
 	State                   *sessions.SessionState
 	Connection              ownedConnectionSnapshot
+	Settings                databaseSettings
 	Target                  *contracts.DatabaseTarget
 	Protocol                string
 	PersistExecutionPlan    bool

--- a/backend/internal/memory/dbgen/models.go
+++ b/backend/internal/memory/dbgen/models.go
@@ -2285,20 +2285,41 @@ type Tenant struct {
 	UserDriveQuotaBytes           pgtype.Int4
 }
 
+type TenantAiBackend struct {
+	ID              string
+	TenantId        string
+	Name            string
+	Provider        string
+	EncryptedApiKey pgtype.Text
+	ApiKeyIV        pgtype.Text
+	ApiKeyTag       pgtype.Text
+	BaseUrl         pgtype.Text
+	DefaultModel    pgtype.Text
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
 type TenantAiConfig struct {
-	ID                  string
-	TenantId            string
-	Provider            string
-	EncryptedApiKey     pgtype.Text
-	ApiKeyIV            pgtype.Text
-	ApiKeyTag           pgtype.Text
-	ModelId             string
-	BaseUrl             pgtype.Text
-	MaxTokensPerRequest int32
-	DailyRequestLimit   int32
-	Enabled             bool
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                     string
+	TenantId               string
+	Provider               string
+	EncryptedApiKey        pgtype.Text
+	ApiKeyIV               pgtype.Text
+	ApiKeyTag              pgtype.Text
+	ModelId                string
+	BaseUrl                pgtype.Text
+	MaxTokensPerRequest    int32
+	DailyRequestLimit      int32
+	Enabled                bool
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	QueryGenerationBackend pgtype.Text
+	QueryGenerationModel   pgtype.Text
+	QueryOptimizerEnabled  bool
+	QueryOptimizerBackend  pgtype.Text
+	QueryOptimizerModel    pgtype.Text
+	Temperature            float64
+	TimeoutMs              int32
 }
 
 type TenantMember struct {

--- a/backend/internal/modelgateway/dbgen/models.go
+++ b/backend/internal/modelgateway/dbgen/models.go
@@ -2285,20 +2285,41 @@ type Tenant struct {
 	UserDriveQuotaBytes           pgtype.Int4
 }
 
+type TenantAiBackend struct {
+	ID              string
+	TenantId        string
+	Name            string
+	Provider        string
+	EncryptedApiKey pgtype.Text
+	ApiKeyIV        pgtype.Text
+	ApiKeyTag       pgtype.Text
+	BaseUrl         pgtype.Text
+	DefaultModel    pgtype.Text
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
 type TenantAiConfig struct {
-	ID                  string
-	TenantId            string
-	Provider            string
-	EncryptedApiKey     pgtype.Text
-	ApiKeyIV            pgtype.Text
-	ApiKeyTag           pgtype.Text
-	ModelId             string
-	BaseUrl             pgtype.Text
-	MaxTokensPerRequest int32
-	DailyRequestLimit   int32
-	Enabled             bool
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                     string
+	TenantId               string
+	Provider               string
+	EncryptedApiKey        pgtype.Text
+	ApiKeyIV               pgtype.Text
+	ApiKeyTag              pgtype.Text
+	ModelId                string
+	BaseUrl                pgtype.Text
+	MaxTokensPerRequest    int32
+	DailyRequestLimit      int32
+	Enabled                bool
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	QueryGenerationBackend pgtype.Text
+	QueryGenerationModel   pgtype.Text
+	QueryOptimizerEnabled  bool
+	QueryOptimizerBackend  pgtype.Text
+	QueryOptimizerModel    pgtype.Text
+	Temperature            float64
+	TimeoutMs              int32
 }
 
 type TenantMember struct {

--- a/backend/internal/modelgatewayapi/ai_firewall.go
+++ b/backend/internal/modelgatewayapi/ai_firewall.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/dnviti/arsenale/backend/internal/dbsessions"
 )
 
 type firewallRuleRecord struct {
@@ -96,6 +98,16 @@ ORDER BY priority DESC, "createdAt" DESC
 	}
 
 	return firewallEvaluation{Allowed: true}, nil
+}
+
+func (s Service) evaluateFirewallForAIContext(ctx context.Context, tenantID string, aiContext dbsessions.OwnedAIContext, queryText, database, table string) (firewallEvaluation, error) {
+	if !boolOrDefault(aiContext.FirewallEnabled, true) {
+		return firewallEvaluation{Allowed: true}, nil
+	}
+	if strings.TrimSpace(database) == "" {
+		database = strings.TrimSpace(aiContext.DatabaseName)
+	}
+	return s.evaluateFirewall(ctx, tenantID, queryText, database, table)
 }
 
 func matchesFirewallRule(pattern, scope, queryText, database, table string) bool {

--- a/backend/internal/modelgatewayapi/ai_generation.go
+++ b/backend/internal/modelgatewayapi/ai_generation.go
@@ -12,29 +12,20 @@ import (
 )
 
 func (s Service) analyzeQueryIntent(ctx context.Context, params analyzeQueryIntentParams) (aiAnalyzeResult, error) {
-	tenantCfg, err := s.loadTenantRuntimeConfig(ctx, params.TenantID)
+	platform, err := s.loadPlatformConfig(ctx, params.TenantID)
 	if err != nil {
 		return aiAnalyzeResult{}, err
 	}
-
-	envCfg := loadAIEnvConfig()
-	if !envCfg.QueryGenerationEnabled && !tenantCfg.Enabled {
+	execution, err := resolveFeatureExecution(platform, params.AIContext, "query-generation")
+	if err != nil {
+		return aiAnalyzeResult{}, err
+	}
+	if !execution.Enabled {
 		return aiAnalyzeResult{}, &requestError{status: http.StatusForbidden, message: "AI query generation is not enabled"}
 	}
 
-	overrides := tenantLLMOverrides(tenantCfg, envCfg)
-	if overrides != nil && strings.TrimSpace(overrides.Model) == "" {
-		overrides.Model = strings.TrimSpace(envCfg.QueryGenerationModel)
-	}
-	if overrides == nil && strings.TrimSpace(envCfg.QueryGenerationModel) != "" {
-		overrides = &llmOverrides{Model: strings.TrimSpace(envCfg.QueryGenerationModel)}
-	}
-
-	dailyLimit := tenantCfg.DailyRequestLimit
-	if dailyLimit <= 0 {
-		dailyLimit = envCfg.MaxRequestsPerDay
-	}
-	if err := s.incrementDailyCounter(ctx, params.TenantID, dailyLimit); err != nil {
+	overrides := llmOverridesFromExecution(execution)
+	if err := s.incrementDailyCounter(ctx, params.TenantID, execution.DailyRequestLimit); err != nil {
 		return aiAnalyzeResult{}, err
 	}
 
@@ -70,6 +61,7 @@ func (s Service) analyzeQueryIntent(ctx context.Context, params analyzeQueryInte
 		DBProtocol: params.DBProtocol,
 		FullSchema: cloneSchemaTables(params.Schema),
 		Overrides:  overrides,
+		AIContext:  params.AIContext,
 		IPAddress:  params.IPAddress,
 		CreatedAt:  now,
 	}
@@ -168,7 +160,7 @@ func (s Service) confirmAndGenerate(ctx context.Context, conversationID string, 
 	}
 
 	var firewallWarning *string
-	if evaluation, err := s.evaluateFirewall(ctx, tenantID, parsed.SQL, "", ""); err == nil && evaluation.Matched {
+	if evaluation, err := s.evaluateFirewallForAIContext(ctx, tenantID, conv.AIContext, parsed.SQL, conv.AIContext.DatabaseName, ""); err == nil && evaluation.Matched {
 		switch evaluation.Action {
 		case "BLOCK":
 			message := "Firewall would block: " + evaluation.RuleName
@@ -179,21 +171,7 @@ func (s Service) confirmAndGenerate(ctx context.Context, conversationID string, 
 		}
 	}
 
-	provider := "none"
-	modelID := ""
-	envCfg := loadAIEnvConfig()
-	if conv.Overrides != nil && strings.TrimSpace(string(conv.Overrides.Provider)) != "" {
-		provider = string(conv.Overrides.Provider)
-	}
-	if provider == "none" && strings.TrimSpace(string(envCfg.Provider)) != "" {
-		provider = string(envCfg.Provider)
-	}
-	if conv.Overrides != nil {
-		modelID = strings.TrimSpace(conv.Overrides.Model)
-	}
-	if modelID == "" {
-		modelID = strings.TrimSpace(envCfg.Model)
-	}
+	provider, modelID := providerAndModelFromOverrides(conv.Overrides)
 
 	_ = s.insertAuditLog(ctx, userID, "AI_QUERY_GENERATED", "DatabaseQuery", tenantID, map[string]any{
 		"prompt":          truncateString(conv.Prompt, 200),

--- a/backend/internal/modelgatewayapi/ai_handlers.go
+++ b/backend/internal/modelgatewayapi/ai_handlers.go
@@ -44,9 +44,17 @@ func (s Service) HandleAnalyzeQuery(w http.ResponseWriter, r *http.Request, clai
 		app.ErrorJSON(w, http.StatusForbidden, "Tenant membership required")
 		return
 	}
+	aiContext, err := s.DatabaseSessions.ResolveOwnedAIContext(r.Context(), claims.UserID, claims.TenantID, req.SessionID)
+	if err != nil {
+		s.writeError(w, err)
+		return
+	}
 
 	schema, sessionProtocol := s.fetchSchemaForAI(r.Context(), claims.UserID, claims.TenantID, req.SessionID)
 	dbProtocol := req.DBProtocol
+	if dbProtocol == "" {
+		dbProtocol = normalizeKnownDBProtocol(aiContext.Protocol)
+	}
 	if dbProtocol == "" {
 		dbProtocol = normalizeKnownDBProtocol(sessionProtocol)
 	}
@@ -60,6 +68,7 @@ func (s Service) HandleAnalyzeQuery(w http.ResponseWriter, r *http.Request, clai
 		Prompt:     req.Prompt,
 		Schema:     schema,
 		DBProtocol: dbProtocol,
+		AIContext:  aiContext,
 		IPAddress:  requestIP(r),
 	})
 	if err != nil {
@@ -135,6 +144,10 @@ func (s Service) HandleOptimizeQuery(w http.ResponseWriter, r *http.Request, cla
 	if req.DBProtocol == "" {
 		_, sessionProtocol := s.fetchSchemaForAI(r.Context(), claims.UserID, claims.TenantID, req.SessionID)
 		req.DBProtocol = normalizeKnownDBProtocol(sessionProtocol)
+	}
+	if strings.TrimSpace(claims.UserID) == "" {
+		app.ErrorJSON(w, http.StatusUnauthorized, "Invalid or expired token")
+		return
 	}
 	if req.DBProtocol == "" {
 		app.ErrorJSON(w, http.StatusBadRequest, `Unsupported dbProtocol "". Must be one of: postgresql, mysql, mongodb, oracle, mssql, db2`)

--- a/backend/internal/modelgatewayapi/ai_optimization.go
+++ b/backend/internal/modelgatewayapi/ai_optimization.go
@@ -14,18 +14,25 @@ import (
 )
 
 func (s Service) optimizeQuery(ctx context.Context, input optimizeQueryInput, userID, tenantID, ipAddress string) (optimizeQueryResult, error) {
-	envCfg := loadAIEnvConfig()
-	tenantCfg, err := s.loadTenantRuntimeConfig(ctx, tenantID)
+	aiContext, err := s.DatabaseSessions.ResolveOwnedAIContext(ctx, userID, tenantID, input.SessionID)
 	if err != nil {
 		return optimizeQueryResult{}, err
 	}
-	overrides := tenantLLMOverrides(tenantCfg, envCfg)
-	if overrides == nil && strings.TrimSpace(string(envCfg.Provider)) == "" {
+	platform, err := s.loadPlatformConfig(ctx, tenantID)
+	if err != nil {
+		return optimizeQueryResult{}, err
+	}
+	execution, err := resolveFeatureExecution(platform, aiContext, "query-optimizer")
+	if err != nil {
+		return optimizeQueryResult{}, err
+	}
+	if !execution.Enabled {
 		return optimizeQueryResult{}, &requestError{
-			status:  http.StatusServiceUnavailable,
-			message: "AI query optimization is not available. An administrator must configure an AI/LLM provider in Settings.",
+			status:  http.StatusForbidden,
+			message: "AI query optimization is not enabled",
 		}
 	}
+	overrides := llmOverridesFromExecution(execution)
 
 	conversationID := uuid.NewString()
 	messages := []llmMessage{
@@ -58,7 +65,7 @@ func (s Service) optimizeQuery(ctx context.Context, input optimizeQueryInput, us
 	}
 	state.mu.Unlock()
 
-	provider, modelID := effectiveLLMProviderAndModel(overrides, envCfg)
+	provider, modelID := providerAndModelFromOverrides(overrides)
 	_ = s.insertAuditLog(ctx, userID, "DB_QUERY_AI_OPTIMIZED", "DatabaseQuery", input.SessionID, map[string]any{
 		"conversationId":   conversationID,
 		"phase":            "initial",
@@ -151,7 +158,7 @@ func (s Service) continueOptimization(ctx context.Context, conversationID string
 		}
 	}
 
-	provider, modelID := effectiveLLMProviderAndModel(conversation.Overrides, loadAIEnvConfig())
+	provider, modelID := providerAndModelFromOverrides(conversation.Overrides)
 	_ = s.insertAuditLog(ctx, userID, "DB_QUERY_AI_OPTIMIZED", "DatabaseQuery", conversation.Input.SessionID, map[string]any{
 		"conversationId":   conversationID,
 		"phase":            "continue",

--- a/backend/internal/modelgatewayapi/ai_provider.go
+++ b/backend/internal/modelgatewayapi/ai_provider.go
@@ -39,8 +39,8 @@ func (s Service) completeLLM(ctx context.Context, options llmCompletionOptions, 
 		if overrides.MaxTokens > 0 {
 			maxTokens = overrides.MaxTokens
 		}
-		if overrides.Temperature != 0 {
-			temperature = overrides.Temperature
+		if overrides.Temperature != nil {
+			temperature = *overrides.Temperature
 		}
 		if overrides.Timeout > 0 {
 			timeout = overrides.Timeout
@@ -50,8 +50,8 @@ func (s Service) completeLLM(ctx context.Context, options llmCompletionOptions, 
 	if options.MaxTokens > 0 {
 		maxTokens = options.MaxTokens
 	}
-	if options.Temperature != 0 {
-		temperature = options.Temperature
+	if options.Temperature != nil {
+		temperature = *options.Temperature
 	}
 	if strings.TrimSpace(string(provider)) == "" {
 		return llmCompletionResult{}, &requestError{
@@ -81,9 +81,15 @@ func (s Service) completeLLM(ctx context.Context, options llmCompletionOptions, 
 
 	switch provider {
 	case contracts.AIProviderAnthropic:
-		return s.completeAnthropic(ctx, options.Messages, modelID, maxTokens, temperature, apiKey, timeout)
+		if strings.TrimSpace(baseURL) == "" {
+			baseURL = "https://api.anthropic.com"
+		}
+		return s.completeAnthropic(ctx, options.Messages, modelID, maxTokens, temperature, baseURL, apiKey, timeout)
 	case contracts.AIProviderOpenAI:
-		return s.completeOpenAICompatible(ctx, options.Messages, modelID, maxTokens, temperature, "https://api.openai.com", timeout, apiKey)
+		if strings.TrimSpace(baseURL) == "" {
+			baseURL = "https://api.openai.com"
+		}
+		return s.completeOpenAICompatible(ctx, options.Messages, modelID, maxTokens, temperature, baseURL, timeout, apiKey)
 	case contracts.AIProviderOllama:
 		return s.completeOpenAICompatible(ctx, options.Messages, modelID, maxTokens, temperature, baseURL, timeout, "")
 	case contracts.AIProviderOpenAICompatible:
@@ -93,7 +99,7 @@ func (s Service) completeLLM(ctx context.Context, options llmCompletionOptions, 
 	}
 }
 
-func (s Service) completeAnthropic(ctx context.Context, messages []llmMessage, modelID string, maxTokens int, temperature float64, apiKey string, timeout time.Duration) (llmCompletionResult, error) {
+func (s Service) completeAnthropic(ctx context.Context, messages []llmMessage, modelID string, maxTokens int, temperature float64, baseURL, apiKey string, timeout time.Duration) (llmCompletionResult, error) {
 	systemPrompt := ""
 	nonSystem := make([]map[string]string, 0, len(messages))
 	for _, message := range messages {
@@ -125,7 +131,13 @@ func (s Service) completeAnthropic(ctx context.Context, messages []llmMessage, m
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, "https://api.anthropic.com/v1/messages", strings.NewReader(string(payload)))
+	endpoint := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if strings.HasSuffix(endpoint, "/v1") {
+		endpoint += "/messages"
+	} else {
+		endpoint += "/v1/messages"
+	}
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, strings.NewReader(string(payload)))
 	if err != nil {
 		return llmCompletionResult{}, err
 	}
@@ -176,7 +188,14 @@ func (s Service) completeOpenAICompatible(ctx context.Context, messages []llmMes
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	endpoint := strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/v1/chat/completions"
+	endpoint := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	switch {
+	case strings.HasSuffix(endpoint, "/chat/completions"):
+	case strings.HasSuffix(endpoint, "/v1"):
+		endpoint += "/chat/completions"
+	default:
+		endpoint += "/v1/chat/completions"
+	}
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, strings.NewReader(string(payload)))
 	if err != nil {
 		return llmCompletionResult{}, err

--- a/backend/internal/modelgatewayapi/ai_runtime.go
+++ b/backend/internal/modelgatewayapi/ai_runtime.go
@@ -80,7 +80,7 @@ func tenantLLMOverrides(tenantCfg tenantRuntimeConfig, envCfg aiEnvConfig) *llmO
 		Model:       strings.TrimSpace(tenantCfg.ModelID),
 		BaseURL:     strings.TrimSpace(tenantCfg.BaseURL),
 		MaxTokens:   tenantCfg.MaxTokensPerRequest,
-		Temperature: envCfg.Temperature,
+		Temperature: &envCfg.Temperature,
 		Timeout:     envCfg.Timeout,
 	}
 }

--- a/backend/internal/modelgatewayapi/ai_types.go
+++ b/backend/internal/modelgatewayapi/ai_types.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dnviti/arsenale/backend/internal/dbsessions"
 	"github.com/dnviti/arsenale/backend/pkg/contracts"
 )
 
@@ -38,6 +39,7 @@ type generationConversation struct {
 	DBProtocol string
 	FullSchema []contracts.SchemaTable
 	Overrides  *llmOverrides
+	AIContext  dbsessions.OwnedAIContext
 	IPAddress  string
 	CreatedAt  time.Time
 }
@@ -62,7 +64,7 @@ type llmMessage struct {
 type llmCompletionOptions struct {
 	Messages    []llmMessage
 	MaxTokens   int
-	Temperature float64
+	Temperature *float64
 }
 
 type llmCompletionResult struct {
@@ -76,7 +78,7 @@ type llmOverrides struct {
 	Model       string
 	BaseURL     string
 	MaxTokens   int
-	Temperature float64
+	Temperature *float64
 	Timeout     time.Duration
 }
 
@@ -191,6 +193,7 @@ type analyzeQueryIntentParams struct {
 	Prompt     string
 	Schema     []contracts.SchemaTable
 	DBProtocol string
+	AIContext  dbsessions.OwnedAIContext
 	IPAddress  string
 }
 

--- a/backend/internal/modelgatewayapi/config_store.go
+++ b/backend/internal/modelgatewayapi/config_store.go
@@ -1,0 +1,824 @@
+package modelgatewayapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dnviti/arsenale/backend/internal/dbsessions"
+	"github.com/dnviti/arsenale/backend/internal/modelgateway"
+	"github.com/dnviti/arsenale/backend/pkg/contracts"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type legacyConfigRow struct {
+	Loaded                 bool
+	Provider               contracts.AIProviderID
+	EncryptedAPIKey        string
+	APIKeyIV               string
+	APIKeyTag              string
+	ModelID                string
+	BaseURL                string
+	MaxTokensPerRequest    int
+	DailyRequestLimit      int
+	Enabled                bool
+	QueryGenerationBackend string
+	QueryGenerationModel   string
+	QueryOptimizerEnabled  bool
+	QueryOptimizerBackend  string
+	QueryOptimizerModel    string
+	Temperature            float64
+	TimeoutMS              int
+}
+
+func defaultStoredAIConfig() storedAIConfig {
+	return storedAIConfig{
+		QueryGeneration: storedAIFeature{
+			Enabled:             false,
+			MaxTokensPerRequest: 4096,
+			DailyRequestLimit:   100,
+		},
+		QueryOptimizer: storedAIFeature{
+			Enabled:             false,
+			MaxTokensPerRequest: 4096,
+		},
+		Temperature: 0.2,
+		TimeoutMS:   60000,
+	}
+}
+
+func normalizeFeatureConfig(feature storedAIFeature, defaultMaxTokens, defaultDailyLimit int) storedAIFeature {
+	feature.Backend = strings.TrimSpace(feature.Backend)
+	feature.ModelID = strings.TrimSpace(feature.ModelID)
+	if feature.MaxTokensPerRequest <= 0 {
+		feature.MaxTokensPerRequest = defaultMaxTokens
+	}
+	if defaultDailyLimit > 0 && feature.DailyRequestLimit <= 0 {
+		feature.DailyRequestLimit = defaultDailyLimit
+	}
+	return feature
+}
+
+func (s Service) loadLegacyConfigRow(ctx context.Context, tenantID string) (legacyConfigRow, error) {
+	if s.DB == nil {
+		return legacyConfigRow{}, errors.New("database is unavailable")
+	}
+
+	row := s.DB.QueryRow(ctx, `
+SELECT provider,
+       COALESCE("encryptedApiKey", ''),
+       COALESCE("apiKeyIV", ''),
+       COALESCE("apiKeyTag", ''),
+       COALESCE("modelId", ''),
+       COALESCE("baseUrl", ''),
+       "maxTokensPerRequest",
+       "dailyRequestLimit",
+       enabled,
+       COALESCE("queryGenerationBackend", ''),
+       COALESCE("queryGenerationModel", ''),
+       "queryOptimizerEnabled",
+       COALESCE("queryOptimizerBackend", ''),
+       COALESCE("queryOptimizerModel", ''),
+       temperature,
+       "timeoutMs"
+FROM "TenantAiConfig"
+WHERE "tenantId" = $1
+`, tenantID)
+
+	var item legacyConfigRow
+	if err := row.Scan(
+		&item.Provider,
+		&item.EncryptedAPIKey,
+		&item.APIKeyIV,
+		&item.APIKeyTag,
+		&item.ModelID,
+		&item.BaseURL,
+		&item.MaxTokensPerRequest,
+		&item.DailyRequestLimit,
+		&item.Enabled,
+		&item.QueryGenerationBackend,
+		&item.QueryGenerationModel,
+		&item.QueryOptimizerEnabled,
+		&item.QueryOptimizerBackend,
+		&item.QueryOptimizerModel,
+		&item.Temperature,
+		&item.TimeoutMS,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return legacyConfigRow{}, nil
+		}
+		return legacyConfigRow{}, fmt.Errorf("load tenant ai config: %w", err)
+	}
+
+	item.Loaded = true
+	item.ModelID = strings.TrimSpace(item.ModelID)
+	item.BaseURL = strings.TrimSpace(item.BaseURL)
+	item.QueryGenerationBackend = strings.TrimSpace(item.QueryGenerationBackend)
+	item.QueryGenerationModel = strings.TrimSpace(item.QueryGenerationModel)
+	item.QueryOptimizerBackend = strings.TrimSpace(item.QueryOptimizerBackend)
+	item.QueryOptimizerModel = strings.TrimSpace(item.QueryOptimizerModel)
+	return item, nil
+}
+
+func (s Service) loadStoredBackends(ctx context.Context, tenantID string) ([]storedAIBackend, error) {
+	if s.DB == nil {
+		return nil, errors.New("database is unavailable")
+	}
+
+	rows, err := s.DB.Query(ctx, `
+SELECT id,
+       name,
+       provider,
+       COALESCE("encryptedApiKey", ''),
+       COALESCE("apiKeyIV", ''),
+       COALESCE("apiKeyTag", ''),
+       COALESCE("baseUrl", ''),
+       COALESCE("defaultModel", ''),
+       "createdAt",
+       "updatedAt"
+FROM "TenantAiBackend"
+WHERE "tenantId" = $1
+ORDER BY name ASC
+`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list tenant ai backends: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]storedAIBackend, 0)
+	for rows.Next() {
+		var item storedAIBackend
+		if err := rows.Scan(
+			&item.ID,
+			&item.Name,
+			&item.Provider,
+			&item.EncryptedAPIKey,
+			&item.APIKeyIV,
+			&item.APIKeyTag,
+			&item.BaseURL,
+			&item.DefaultModel,
+			&item.CreatedAt,
+			&item.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan tenant ai backend: %w", err)
+		}
+		item.Name = strings.TrimSpace(item.Name)
+		item.BaseURL = strings.TrimSpace(item.BaseURL)
+		item.DefaultModel = strings.TrimSpace(item.DefaultModel)
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tenant ai backends: %w", err)
+	}
+	return items, nil
+}
+
+func decryptStoredBackend(item storedAIBackend, key []byte) runtimeAIBackend {
+	runtime := runtimeAIBackend{
+		Name:         item.Name,
+		Provider:     item.Provider,
+		BaseURL:      item.BaseURL,
+		DefaultModel: item.DefaultModel,
+	}
+	if item.EncryptedAPIKey != "" && item.APIKeyIV != "" && item.APIKeyTag != "" && len(key) > 0 {
+		if decrypted, err := modelgateway.DecryptAPIKey(item.EncryptedAPIKey, item.APIKeyIV, item.APIKeyTag, key); err == nil {
+			runtime.APIKey = strings.TrimSpace(decrypted)
+		}
+	}
+	return runtime
+}
+
+func decryptLegacyBackend(row legacyConfigRow, key []byte) runtimeAIBackend {
+	runtime := runtimeAIBackend{
+		Name:         "default",
+		Provider:     row.Provider,
+		BaseURL:      row.BaseURL,
+		DefaultModel: row.ModelID,
+	}
+	if row.EncryptedAPIKey != "" && row.APIKeyIV != "" && row.APIKeyTag != "" && len(key) > 0 {
+		if decrypted, err := modelgateway.DecryptAPIKey(row.EncryptedAPIKey, row.APIKeyIV, row.APIKeyTag, key); err == nil {
+			runtime.APIKey = strings.TrimSpace(decrypted)
+		}
+	}
+	return runtime
+}
+
+func hasLegacyProvider(row legacyConfigRow) bool {
+	provider := strings.TrimSpace(string(row.Provider))
+	return provider != "" && row.Provider != contracts.AIProviderNone
+}
+
+func buildStoredConfig(row legacyConfigRow, backends []storedAIBackend) storedAIConfig {
+	config := defaultStoredAIConfig()
+	config.QueryGeneration = storedAIFeature{
+		Enabled:             row.Enabled,
+		Backend:             row.QueryGenerationBackend,
+		ModelID:             row.QueryGenerationModel,
+		MaxTokensPerRequest: row.MaxTokensPerRequest,
+		DailyRequestLimit:   row.DailyRequestLimit,
+	}
+	config.QueryOptimizer = storedAIFeature{
+		Enabled:             row.QueryOptimizerEnabled,
+		Backend:             row.QueryOptimizerBackend,
+		ModelID:             row.QueryOptimizerModel,
+		MaxTokensPerRequest: row.MaxTokensPerRequest,
+	}
+	if row.Temperature != 0 {
+		config.Temperature = row.Temperature
+	}
+	if row.TimeoutMS > 0 {
+		config.TimeoutMS = row.TimeoutMS
+	}
+
+	hasNamedBackends := len(backends) > 0
+	if !hasNamedBackends && hasLegacyProvider(row) {
+		if config.QueryGeneration.Backend == "" {
+			config.QueryGeneration.Backend = "default"
+		}
+		if config.QueryGeneration.ModelID == "" {
+			config.QueryGeneration.ModelID = row.ModelID
+		}
+		if !config.QueryOptimizer.Enabled {
+			config.QueryOptimizer.Enabled = true
+		}
+		if config.QueryOptimizer.Backend == "" {
+			config.QueryOptimizer.Backend = "default"
+		}
+		if config.QueryOptimizer.ModelID == "" {
+			config.QueryOptimizer.ModelID = row.ModelID
+		}
+	}
+
+	config.QueryGeneration = normalizeFeatureConfig(config.QueryGeneration, 4096, 100)
+	config.QueryOptimizer = normalizeFeatureConfig(config.QueryOptimizer, 4096, 0)
+	return config
+}
+
+func buildConfigResponse(config storedAIConfig, backends []storedAIBackend, legacyRow legacyConfigRow) configResponse {
+	items := make([]aiBackendResponse, 0, len(backends)+1)
+	for _, backend := range backends {
+		item := aiBackendResponse{
+			Name:         backend.Name,
+			Provider:     backend.Provider,
+			HasAPIKey:    backend.EncryptedAPIKey != "",
+			DefaultModel: backend.DefaultModel,
+		}
+		if backend.BaseURL != "" {
+			baseURL := backend.BaseURL
+			item.BaseURL = &baseURL
+		}
+		items = append(items, item)
+	}
+
+	if len(items) == 0 && hasLegacyProvider(legacyRow) {
+		item := aiBackendResponse{
+			Name:         "default",
+			Provider:     legacyRow.Provider,
+			HasAPIKey:    legacyRow.EncryptedAPIKey != "",
+			DefaultModel: legacyRow.ModelID,
+		}
+		if legacyRow.BaseURL != "" {
+			baseURL := legacyRow.BaseURL
+			item.BaseURL = &baseURL
+		}
+		items = append(items, item)
+	}
+
+	response := configResponse{
+		Backends: items,
+		QueryGeneration: aiFeatureResponse{
+			Enabled:             config.QueryGeneration.Enabled,
+			Backend:             config.QueryGeneration.Backend,
+			ModelID:             config.QueryGeneration.ModelID,
+			MaxTokensPerRequest: config.QueryGeneration.MaxTokensPerRequest,
+			DailyRequestLimit:   config.QueryGeneration.DailyRequestLimit,
+		},
+		QueryOptimizer: aiFeatureResponse{
+			Enabled:             config.QueryOptimizer.Enabled,
+			Backend:             config.QueryOptimizer.Backend,
+			ModelID:             config.QueryOptimizer.ModelID,
+			MaxTokensPerRequest: config.QueryOptimizer.MaxTokensPerRequest,
+		},
+		Temperature: config.Temperature,
+		TimeoutMS:   config.TimeoutMS,
+	}
+
+	legacyBackendName := strings.TrimSpace(config.QueryGeneration.Backend)
+	for _, backend := range response.Backends {
+		if backend.Name != legacyBackendName {
+			continue
+		}
+		response.Provider = backend.Provider
+		response.HasAPIKey = backend.HasAPIKey
+		response.BaseURL = backend.BaseURL
+		break
+	}
+	response.ModelID = response.QueryGeneration.ModelID
+	if response.ModelID == "" {
+		for _, backend := range response.Backends {
+			if backend.Name == legacyBackendName {
+				response.ModelID = backend.DefaultModel
+				break
+			}
+		}
+	}
+	if response.Provider == "" {
+		response.Provider = contracts.AIProviderNone
+	}
+	response.MaxTokensPerRequest = response.QueryGeneration.MaxTokensPerRequest
+	response.DailyRequestLimit = response.QueryGeneration.DailyRequestLimit
+	response.Enabled = response.QueryGeneration.Enabled
+	return response
+}
+
+func (s Service) getConfig(ctx context.Context, tenantID string) (configResponse, error) {
+	legacyRow, err := s.loadLegacyConfigRow(ctx, tenantID)
+	if err != nil {
+		return configResponse{}, err
+	}
+	backends, err := s.loadStoredBackends(ctx, tenantID)
+	if err != nil {
+		return configResponse{}, err
+	}
+	return buildConfigResponse(buildStoredConfig(legacyRow, backends), backends, legacyRow), nil
+}
+
+func buildEnvPlatformConfig() (aiPlatformConfig, bool) {
+	envCfg := loadAIEnvConfig()
+	if strings.TrimSpace(string(envCfg.Provider)) == "" || envCfg.Provider == contracts.AIProviderNone {
+		return aiPlatformConfig{}, false
+	}
+
+	defaultModel := strings.TrimSpace(envCfg.Model)
+	if defaultModel == "" {
+		defaultModel = defaultModelForProvider(envCfg.Provider)
+	}
+	queryGenerationModel := strings.TrimSpace(envCfg.QueryGenerationModel)
+	if queryGenerationModel == "" {
+		queryGenerationModel = defaultModel
+	}
+
+	return aiPlatformConfig{
+		Backends: []runtimeAIBackend{{
+			Name:         "environment",
+			Provider:     envCfg.Provider,
+			APIKey:       strings.TrimSpace(envCfg.APIKey),
+			BaseURL:      strings.TrimSpace(envCfg.BaseURL),
+			DefaultModel: defaultModel,
+		}},
+		QueryGeneration: normalizeFeatureConfig(storedAIFeature{
+			Enabled:             envCfg.QueryGenerationEnabled,
+			Backend:             "environment",
+			ModelID:             queryGenerationModel,
+			MaxTokensPerRequest: envCfg.MaxTokens,
+			DailyRequestLimit:   envCfg.MaxRequestsPerDay,
+		}, 4096, 100),
+		QueryOptimizer: normalizeFeatureConfig(storedAIFeature{
+			Enabled:             true,
+			Backend:             "environment",
+			ModelID:             defaultModel,
+			MaxTokensPerRequest: envCfg.MaxTokens,
+		}, 4096, 0),
+		Temperature: envCfg.Temperature,
+		Timeout:     envCfg.Timeout,
+	}, true
+}
+
+func (s Service) loadPlatformConfig(ctx context.Context, tenantID string) (aiPlatformConfig, error) {
+	legacyRow, err := s.loadLegacyConfigRow(ctx, tenantID)
+	if err != nil {
+		return aiPlatformConfig{}, err
+	}
+	backends, err := s.loadStoredBackends(ctx, tenantID)
+	if err != nil {
+		return aiPlatformConfig{}, err
+	}
+
+	config := buildStoredConfig(legacyRow, backends)
+	runtimeBackends := make([]runtimeAIBackend, 0, len(backends)+1)
+	for _, backend := range backends {
+		runtimeBackends = append(runtimeBackends, decryptStoredBackend(backend, s.ServerEncryptionKey))
+	}
+	if len(runtimeBackends) == 0 && hasLegacyProvider(legacyRow) {
+		runtimeBackends = append(runtimeBackends, decryptLegacyBackend(legacyRow, s.ServerEncryptionKey))
+	}
+	if len(runtimeBackends) == 0 && !legacyRow.Loaded {
+		if envPlatform, ok := buildEnvPlatformConfig(); ok {
+			return envPlatform, nil
+		}
+	}
+
+	return aiPlatformConfig{
+		Backends:        runtimeBackends,
+		QueryGeneration: config.QueryGeneration,
+		QueryOptimizer:  config.QueryOptimizer,
+		Temperature:     config.Temperature,
+		Timeout:         time.Duration(config.TimeoutMS) * time.Millisecond,
+	}, nil
+}
+
+func backendMapByName(items []storedAIBackend) map[string]storedAIBackend {
+	result := make(map[string]storedAIBackend, len(items))
+	for _, item := range items {
+		result[item.Name] = item
+	}
+	return result
+}
+
+func normalizeBackendUpdate(input aiBackendUpdate, existing map[string]storedAIBackend, encryptionKey []byte) (storedAIBackend, error) {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return storedAIBackend{}, errors.New("backend name is required")
+	}
+	if input.Provider == "" || input.Provider == contracts.AIProviderNone {
+		return storedAIBackend{}, fmt.Errorf("backend %q requires a provider", name)
+	}
+	providerMeta, ok := modelgateway.LookupProvider(input.Provider)
+	if !ok || input.Provider == contracts.AIProviderNone {
+		return storedAIBackend{}, fmt.Errorf("backend %q has an unsupported provider %q", name, input.Provider)
+	}
+
+	current, hasCurrent := existing[name]
+	item := storedAIBackend{
+		ID:           uuid.NewString(),
+		Name:         name,
+		Provider:     input.Provider,
+		BaseURL:      strings.TrimSpace(stringOrEmpty(input.BaseURL)),
+		DefaultModel: strings.TrimSpace(stringOrEmpty(input.DefaultModel)),
+	}
+	if hasCurrent {
+		item.ID = current.ID
+		item.CreatedAt = current.CreatedAt
+		item.UpdatedAt = current.UpdatedAt
+		item.EncryptedAPIKey = current.EncryptedAPIKey
+		item.APIKeyIV = current.APIKeyIV
+		item.APIKeyTag = current.APIKeyTag
+	}
+
+	if input.ClearAPIKey {
+		item.EncryptedAPIKey = ""
+		item.APIKeyIV = ""
+		item.APIKeyTag = ""
+	}
+	if input.APIKey != nil {
+		apiKey := strings.TrimSpace(*input.APIKey)
+		if apiKey == "" {
+			item.EncryptedAPIKey = ""
+			item.APIKeyIV = ""
+			item.APIKeyTag = ""
+		} else {
+			if len(encryptionKey) == 0 {
+				return storedAIBackend{}, errors.New("SERVER_ENCRYPTION_KEY is required to store apiKey")
+			}
+			ciphertext, iv, tag, err := modelgateway.EncryptAPIKey(apiKey, encryptionKey)
+			if err != nil {
+				return storedAIBackend{}, err
+			}
+			item.EncryptedAPIKey = ciphertext
+			item.APIKeyIV = iv
+			item.APIKeyTag = tag
+		}
+	}
+
+	if providerMeta.RequiresBaseURL && item.BaseURL == "" {
+		return storedAIBackend{}, fmt.Errorf("backend %q requires baseUrl", name)
+	}
+	if providerMeta.RequiresAPIKey && item.EncryptedAPIKey == "" {
+		return storedAIBackend{}, fmt.Errorf("backend %q requires an apiKey", name)
+	}
+	if item.DefaultModel == "" {
+		item.DefaultModel = providerMeta.DefaultModel
+	}
+	return item, nil
+}
+
+func normalizeFeatureUpdate(feature aiFeatureUpdate, defaultMaxTokens, defaultDailyLimit int) storedAIFeature {
+	item := storedAIFeature{
+		Enabled:             feature.Enabled,
+		Backend:             strings.TrimSpace(feature.Backend),
+		ModelID:             strings.TrimSpace(feature.ModelID),
+		MaxTokensPerRequest: feature.MaxTokensPerRequest,
+		DailyRequestLimit:   feature.DailyRequestLimit,
+	}
+	return normalizeFeatureConfig(item, defaultMaxTokens, defaultDailyLimit)
+}
+
+func validateFeatureBackend(featureName string, feature storedAIFeature, backends []storedAIBackend) error {
+	if !feature.Enabled {
+		return nil
+	}
+	if strings.TrimSpace(feature.Backend) == "" {
+		return fmt.Errorf("%s backend is required when the feature is enabled", featureName)
+	}
+	for _, backend := range backends {
+		if backend.Name == feature.Backend {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s backend %q is not configured", featureName, feature.Backend)
+}
+
+func legacyColumnsForFeature(feature storedAIFeature, backends []storedAIBackend) legacyConfigRow {
+	row := legacyConfigRow{
+		Provider:            contracts.AIProviderNone,
+		MaxTokensPerRequest: feature.MaxTokensPerRequest,
+		DailyRequestLimit:   feature.DailyRequestLimit,
+		Enabled:             feature.Enabled,
+		ModelID:             feature.ModelID,
+	}
+	for _, backend := range backends {
+		if backend.Name != feature.Backend {
+			continue
+		}
+		row.Provider = backend.Provider
+		row.EncryptedAPIKey = backend.EncryptedAPIKey
+		row.APIKeyIV = backend.APIKeyIV
+		row.APIKeyTag = backend.APIKeyTag
+		row.BaseURL = backend.BaseURL
+		if row.ModelID == "" {
+			row.ModelID = backend.DefaultModel
+		}
+		break
+	}
+	return row
+}
+
+func (s Service) saveConfig(ctx context.Context, tenantID, userID string, update configUpdate) (configResponse, error) {
+	if s.DB == nil {
+		return configResponse{}, errors.New("database is unavailable")
+	}
+
+	existingBackends, err := s.loadStoredBackends(ctx, tenantID)
+	if err != nil {
+		return configResponse{}, err
+	}
+	existingByName := backendMapByName(existingBackends)
+
+	normalizedBackends := make([]storedAIBackend, 0, len(update.Backends))
+	seenNames := make(map[string]struct{}, len(update.Backends))
+	for _, backend := range update.Backends {
+		normalized, err := normalizeBackendUpdate(backend, existingByName, s.ServerEncryptionKey)
+		if err != nil {
+			return configResponse{}, err
+		}
+		if _, exists := seenNames[normalized.Name]; exists {
+			return configResponse{}, fmt.Errorf("backend name %q is duplicated", normalized.Name)
+		}
+		seenNames[normalized.Name] = struct{}{}
+		normalizedBackends = append(normalizedBackends, normalized)
+	}
+
+	queryGeneration := normalizeFeatureUpdate(update.QueryGeneration, 4096, 100)
+	queryOptimizer := normalizeFeatureUpdate(update.QueryOptimizer, 4096, 0)
+	if err := validateFeatureBackend("queryGeneration", queryGeneration, normalizedBackends); err != nil {
+		return configResponse{}, err
+	}
+	if err := validateFeatureBackend("queryOptimizer", queryOptimizer, normalizedBackends); err != nil {
+		return configResponse{}, err
+	}
+
+	temperature := update.Temperature
+	if temperature < 0 || temperature > 2 {
+		return configResponse{}, errors.New("temperature must be between 0 and 2")
+	}
+	timeoutMS := update.TimeoutMS
+	if timeoutMS <= 0 {
+		timeoutMS = 60000
+	}
+
+	legacy := legacyColumnsForFeature(queryGeneration, normalizedBackends)
+	legacy.QueryGenerationBackend = queryGeneration.Backend
+	legacy.QueryGenerationModel = queryGeneration.ModelID
+	legacy.QueryOptimizerEnabled = queryOptimizer.Enabled
+	legacy.QueryOptimizerBackend = queryOptimizer.Backend
+	legacy.QueryOptimizerModel = queryOptimizer.ModelID
+	legacy.Temperature = temperature
+	legacy.TimeoutMS = timeoutMS
+
+	tx, err := s.DB.Begin(ctx)
+	if err != nil {
+		return configResponse{}, fmt.Errorf("begin ai config update: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+INSERT INTO "TenantAiConfig" (
+	id,
+	"tenantId",
+	provider,
+	"encryptedApiKey",
+	"apiKeyIV",
+	"apiKeyTag",
+	"modelId",
+	"baseUrl",
+	"maxTokensPerRequest",
+	"dailyRequestLimit",
+	enabled,
+	"queryGenerationBackend",
+	"queryGenerationModel",
+	"queryOptimizerEnabled",
+	"queryOptimizerBackend",
+	"queryOptimizerModel",
+	temperature,
+	"timeoutMs",
+	"createdAt",
+	"updatedAt"
+)
+VALUES (
+	$1, $2, $3, NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''),
+	$9, $10, $11, NULLIF($12, ''), NULLIF($13, ''), $14, NULLIF($15, ''), NULLIF($16, ''), $17, $18, NOW(), NOW()
+)
+ON CONFLICT ("tenantId") DO UPDATE SET
+	provider = EXCLUDED.provider,
+	"encryptedApiKey" = EXCLUDED."encryptedApiKey",
+	"apiKeyIV" = EXCLUDED."apiKeyIV",
+	"apiKeyTag" = EXCLUDED."apiKeyTag",
+	"modelId" = EXCLUDED."modelId",
+	"baseUrl" = EXCLUDED."baseUrl",
+	"maxTokensPerRequest" = EXCLUDED."maxTokensPerRequest",
+	"dailyRequestLimit" = EXCLUDED."dailyRequestLimit",
+	enabled = EXCLUDED.enabled,
+	"queryGenerationBackend" = EXCLUDED."queryGenerationBackend",
+	"queryGenerationModel" = EXCLUDED."queryGenerationModel",
+	"queryOptimizerEnabled" = EXCLUDED."queryOptimizerEnabled",
+	"queryOptimizerBackend" = EXCLUDED."queryOptimizerBackend",
+	"queryOptimizerModel" = EXCLUDED."queryOptimizerModel",
+	temperature = EXCLUDED.temperature,
+	"timeoutMs" = EXCLUDED."timeoutMs",
+	"updatedAt" = NOW()
+`, uuid.NewString(), tenantID, legacy.Provider, legacy.EncryptedAPIKey, legacy.APIKeyIV, legacy.APIKeyTag, legacy.ModelID, legacy.BaseURL, queryGeneration.MaxTokensPerRequest, queryGeneration.DailyRequestLimit, queryGeneration.Enabled, queryGeneration.Backend, queryGeneration.ModelID, queryOptimizer.Enabled, queryOptimizer.Backend, queryOptimizer.ModelID, temperature, timeoutMS); err != nil {
+		return configResponse{}, fmt.Errorf("upsert tenant ai config: %w", err)
+	}
+
+	names := make([]string, 0, len(normalizedBackends))
+	for _, backend := range normalizedBackends {
+		names = append(names, backend.Name)
+	}
+	if _, err := tx.Exec(ctx, `
+DELETE FROM "TenantAiBackend"
+WHERE "tenantId" = $1
+  AND NOT (name = ANY($2))
+`, tenantID, names); err != nil {
+		return configResponse{}, fmt.Errorf("delete stale ai backends: %w", err)
+	}
+	if len(normalizedBackends) == 0 {
+		if _, err := tx.Exec(ctx, `DELETE FROM "TenantAiBackend" WHERE "tenantId" = $1`, tenantID); err != nil {
+			return configResponse{}, fmt.Errorf("clear ai backends: %w", err)
+		}
+	}
+
+	for _, backend := range normalizedBackends {
+		if _, err := tx.Exec(ctx, `
+INSERT INTO "TenantAiBackend" (
+	id,
+	"tenantId",
+	name,
+	provider,
+	"encryptedApiKey",
+	"apiKeyIV",
+	"apiKeyTag",
+	"baseUrl",
+	"defaultModel",
+	"createdAt",
+	"updatedAt"
+)
+VALUES (
+	$1, $2, $3, $4, NULLIF($5, ''), NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), NULLIF($9, ''), NOW(), NOW()
+)
+ON CONFLICT ("tenantId", name) DO UPDATE SET
+	provider = EXCLUDED.provider,
+	"encryptedApiKey" = EXCLUDED."encryptedApiKey",
+	"apiKeyIV" = EXCLUDED."apiKeyIV",
+	"apiKeyTag" = EXCLUDED."apiKeyTag",
+	"baseUrl" = EXCLUDED."baseUrl",
+	"defaultModel" = EXCLUDED."defaultModel",
+	"updatedAt" = NOW()
+`, backend.ID, tenantID, backend.Name, backend.Provider, backend.EncryptedAPIKey, backend.APIKeyIV, backend.APIKeyTag, backend.BaseURL, backend.DefaultModel); err != nil {
+			return configResponse{}, fmt.Errorf("upsert ai backend %q: %w", backend.Name, err)
+		}
+	}
+
+	if err := s.insertAuditLog(ctx, userID, "APP_CONFIG_UPDATE", "ai_config", tenantID, map[string]any{
+		"backendNames":       names,
+		"queryGeneration":    map[string]any{"enabled": queryGeneration.Enabled, "backend": queryGeneration.Backend, "modelId": queryGeneration.ModelID},
+		"queryOptimizer":     map[string]any{"enabled": queryOptimizer.Enabled, "backend": queryOptimizer.Backend, "modelId": queryOptimizer.ModelID},
+		"temperature":        temperature,
+		"timeoutMs":          timeoutMS,
+		"configuredBackends": len(normalizedBackends),
+	}, ""); err != nil {
+		return configResponse{}, fmt.Errorf("audit ai config update: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return configResponse{}, fmt.Errorf("commit ai config update: %w", err)
+	}
+
+	return buildConfigResponse(storedAIConfig{
+		QueryGeneration: queryGeneration,
+		QueryOptimizer:  queryOptimizer,
+		Temperature:     temperature,
+		TimeoutMS:       timeoutMS,
+	}, normalizedBackends, legacy), nil
+}
+
+func stringOrEmpty(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}
+
+func findRuntimeBackend(backends []runtimeAIBackend, name string) (runtimeAIBackend, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return runtimeAIBackend{}, false
+	}
+	for _, backend := range backends {
+		if backend.Name == name {
+			return backend, true
+		}
+	}
+	return runtimeAIBackend{}, false
+}
+
+func boolOrDefault(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func resolveFeatureExecution(platform aiPlatformConfig, context dbsessions.OwnedAIContext, featureName string) (aiFeatureExecution, error) {
+	switch featureName {
+	case "query-generation":
+		enabled := boolOrDefault(context.AIQueryGenerationEnabled, platform.QueryGeneration.Enabled)
+		backendName := strings.TrimSpace(context.AIQueryGenerationBackend)
+		if backendName == "" {
+			backendName = platform.QueryGeneration.Backend
+		}
+		modelID := strings.TrimSpace(context.AIQueryGenerationModel)
+		if modelID == "" {
+			modelID = platform.QueryGeneration.ModelID
+		}
+		return buildFeatureExecution(platform, enabled, backendName, modelID, platform.QueryGeneration.MaxTokensPerRequest, platform.QueryGeneration.DailyRequestLimit)
+	case "query-optimizer":
+		enabled := boolOrDefault(context.AIQueryOptimizerEnabled, platform.QueryOptimizer.Enabled)
+		backendName := strings.TrimSpace(context.AIQueryOptimizerBackend)
+		if backendName == "" {
+			backendName = platform.QueryOptimizer.Backend
+		}
+		modelID := strings.TrimSpace(context.AIQueryOptimizerModel)
+		if modelID == "" {
+			modelID = platform.QueryOptimizer.ModelID
+		}
+		return buildFeatureExecution(platform, enabled, backendName, modelID, platform.QueryOptimizer.MaxTokensPerRequest, platform.QueryOptimizer.DailyRequestLimit)
+	default:
+		return aiFeatureExecution{}, fmt.Errorf("unsupported ai feature %q", featureName)
+	}
+}
+
+func buildFeatureExecution(platform aiPlatformConfig, enabled bool, backendName, modelID string, maxTokens, dailyLimit int) (aiFeatureExecution, error) {
+	if !enabled {
+		return aiFeatureExecution{}, nil
+	}
+	backend, ok := findRuntimeBackend(platform.Backends, backendName)
+	if !ok {
+		return aiFeatureExecution{}, &requestError{status: 503, message: "AI backend is not configured or is unavailable."}
+	}
+	if modelID == "" {
+		modelID = strings.TrimSpace(backend.DefaultModel)
+	}
+	if modelID == "" {
+		modelID = defaultModelForProvider(backend.Provider)
+	}
+	if modelID == "" {
+		return aiFeatureExecution{}, &requestError{status: 503, message: "AI model is not configured and no default is available for the selected backend."}
+	}
+
+	providerMeta, ok := modelgateway.LookupProvider(backend.Provider)
+	if !ok {
+		return aiFeatureExecution{}, &requestError{status: 503, message: "AI backend provider is not supported."}
+	}
+	if providerMeta.RequiresAPIKey && strings.TrimSpace(backend.APIKey) == "" {
+		return aiFeatureExecution{}, &requestError{status: 503, message: "AI backend API key is not configured."}
+	}
+	if providerMeta.RequiresBaseURL && strings.TrimSpace(backend.BaseURL) == "" {
+		return aiFeatureExecution{}, &requestError{status: 503, message: fmt.Sprintf("AI backend base URL is required for %s.", backend.Provider)}
+	}
+
+	if maxTokens <= 0 {
+		maxTokens = 4096
+	}
+	return aiFeatureExecution{
+		Enabled:           true,
+		Backend:           backend,
+		ModelID:           modelID,
+		MaxTokens:         maxTokens,
+		DailyRequestLimit: dailyLimit,
+		Temperature:       platform.Temperature,
+		Timeout:           platform.Timeout,
+	}, nil
+}

--- a/backend/internal/modelgatewayapi/config_types.go
+++ b/backend/internal/modelgatewayapi/config_types.go
@@ -1,0 +1,118 @@
+package modelgatewayapi
+
+import (
+	"time"
+
+	"github.com/dnviti/arsenale/backend/pkg/contracts"
+)
+
+type aiBackendResponse struct {
+	Name         string                 `json:"name"`
+	Provider     contracts.AIProviderID `json:"provider"`
+	HasAPIKey    bool                   `json:"hasApiKey"`
+	BaseURL      *string                `json:"baseUrl,omitempty"`
+	DefaultModel string                 `json:"defaultModel,omitempty"`
+}
+
+type aiFeatureResponse struct {
+	Enabled             bool   `json:"enabled"`
+	Backend             string `json:"backend,omitempty"`
+	ModelID             string `json:"modelId,omitempty"`
+	MaxTokensPerRequest int    `json:"maxTokensPerRequest"`
+	DailyRequestLimit   int    `json:"dailyRequestLimit,omitempty"`
+}
+
+type configResponse struct {
+	Backends        []aiBackendResponse `json:"backends"`
+	QueryGeneration aiFeatureResponse   `json:"queryGeneration"`
+	QueryOptimizer  aiFeatureResponse   `json:"queryOptimizer"`
+	Temperature     float64             `json:"temperature"`
+	TimeoutMS       int                 `json:"timeoutMs"`
+
+	Provider            contracts.AIProviderID `json:"provider"`
+	HasAPIKey           bool                   `json:"hasApiKey"`
+	ModelID             string                 `json:"modelId"`
+	BaseURL             *string                `json:"baseUrl"`
+	MaxTokensPerRequest int                    `json:"maxTokensPerRequest"`
+	DailyRequestLimit   int                    `json:"dailyRequestLimit"`
+	Enabled             bool                   `json:"enabled"`
+}
+
+type aiBackendUpdate struct {
+	Name         string                 `json:"name"`
+	Provider     contracts.AIProviderID `json:"provider"`
+	APIKey       *string                `json:"apiKey,omitempty"`
+	ClearAPIKey  bool                   `json:"clearApiKey,omitempty"`
+	BaseURL      *string                `json:"baseUrl,omitempty"`
+	DefaultModel *string                `json:"defaultModel,omitempty"`
+}
+
+type aiFeatureUpdate struct {
+	Enabled             bool   `json:"enabled"`
+	Backend             string `json:"backend,omitempty"`
+	ModelID             string `json:"modelId,omitempty"`
+	MaxTokensPerRequest int    `json:"maxTokensPerRequest,omitempty"`
+	DailyRequestLimit   int    `json:"dailyRequestLimit,omitempty"`
+}
+
+type configUpdate struct {
+	Backends        []aiBackendUpdate `json:"backends"`
+	QueryGeneration aiFeatureUpdate   `json:"queryGeneration"`
+	QueryOptimizer  aiFeatureUpdate   `json:"queryOptimizer"`
+	Temperature     float64           `json:"temperature"`
+	TimeoutMS       int               `json:"timeoutMs"`
+}
+
+type storedAIConfig struct {
+	QueryGeneration storedAIFeature
+	QueryOptimizer  storedAIFeature
+	Temperature     float64
+	TimeoutMS       int
+}
+
+type storedAIBackend struct {
+	ID              string
+	Name            string
+	Provider        contracts.AIProviderID
+	EncryptedAPIKey string
+	APIKeyIV        string
+	APIKeyTag       string
+	BaseURL         string
+	DefaultModel    string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type storedAIFeature struct {
+	Enabled             bool
+	Backend             string
+	ModelID             string
+	MaxTokensPerRequest int
+	DailyRequestLimit   int
+}
+
+type runtimeAIBackend struct {
+	Name         string
+	Provider     contracts.AIProviderID
+	APIKey       string
+	BaseURL      string
+	DefaultModel string
+}
+
+type aiPlatformConfig struct {
+	Backends        []runtimeAIBackend
+	QueryGeneration storedAIFeature
+	QueryOptimizer  storedAIFeature
+	Temperature     float64
+	Timeout         time.Duration
+}
+
+type aiFeatureExecution struct {
+	Enabled           bool
+	Backend           runtimeAIBackend
+	ModelID           string
+	MaxTokens         int
+	DailyRequestLimit int
+	Temperature       float64
+	Timeout           time.Duration
+}

--- a/backend/internal/modelgatewayapi/feature_resolution.go
+++ b/backend/internal/modelgatewayapi/feature_resolution.go
@@ -1,0 +1,63 @@
+package modelgatewayapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/dnviti/arsenale/backend/internal/dbsessions"
+)
+
+func llmOverridesFromExecution(execution aiFeatureExecution) *llmOverrides {
+	if !execution.Enabled {
+		return nil
+	}
+	return &llmOverrides{
+		Provider:    execution.Backend.Provider,
+		APIKey:      strings.TrimSpace(execution.Backend.APIKey),
+		Model:       strings.TrimSpace(execution.ModelID),
+		BaseURL:     strings.TrimSpace(execution.Backend.BaseURL),
+		MaxTokens:   execution.MaxTokens,
+		Temperature: &execution.Temperature,
+		Timeout:     execution.Timeout,
+	}
+}
+
+func providerAndModelFromOverrides(overrides *llmOverrides) (string, string) {
+	if overrides == nil {
+		return "none", ""
+	}
+	provider := strings.TrimSpace(string(overrides.Provider))
+	if provider == "" {
+		provider = "none"
+	}
+	modelID := strings.TrimSpace(overrides.Model)
+	return provider, modelID
+}
+
+func (s Service) resolveFeatureExecutionForSession(ctx context.Context, userID, tenantID, sessionID, featureName string) (dbsessions.OwnedAIContext, aiFeatureExecution, error) {
+	aiContext, err := s.DatabaseSessions.ResolveOwnedAIContext(ctx, userID, tenantID, sessionID)
+	if err != nil {
+		return dbsessions.OwnedAIContext{}, aiFeatureExecution{}, err
+	}
+	platform, err := s.loadPlatformConfig(ctx, tenantID)
+	if err != nil {
+		return dbsessions.OwnedAIContext{}, aiFeatureExecution{}, err
+	}
+	execution, err := resolveFeatureExecution(platform, aiContext, featureName)
+	if err != nil {
+		return dbsessions.OwnedAIContext{}, aiFeatureExecution{}, err
+	}
+	if execution.Enabled {
+		return aiContext, execution, nil
+	}
+
+	message := "AI feature is not enabled"
+	switch featureName {
+	case "query-generation":
+		message = "AI query generation is not enabled"
+	case "query-optimizer":
+		message = "AI query optimization is not enabled"
+	}
+	return aiContext, aiFeatureExecution{}, &requestError{status: http.StatusForbidden, message: message}
+}

--- a/backend/internal/modelgatewayapi/service.go
+++ b/backend/internal/modelgatewayapi/service.go
@@ -2,7 +2,6 @@ package modelgatewayapi
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"github.com/dnviti/arsenale/backend/internal/dbsessions"
 	"github.com/dnviti/arsenale/backend/internal/modelgateway"
 	"github.com/dnviti/arsenale/backend/internal/tenantauth"
-	"github.com/dnviti/arsenale/backend/pkg/contracts"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -30,16 +28,6 @@ type Service struct {
 type requestError struct {
 	status  int
 	message string
-}
-
-type configResponse struct {
-	Provider            contracts.AIProviderID `json:"provider"`
-	HasAPIKey           bool                   `json:"hasApiKey"`
-	ModelID             string                 `json:"modelId"`
-	BaseURL             *string                `json:"baseUrl"`
-	MaxTokensPerRequest int                    `json:"maxTokensPerRequest"`
-	DailyRequestLimit   int                    `json:"dailyRequestLimit"`
-	Enabled             bool                   `json:"enabled"`
 }
 
 func (e *requestError) Error() string {
@@ -62,7 +50,7 @@ func (s Service) HandleGetConfig(w http.ResponseWriter, r *http.Request, claims 
 		return
 	}
 
-	app.WriteJSON(w, http.StatusOK, normalizeConfigResponse(cfg))
+	app.WriteJSON(w, http.StatusOK, cfg)
 }
 
 func (s Service) HandleUpdateConfig(w http.ResponseWriter, r *http.Request, claims authn.Claims) {
@@ -75,45 +63,19 @@ func (s Service) HandleUpdateConfig(w http.ResponseWriter, r *http.Request, clai
 		return
 	}
 
-	var payload map[string]json.RawMessage
-	if err := app.ReadJSON(r, &payload); err != nil {
+	var update configUpdate
+	if err := app.ReadJSON(r, &update); err != nil {
 		app.ErrorJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	update, err := parseUpdatePayload(payload)
+	cfg, err := s.saveConfig(r.Context(), claims.TenantID, claims.UserID, update)
 	if err != nil {
-		app.ErrorJSON(w, http.StatusBadRequest, err.Error())
+		s.writeError(w, classifyConfigError(err))
 		return
 	}
 
-	if s.Store == nil {
-		s.writeError(w, errors.New("model gateway store is not configured"))
-		return
-	}
-
-	cfg, err := s.Store.UpsertConfig(r.Context(), claims.TenantID, update, s.ServerEncryptionKey)
-	if err != nil {
-		s.writeError(w, classifyStoreError(err))
-		return
-	}
-
-	app.WriteJSON(w, http.StatusOK, normalizeConfigResponse(cfg))
-}
-
-func (s Service) getConfig(ctx context.Context, tenantID string) (contracts.TenantAIConfig, error) {
-	if s.Store == nil {
-		return contracts.TenantAIConfig{}, errors.New("model gateway store is not configured")
-	}
-
-	cfg, err := s.Store.GetConfig(ctx, tenantID)
-	if err == nil {
-		return cfg, nil
-	}
-	if modelgateway.IsNotFound(err) {
-		return defaultTenantAIConfig(tenantID), nil
-	}
-	return contracts.TenantAIConfig{}, err
+	app.WriteJSON(w, http.StatusOK, cfg)
 }
 
 func (s Service) requireTenantRole(ctx context.Context, claims authn.Claims, minimum string) error {
@@ -150,120 +112,25 @@ func requireDatabaseProxyFeature() error {
 	return nil
 }
 
-func defaultTenantAIConfig(tenantID string) contracts.TenantAIConfig {
-	return contracts.TenantAIConfig{
-		TenantID:            tenantID,
-		Provider:            contracts.AIProviderNone,
-		HasAPIKey:           false,
-		ModelID:             "",
-		BaseURL:             "",
-		MaxTokensPerRequest: 4000,
-		DailyRequestLimit:   100,
-		Enabled:             false,
-	}
-}
-
-func normalizeConfigResponse(cfg contracts.TenantAIConfig) configResponse {
-	response := configResponse{
-		Provider:            cfg.Provider,
-		HasAPIKey:           cfg.HasAPIKey,
-		ModelID:             cfg.ModelID,
-		MaxTokensPerRequest: cfg.MaxTokensPerRequest,
-		DailyRequestLimit:   cfg.DailyRequestLimit,
-		Enabled:             cfg.Enabled,
-	}
-	if trimmed := strings.TrimSpace(cfg.BaseURL); trimmed != "" {
-		response.BaseURL = &trimmed
-	}
-	return response
-}
-
-func parseUpdatePayload(payload map[string]json.RawMessage) (contracts.TenantAIConfigUpdate, error) {
-	var update contracts.TenantAIConfigUpdate
-	allowed := map[string]struct{}{
-		"provider":            {},
-		"apiKey":              {},
-		"modelId":             {},
-		"baseUrl":             {},
-		"maxTokensPerRequest": {},
-		"dailyRequestLimit":   {},
-		"enabled":             {},
-	}
-	for key := range payload {
-		if _, ok := allowed[key]; !ok {
-			return contracts.TenantAIConfigUpdate{}, fmt.Errorf("unknown field %q", key)
-		}
+func classifyConfigError(err error) error {
+	var reqErr *requestError
+	if errors.As(err, &reqErr) {
+		return reqErr
 	}
 
-	if raw, ok := payload["provider"]; ok {
-		var provider contracts.AIProviderID
-		if err := json.Unmarshal(raw, &provider); err != nil {
-			return contracts.TenantAIConfigUpdate{}, fmt.Errorf("provider must be a string")
-		}
-		update.Provider = &provider
-	}
-	if raw, ok := payload["apiKey"]; ok {
-		var apiKey string
-		if err := json.Unmarshal(raw, &apiKey); err != nil {
-			return contracts.TenantAIConfigUpdate{}, fmt.Errorf("apiKey must be a string")
-		}
-		update.APIKey = &apiKey
-	}
-	if raw, ok := payload["modelId"]; ok {
-		var modelID string
-		if err := json.Unmarshal(raw, &modelID); err != nil {
-			return contracts.TenantAIConfigUpdate{}, fmt.Errorf("modelId must be a string")
-		}
-		update.ModelID = &modelID
-	}
-	if raw, ok := payload["baseUrl"]; ok {
-		baseURL, err := decodeNullableString(raw, "baseUrl")
-		if err != nil {
-			return contracts.TenantAIConfigUpdate{}, err
-		}
-		update.BaseURL = &baseURL
-	}
-	if raw, ok := payload["maxTokensPerRequest"]; ok {
-		var value int
-		if err := json.Unmarshal(raw, &value); err != nil {
-			return contracts.TenantAIConfigUpdate{}, fmt.Errorf("maxTokensPerRequest must be a number")
-		}
-		update.MaxTokensPerRequest = &value
-	}
-	if raw, ok := payload["dailyRequestLimit"]; ok {
-		var value int
-		if err := json.Unmarshal(raw, &value); err != nil {
-			return contracts.TenantAIConfigUpdate{}, fmt.Errorf("dailyRequestLimit must be a number")
-		}
-		update.DailyRequestLimit = &value
-	}
-	if raw, ok := payload["enabled"]; ok {
-		var enabled bool
-		if err := json.Unmarshal(raw, &enabled); err != nil {
-			return contracts.TenantAIConfigUpdate{}, fmt.Errorf("enabled must be a boolean")
-		}
-		update.Enabled = &enabled
-	}
-
-	return update, nil
-}
-
-func decodeNullableString(raw json.RawMessage, field string) (string, error) {
-	if strings.TrimSpace(string(raw)) == "null" {
-		return "", nil
-	}
-	var value string
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return "", fmt.Errorf("%s must be a string or null", field)
-	}
-	return value, nil
-}
-
-func classifyStoreError(err error) error {
 	lowered := strings.ToLower(err.Error())
 	switch {
-	case strings.HasPrefix(lowered, "invalid tenant ai config:"):
-		return &requestError{status: http.StatusBadRequest, message: strings.TrimPrefix(err.Error(), "invalid tenant ai config: ")}
+	case strings.Contains(lowered, "json: unknown field"),
+		strings.Contains(lowered, "cannot unmarshal"),
+		strings.Contains(lowered, "backend name is required"),
+		strings.Contains(lowered, "requires a provider"),
+		strings.Contains(lowered, "requires baseurl"),
+		strings.Contains(lowered, "requires an apikey"),
+		strings.Contains(lowered, "temperature must be between"),
+		strings.Contains(lowered, "is duplicated"),
+		strings.Contains(lowered, "is not configured"),
+		strings.Contains(lowered, "unknown field"):
+		return &requestError{status: http.StatusBadRequest, message: err.Error()}
 	case strings.Contains(lowered, "unsupported provider"):
 		return &requestError{status: http.StatusBadRequest, message: err.Error()}
 	case strings.Contains(lowered, "server_encryption_key"):

--- a/backend/internal/modelgatewayapi/service_test.go
+++ b/backend/internal/modelgatewayapi/service_test.go
@@ -1,70 +1,72 @@
 package modelgatewayapi
 
 import (
-	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/dnviti/arsenale/backend/pkg/contracts"
 )
 
-func TestNormalizeConfigResponseOmitsEmptyBaseURLAsNull(t *testing.T) {
+func TestBuildConfigResponseOmitsEmptyBaseURLAsNull(t *testing.T) {
 	t.Parallel()
 
-	response := normalizeConfigResponse(contracts.TenantAIConfig{
-		Provider:            contracts.AIProviderOpenAI,
-		HasAPIKey:           true,
-		ModelID:             "gpt-4o",
-		BaseURL:             "",
-		MaxTokensPerRequest: 2048,
-		DailyRequestLimit:   25,
-		Enabled:             true,
-	})
+	response := buildConfigResponse(
+		storedAIConfig{
+			QueryGeneration: storedAIFeature{
+				Enabled:             true,
+				Backend:             "primary",
+				ModelID:             "gpt-4o",
+				MaxTokensPerRequest: 2048,
+				DailyRequestLimit:   25,
+			},
+			QueryOptimizer: storedAIFeature{
+				Enabled:             true,
+				Backend:             "primary",
+				ModelID:             "gpt-4o-mini",
+				MaxTokensPerRequest: 2048,
+			},
+			Temperature: 0.2,
+			TimeoutMS:   60000,
+		},
+		[]storedAIBackend{{
+			Name:         "primary",
+			Provider:     contracts.AIProviderOpenAI,
+			DefaultModel: "gpt-4o",
+		}},
+		legacyConfigRow{},
+	)
 
 	if response.BaseURL != nil {
 		t.Fatalf("expected nil baseUrl, got %q", *response.BaseURL)
 	}
-}
-
-func TestParseUpdatePayloadSupportsNullBaseURL(t *testing.T) {
-	t.Parallel()
-
-	payload := map[string]json.RawMessage{
-		"provider":            json.RawMessage(`"openai-compatible"`),
-		"apiKey":              json.RawMessage(`"secret"`),
-		"modelId":             json.RawMessage(`"gpt-4.1"`),
-		"baseUrl":             json.RawMessage(`null`),
-		"maxTokensPerRequest": json.RawMessage(`512`),
-		"dailyRequestLimit":   json.RawMessage(`42`),
-		"enabled":             json.RawMessage(`true`),
-	}
-
-	update, err := parseUpdatePayload(payload)
-	if err != nil {
-		t.Fatalf("parseUpdatePayload returned error: %v", err)
-	}
-	if update.Provider == nil || *update.Provider != contracts.AIProviderOpenAICompatible {
-		t.Fatalf("unexpected provider: %#v", update.Provider)
-	}
-	if update.BaseURL == nil || *update.BaseURL != "" {
-		t.Fatalf("expected empty baseUrl for null input, got %#v", update.BaseURL)
-	}
-	if update.Enabled == nil || !*update.Enabled {
-		t.Fatalf("expected enabled=true, got %#v", update.Enabled)
-	}
-	if update.MaxTokensPerRequest == nil || *update.MaxTokensPerRequest != 512 {
-		t.Fatalf("unexpected maxTokensPerRequest: %#v", update.MaxTokensPerRequest)
+	if response.Provider != contracts.AIProviderOpenAI {
+		t.Fatalf("unexpected provider %q", response.Provider)
 	}
 }
 
-func TestParseUpdatePayloadRejectsUnknownField(t *testing.T) {
+func TestClassifyConfigErrorMapsUnknownJSONFieldToBadRequest(t *testing.T) {
 	t.Parallel()
 
-	_, err := parseUpdatePayload(map[string]json.RawMessage{
-		"provider": json.RawMessage(`"openai"`),
-		"extra":    json.RawMessage(`true`),
-	})
-	if err == nil {
-		t.Fatal("expected error for unknown field")
+	err := classifyConfigError(errors.New(`json: unknown field "extra"`))
+	reqErr, ok := err.(*requestError)
+	if !ok {
+		t.Fatalf("expected requestError, got %T", err)
+	}
+	if reqErr.status != 400 {
+		t.Fatalf("unexpected status %d", reqErr.status)
+	}
+}
+
+func TestClassifyConfigErrorMapsValidationFailureToBadRequest(t *testing.T) {
+	t.Parallel()
+
+	err := classifyConfigError(errors.New(`backend "primary" requires baseUrl`))
+	reqErr, ok := err.(*requestError)
+	if !ok {
+		t.Fatalf("expected requestError, got %T", err)
+	}
+	if reqErr.status != 400 {
+		t.Fatalf("unexpected status %d", reqErr.status)
 	}
 }
 

--- a/backend/internal/orchestration/dbgen/models.go
+++ b/backend/internal/orchestration/dbgen/models.go
@@ -2285,20 +2285,41 @@ type Tenant struct {
 	UserDriveQuotaBytes           pgtype.Int4
 }
 
+type TenantAiBackend struct {
+	ID              string
+	TenantId        string
+	Name            string
+	Provider        string
+	EncryptedApiKey pgtype.Text
+	ApiKeyIV        pgtype.Text
+	ApiKeyTag       pgtype.Text
+	BaseUrl         pgtype.Text
+	DefaultModel    pgtype.Text
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
 type TenantAiConfig struct {
-	ID                  string
-	TenantId            string
-	Provider            string
-	EncryptedApiKey     pgtype.Text
-	ApiKeyIV            pgtype.Text
-	ApiKeyTag           pgtype.Text
-	ModelId             string
-	BaseUrl             pgtype.Text
-	MaxTokensPerRequest int32
-	DailyRequestLimit   int32
-	Enabled             bool
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
+	ID                     string
+	TenantId               string
+	Provider               string
+	EncryptedApiKey        pgtype.Text
+	ApiKeyIV               pgtype.Text
+	ApiKeyTag              pgtype.Text
+	ModelId                string
+	BaseUrl                pgtype.Text
+	MaxTokensPerRequest    int32
+	DailyRequestLimit      int32
+	Enabled                bool
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	QueryGenerationBackend pgtype.Text
+	QueryGenerationModel   pgtype.Text
+	QueryOptimizerEnabled  bool
+	QueryOptimizerBackend  pgtype.Text
+	QueryOptimizerModel    pgtype.Text
+	Temperature            float64
+	TimeoutMs              int32
 }
 
 type TenantMember struct {

--- a/backend/migrations/000005_tenant_ai_backends.sql
+++ b/backend/migrations/000005_tenant_ai_backends.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS public."TenantAiBackend" (
+    id text NOT NULL,
+    "tenantId" text NOT NULL,
+    name text NOT NULL,
+    provider text NOT NULL,
+    "encryptedApiKey" text,
+    "apiKeyIV" text,
+    "apiKeyTag" text,
+    "baseUrl" text,
+    "defaultModel" text,
+    "createdAt" timestamp(3) without time zone DEFAULT now() NOT NULL,
+    "updatedAt" timestamp(3) without time zone DEFAULT now() NOT NULL,
+    CONSTRAINT "TenantAiBackend_pkey" PRIMARY KEY (id),
+    CONSTRAINT "TenantAiBackend_tenantId_name_key" UNIQUE ("tenantId", name),
+    CONSTRAINT "TenantAiBackend_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES public."Tenant"(id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "TenantAiBackend_tenantId_idx"
+    ON public."TenantAiBackend" USING btree ("tenantId");
+
+ALTER TABLE public."TenantAiConfig"
+    ADD COLUMN IF NOT EXISTS "queryGenerationBackend" text,
+    ADD COLUMN IF NOT EXISTS "queryGenerationModel" text,
+    ADD COLUMN IF NOT EXISTS "queryOptimizerEnabled" boolean DEFAULT false NOT NULL,
+    ADD COLUMN IF NOT EXISTS "queryOptimizerBackend" text,
+    ADD COLUMN IF NOT EXISTS "queryOptimizerModel" text,
+    ADD COLUMN IF NOT EXISTS temperature double precision DEFAULT 0.2 NOT NULL,
+    ADD COLUMN IF NOT EXISTS "timeoutMs" integer DEFAULT 60000 NOT NULL;

--- a/client/src/api/aiQuery.api.ts
+++ b/client/src/api/aiQuery.api.ts
@@ -1,11 +1,36 @@
 import api from './client';
 
-// ---------------------------------------------------------------------------
-// AI Query Generation Types (AISQL-2069)
-// ---------------------------------------------------------------------------
+export type AiProvider =
+  | 'none'
+  | 'anthropic'
+  | 'openai'
+  | 'ollama'
+  | 'openai-compatible';
+
+export interface AiBackendConfig {
+  name: string;
+  provider: AiProvider;
+  hasApiKey: boolean;
+  baseUrl?: string | null;
+  defaultModel?: string;
+}
+
+export interface AiFeatureConfig {
+  enabled: boolean;
+  backend?: string;
+  modelId?: string;
+  maxTokensPerRequest: number;
+  dailyRequestLimit?: number;
+}
 
 export interface AiConfig {
-  provider: string;
+  backends: AiBackendConfig[];
+  queryGeneration: AiFeatureConfig;
+  queryOptimizer: AiFeatureConfig;
+  temperature: number;
+  timeoutMs: number;
+
+  provider: AiProvider;
   hasApiKey: boolean;
   modelId: string;
   baseUrl: string | null;
@@ -14,14 +39,29 @@ export interface AiConfig {
   enabled: boolean;
 }
 
-export interface AiConfigUpdate {
-  provider?: string;
+export interface AiBackendUpdate {
+  name: string;
+  provider: AiProvider;
   apiKey?: string;
-  modelId?: string;
+  clearApiKey?: boolean;
   baseUrl?: string | null;
+  defaultModel?: string | null;
+}
+
+export interface AiFeatureUpdate {
+  enabled: boolean;
+  backend?: string;
+  modelId?: string;
   maxTokensPerRequest?: number;
   dailyRequestLimit?: number;
-  enabled?: boolean;
+}
+
+export interface AiConfigUpdate {
+  backends: AiBackendUpdate[];
+  queryGeneration: AiFeatureUpdate;
+  queryOptimizer: AiFeatureUpdate;
+  temperature: number;
+  timeoutMs: number;
 }
 
 export interface ObjectRequest {
@@ -77,10 +117,6 @@ export async function confirmGeneration(
   return data;
 }
 
-// ---------------------------------------------------------------------------
-// AI Query Optimization Types (SQLVIZ-2070)
-// ---------------------------------------------------------------------------
-
 export interface DataRequest {
   type: string;
   target: string;
@@ -104,10 +140,6 @@ export interface OptimizeQueryResult {
   explanation?: string;
   changes?: string[];
 }
-
-// ---------------------------------------------------------------------------
-// AI Query Optimization API calls
-// ---------------------------------------------------------------------------
 
 export async function optimizeQuery(params: OptimizeQueryParams): Promise<OptimizeQueryResult> {
   const { data } = await api.post('/ai/optimize-query', params);

--- a/client/src/api/connections.api.ts
+++ b/client/src/api/connections.api.ts
@@ -2,6 +2,15 @@ import api from './client';
 import type { SshTerminalConfig } from '../constants/terminalThemes';
 import type { RdpSettings } from '../constants/rdpDefaults';
 import type { VncSettings } from '../constants/vncDefaults';
+import type {
+  DbQueryType,
+  FirewallAction,
+  FirewallRuleInput,
+  MaskingPolicyInput,
+  MaskingStrategy,
+  RateLimitAction,
+  RateLimitPolicyInput,
+} from './dbAudit.api';
 
 export interface DlpPolicy {
   disableCopy?: boolean;
@@ -21,6 +30,25 @@ export type DbProtocol = 'postgresql' | 'mysql' | 'mongodb' | 'oracle' | 'mssql'
 export type DbCloudProvider = 'azure' | 'aws' | 'gcp';
 export type OracleConnectionType = 'basic' | 'tns' | 'custom';
 export type OracleRole = 'normal' | 'sysdba' | 'sysoper' | 'sysasm' | 'sysbackup' | 'sysdg' | 'syskm' | 'sysrac';
+export type DbPolicyOverrideMode = 'inherit' | 'merge' | 'override';
+
+export interface ConnectionFirewallRule extends FirewallRuleInput {
+  id?: string;
+  action: FirewallAction;
+}
+
+export interface ConnectionMaskingPolicy extends MaskingPolicyInput {
+  id?: string;
+  strategy: MaskingStrategy;
+  exemptRoles?: string[];
+}
+
+export interface ConnectionRateLimitPolicy extends RateLimitPolicyInput {
+  id?: string;
+  queryType?: DbQueryType | null;
+  action?: RateLimitAction;
+  exemptRoles?: string[];
+}
 
 export interface DbSettings {
   protocol: DbProtocol;
@@ -31,6 +59,36 @@ export interface DbSettings {
   sslMode?: string;
   /** Persist execution plans in DB audit logs for supported SQL protocols. */
   persistExecutionPlan?: boolean;
+  /** Enable SQL firewall enforcement for this connection. */
+  firewallEnabled?: boolean;
+  /** Control how connection firewall rules interact with tenant-wide firewall rules. */
+  firewallPolicyMode?: DbPolicyOverrideMode;
+  /** Connection-specific firewall rules. */
+  firewallRules?: ConnectionFirewallRule[];
+  /** Enable masking enforcement for this connection. */
+  maskingEnabled?: boolean;
+  /** Control how connection masking policies interact with tenant-wide masking policies. */
+  maskingPolicyMode?: DbPolicyOverrideMode;
+  /** Connection-specific masking policies. */
+  maskingPolicies?: ConnectionMaskingPolicy[];
+  /** Enable rate limiting for this connection. */
+  rateLimitEnabled?: boolean;
+  /** Control how connection rate limits interact with tenant-wide rate limits. */
+  rateLimitPolicyMode?: DbPolicyOverrideMode;
+  /** Connection-specific rate limit policies. */
+  rateLimitPolicies?: ConnectionRateLimitPolicy[];
+  /** Enable AI query generation for this connection. */
+  aiQueryGenerationEnabled?: boolean;
+  /** Preferred AI backend for query generation. */
+  aiQueryGenerationBackend?: string;
+  /** Preferred model override for query generation. */
+  aiQueryGenerationModel?: string;
+  /** Enable AI query optimization for this connection. */
+  aiQueryOptimizerEnabled?: boolean;
+  /** Preferred AI backend for query optimization. */
+  aiQueryOptimizerBackend?: string;
+  /** Preferred model override for query optimization. */
+  aiQueryOptimizerModel?: string;
   /** Oracle: connection mode (defaults to 'basic' for backward compat). */
   oracleConnectionType?: OracleConnectionType;
   /** Oracle Basic: SID for the target instance (mutually exclusive with serviceName). */

--- a/client/src/components/DatabaseClient/DbEditor.tsx
+++ b/client/src/components/DatabaseClient/DbEditor.tsx
@@ -17,6 +17,7 @@ import type * as monacoNs from 'monaco-editor';
 import api from '../../api/client';
 import { ensureLocalMonacoLoader } from '../../lib/monacoLoader';
 import type { CredentialOverride } from '../../store/tabsStore';
+import type { DbSettings } from '../../api/connections.api';
 import type { DbQueryResult, DbSchemaInfo, DbSessionConfig } from '../../api/database.api';
 import { createDbSession, endDbSession, dbSessionHeartbeat, updateDbSessionConfig } from '../../api/database.api';
 import { extractApiError } from '../../utils/apiError';
@@ -46,6 +47,7 @@ interface DbEditorProps {
   isActive?: boolean;
   credentials?: CredentialOverride;
   initialProtocol?: string;
+  dbSettings?: DbSettings | null;
 }
 
 interface QuerySubTab {
@@ -145,6 +147,7 @@ export default function DbEditor({
   isActive = true,
   credentials,
   initialProtocol,
+  dbSettings,
 }: DbEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const monacoEditorRef = useRef<monacoNs.editor.IStandaloneCodeEditor | null>(null);
@@ -194,6 +197,7 @@ export default function DbEditor({
   const [aiApprovals, setAiApprovals] = useState<Record<number, boolean>>({});
   const [aiConversationId, setAiConversationId] = useState('');
   const aiPanelOpen = useUiPreferencesStore((s) => s.dbAiPanelOpen);
+  const aiGenerationAvailable = dbSettings?.aiQueryGenerationEnabled !== false;
 
   const [queryTabs, setQueryTabs] = useState<QuerySubTab[]>(() => {
     if (storedSubTabs?.tabs?.length) {
@@ -825,13 +829,13 @@ export default function DbEditor({
       },
       active: schemaBrowserOpen,
     },
-    {
+    ...(aiGenerationAvailable ? [{
       id: 'ai-assistant',
       icon: <Sparkles />,
       tooltip: aiPanelOpen ? 'Hide AI assistant' : 'Show AI assistant',
       onClick: () => setPref('dbAiPanelOpen', !aiPanelOpen),
       active: aiPanelOpen,
-    },
+    } satisfies ToolbarAction] : []),
     {
       id: 'query-history',
       icon: <History />,
@@ -1000,7 +1004,7 @@ export default function DbEditor({
       )}
 
       {/* AI Assistant panel */}
-      {aiPanelOpen && connectionState === 'connected' && (
+      {aiGenerationAvailable && aiPanelOpen && connectionState === 'connected' && (
         <div className="border-b border-border p-3 bg-primary/[0.04]">
           <div className="flex items-center gap-2 mb-2">
             <Sparkles className="size-[18px] text-primary" />
@@ -1271,6 +1275,7 @@ export default function DbEditor({
         blocked={false}
         sessionId={sessionIdRef.current ?? undefined}
         dbProtocol={protocol}
+        aiQueryOptimizerEnabled={dbSettings?.aiQueryOptimizerEnabled !== false}
         onApplySql={(optimizedSql) => {
           updateTab(activeQueryTabId, { sql: optimizedSql });
           setVisualizerOpen(false);

--- a/client/src/components/DatabaseClient/QueryVisualizer.tsx
+++ b/client/src/components/DatabaseClient/QueryVisualizer.tsx
@@ -32,6 +32,7 @@ interface QueryVisualizerProps {
   dbProtocol?: string;
   storedExecutionPlan?: Record<string, unknown> | null;
   onApplySql?: (sql: string) => void;
+  aiQueryOptimizerEnabled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -40,7 +41,7 @@ interface QueryVisualizerProps {
 
 export default function QueryVisualizer({
   open, onClose, queryText, queryType, executionTimeMs, rowsAffected,
-  tablesAccessed, blocked, blockReason, sessionId, dbProtocol, storedExecutionPlan, onApplySql,
+  tablesAccessed, blocked, blockReason, sessionId, dbProtocol, storedExecutionPlan, onApplySql, aiQueryOptimizerEnabled = true,
 }: QueryVisualizerProps) {
   const [copied, setCopied] = useState(false);
   const [planLoading, setPlanLoading] = useState(false);
@@ -279,7 +280,7 @@ export default function QueryVisualizer({
           )}
 
           {/* Section 4: AI Optimization */}
-          {canExplain && (
+          {canExplain && aiQueryOptimizerEnabled && (
             <>
               <Separator className="mb-4" />
               <h4 className="text-sm font-semibold mb-2">AI Query Optimization</h4>

--- a/client/src/components/Dialogs/ConnectionDialog.tsx
+++ b/client/src/components/Dialogs/ConnectionDialog.tsx
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react';
 import {
-  Dialog, DialogContent, DialogHeader, DialogTitle,
-  DialogDescription, DialogFooter,
+  Dialog, DialogContent,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Switch } from '@/components/ui/switch';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem,
@@ -16,7 +14,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { cn } from '@/lib/utils';
 import { Keyboard, KeyRound, Cloud, X } from 'lucide-react';
-import { createConnection, updateConnection, ConnectionInput, ConnectionUpdate, ConnectionData, DlpPolicy, DbSettings, DbProtocol, OracleConnectionType, OracleRole } from '../../api/connections.api';
+import { createConnection, updateConnection, ConnectionInput, ConnectionUpdate, ConnectionData, DlpPolicy, DbSettings, DbProtocol } from '../../api/connections.api';
 import { useConnectionsStore } from '../../store/connectionsStore';
 import type { SshTerminalConfig } from '../../constants/terminalThemes';
 import { mergeTerminalConfig } from '../../constants/terminalThemes';
@@ -38,14 +36,8 @@ import { useAsyncAction } from '../../hooks/useAsyncAction';
 import { useFeatureFlagsStore } from '../../store/featureFlagsStore';
 import { listVaultProviders, VaultProviderData } from '../../api/externalVault.api';
 import { gatewayEndpointLabel } from '../../utils/gatewayMode';
-import {
-  cloudProviderHint,
-  nextSSLModeForCloudProvider,
-  normalizeCloudProviderSelection,
-  remapSSLModeOnProtocolChange,
-  supportsCloudProviderPresets,
-  tlsModeOptions,
-} from '../../utils/dbConnectionSecurity';
+import { supportsCloudProviderPresets } from '../../utils/dbConnectionSecurity';
+import ConnectionDialogDatabaseSection from './ConnectionDialogDatabaseSection';
 
 interface ConnectionDialogProps {
   open: boolean;
@@ -59,19 +51,60 @@ function supportsPersistedExecutionPlans(protocol?: DbProtocol): boolean {
   return protocol === 'postgresql' || protocol === 'mysql' || protocol === 'oracle' || protocol === 'mssql';
 }
 
+function supportsDatabaseSettings(type: 'SSH' | 'RDP' | 'VNC' | 'DATABASE' | 'DB_TUNNEL'): boolean {
+  return type === 'DATABASE' || type === 'DB_TUNNEL';
+}
+
+function inferDbProtocol(value?: string | null): DbProtocol {
+  switch ((value ?? '').trim().toLowerCase()) {
+    case 'mysql':
+    case 'mariadb':
+      return 'mysql';
+    case 'mongodb':
+    case 'mongo':
+      return 'mongodb';
+    case 'oracle':
+      return 'oracle';
+    case 'mssql':
+    case 'sqlserver':
+      return 'mssql';
+    case 'db2':
+      return 'db2';
+    default:
+      return 'postgresql';
+  }
+}
+
+function seedDbSettings(
+  connectionType: 'SSH' | 'RDP' | 'VNC' | 'DATABASE' | 'DB_TUNNEL',
+  settings?: Partial<DbSettings> | null,
+  dbType?: string | null,
+): Partial<DbSettings> {
+  if (!supportsDatabaseSettings(connectionType)) {
+    return settings ?? {};
+  }
+
+  const nextSettings = { ...(settings ?? {}) };
+  if (!nextSettings.protocol) {
+    nextSettings.protocol = inferDbProtocol(dbType);
+  }
+  return nextSettings;
+}
+
 function normalizeDbSettings(settings: Partial<DbSettings>): DbSettings | null {
-  if (!settings.protocol) {
+  const protocol = settings.protocol ?? inferDbProtocol();
+  if (!protocol) {
     return null;
   }
 
-  const supportsCloudPresets = supportsCloudProviderPresets(settings.protocol);
+  const supportsCloudPresets = supportsCloudProviderPresets(protocol);
 
   return {
     ...settings,
-    protocol: settings.protocol,
+    protocol,
     cloudProvider: supportsCloudPresets ? settings.cloudProvider : undefined,
     sslMode: settings.sslMode,
-    persistExecutionPlan: supportsPersistedExecutionPlans(settings.protocol)
+    persistExecutionPlan: supportsPersistedExecutionPlans(protocol)
       ? settings.persistExecutionPlan
       : undefined,
   };
@@ -143,9 +176,7 @@ export default function ConnectionDialog({ open, onClose, connection, folderId, 
       setVncSettings(
         (connection.vncSettings as Partial<VncSettings>) ?? {}
       );
-      setDbSettings(
-        (connection.dbSettings as Partial<DbSettings>) ?? {}
-      );
+      setDbSettings(seedDbSettings(connection.type, connection.dbSettings as Partial<DbSettings>, connection.dbType));
       if (connection.externalVaultProviderId) {
         setCredentialMode('external-vault');
         setSelectedVaultProviderId(connection.externalVaultProviderId);
@@ -204,8 +235,11 @@ export default function ConnectionDialog({ open, onClose, connection, folderId, 
     if (newType === 'DB_TUNNEL' && knownPorts.includes(port)) setPort('22');
     setGatewayId('');
     setActiveSection('general');
-    if (newType === 'DATABASE') {
-      setDbSettings((prev) => ({ protocol: 'postgresql', ...prev }));
+    if (supportsDatabaseSettings(newType)) {
+      setDbSettings((prev) => seedDbSettings(newType, prev));
+      if (newType === 'DB_TUNNEL' && !targetDbPort) {
+        setTargetDbPort('5432');
+      }
     }
   };
 
@@ -215,10 +249,6 @@ export default function ConnectionDialog({ open, onClose, connection, folderId, 
     if (type === 'DATABASE') return g.type === 'DB_PROXY';
     return false;
   });
-  const dbTLSOptions = tlsModeOptions(dbSettings.protocol);
-  const currentDbTLSOption = dbTLSOptions.find((option) => option.value === (dbSettings.sslMode || '__default__'))
-    ?? dbTLSOptions[0];
-  const dbCloudHint = cloudProviderHint(dbSettings.protocol, dbSettings.cloudProvider);
 
   const sections: { key: string; label: string }[] = [
     { key: 'general', label: 'General' },
@@ -227,7 +257,7 @@ export default function ConnectionDialog({ open, onClose, connection, folderId, 
     ...(type === 'SSH' ? [{ key: 'terminal', label: 'Terminal' }] : []),
     ...(type === 'RDP' ? [{ key: 'rdp', label: 'RDP Settings' }] : []),
     ...(type === 'VNC' ? [{ key: 'vnc', label: 'VNC Settings' }] : []),
-    ...(type === 'DATABASE' ? [{ key: 'database', label: 'Database' }] : []),
+    ...(supportsDatabaseSettings(type) ? [{ key: 'database', label: 'Database' }] : []),
     ...((type === 'RDP' || type === 'VNC') ? [{ key: 'dlp', label: 'DLP Policy' }] : []),
   ];
 
@@ -275,7 +305,7 @@ export default function ConnectionDialog({ open, onClose, connection, folderId, 
           ...(type === 'VNC' && {
             vncSettings: Object.keys(vncSettings).length > 0 ? vncSettings : null,
           }),
-          ...(type === 'DATABASE' && {
+          ...(supportsDatabaseSettings(type) && {
             dbSettings: normalizeDbSettings(dbSettings),
           }),
           defaultCredentialMode: (defaultConnectMode as 'saved' | 'domain' | 'prompt') || null,
@@ -319,7 +349,7 @@ export default function ConnectionDialog({ open, onClose, connection, folderId, 
           ...(type === 'VNC' && Object.keys(vncSettings).length > 0 && {
             vncSettings,
           }),
-          ...(type === 'DATABASE' && dbSettings.protocol && {
+          ...(supportsDatabaseSettings(type) && {
             dbSettings: normalizeDbSettings(dbSettings) as DbSettings,
           }),
           ...(defaultConnectMode ? { defaultCredentialMode: defaultConnectMode as 'saved' | 'domain' | 'prompt' } : {}),
@@ -673,307 +703,12 @@ export default function ConnectionDialog({ open, onClose, connection, folderId, 
               )}
 
               {/* Database Settings */}
-              {activeSection === 'database' && type === 'DATABASE' && (
-                <div className="flex flex-col gap-4">
-                  <div className="space-y-2">
-                    <Label>Database Protocol</Label>
-                    <Select
-                      value={dbSettings.protocol ?? 'postgresql'}
-                      onValueChange={(v) => {
-                        const proto = v as DbProtocol;
-                        setDbSettings((prev) => ({
-                          protocol: proto,
-                          databaseName: prev.databaseName,
-                          cloudProvider: supportsCloudProviderPresets(proto) ? prev.cloudProvider : undefined,
-                          sslMode: remapSSLModeOnProtocolChange(
-                            prev.protocol,
-                            proto,
-                            prev.sslMode,
-                            supportsCloudProviderPresets(proto) ? prev.cloudProvider : undefined,
-                          ),
-                          persistExecutionPlan: supportsPersistedExecutionPlans(proto)
-                            ? prev.persistExecutionPlan
-                            : undefined,
-                          ...(proto === 'oracle' ? { oracleConnectionType: 'basic' as OracleConnectionType } : {}),
-                        }));
-                        const protoPorts: Record<string, string> = { postgresql: '5432', mysql: '3306', mongodb: '27017', oracle: '1521', mssql: '1433', db2: '50000' };
-                        setPort(protoPorts[proto] ?? '5432');
-                      }}
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="postgresql">PostgreSQL</SelectItem>
-                        <SelectItem value="mysql">MySQL / MariaDB</SelectItem>
-                        <SelectItem value="mongodb">MongoDB</SelectItem>
-                        <SelectItem value="oracle">Oracle (TNS)</SelectItem>
-                        <SelectItem value="mssql">Microsoft SQL Server (TDS)</SelectItem>
-                        <SelectItem value="db2">IBM DB2 (DRDA)</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="db-name">Database Name (optional)</Label>
-                    <Input
-                      id="db-name"
-                      value={dbSettings.databaseName ?? ''}
-                      onChange={(e) => setDbSettings((prev) => ({ ...prev, databaseName: e.target.value || undefined }))}
-                      placeholder="e.g. mydb"
-                    />
-                  </div>
-                  {supportsCloudProviderPresets(dbSettings.protocol) && (
-                    <>
-                      <div className="space-y-2">
-                        <Label>Cloud Provider Preset</Label>
-                        <Select
-                          value={dbSettings.cloudProvider ?? 'generic'}
-                          onValueChange={(v) => {
-                            const nextProvider = normalizeCloudProviderSelection(v);
-                            setDbSettings((prev) => ({
-                              ...prev,
-                              cloudProvider: nextProvider,
-                              sslMode: nextSSLModeForCloudProvider(
-                                prev.protocol,
-                                prev.sslMode,
-                                prev.cloudProvider,
-                                nextProvider,
-                              ),
-                            }));
-                          }}
-                        >
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="generic">Generic / self-hosted</SelectItem>
-                            <SelectItem value="azure">Azure Database</SelectItem>
-                            <SelectItem value="aws">AWS RDS / Aurora</SelectItem>
-                            <SelectItem value="gcp">GCP Cloud SQL</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <div className="space-y-2">
-                        <Label>TLS Mode</Label>
-                        <Select
-                          value={dbSettings.sslMode || '__default__'}
-                          onValueChange={(v) => setDbSettings((prev) => ({ ...prev, sslMode: v === '__default__' ? undefined : v }))}
-                        >
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {dbTLSOptions.map((option) => (
-                              <SelectItem key={option.value || 'default'} value={option.value}>
-                                {option.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      {currentDbTLSOption && (
-                        <p className="text-xs text-muted-foreground">{currentDbTLSOption.helperText}</p>
-                      )}
-                      {dbCloudHint && (
-                        <div className="rounded-md border border-blue-600/50 bg-blue-600/10 px-4 py-3 text-sm text-blue-400">
-                          {dbCloudHint}
-                        </div>
-                      )}
-                      {dbSettings.sslMode === 'skip-verify' && (
-                        <div className="rounded-md border border-yellow-600/50 bg-yellow-600/10 px-4 py-3 text-sm text-yellow-500">
-                          Skip verification accepts any server certificate. Use it only when you control the network and cannot trust the certificate chain yet.
-                        </div>
-                      )}
-                    </>
-                  )}
-                  {supportsPersistedExecutionPlans(dbSettings.protocol ?? 'postgresql') && (
-                    <div>
-                      <div className="flex items-center gap-3">
-                        <Switch
-                          id="persist-plan"
-                          checked={Boolean(dbSettings.persistExecutionPlan)}
-                          onCheckedChange={(v) => setDbSettings((prev) => ({
-                            ...prev,
-                            persistExecutionPlan: v || undefined,
-                          }))}
-                        />
-                        <Label htmlFor="persist-plan" className="font-normal">Persist execution plans in audit logs</Label>
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        Store the DB proxy execution plan with each audited query so it remains visible after the session closes.
-                      </p>
-                    </div>
-                  )}
-                  {dbSettings.protocol === 'oracle' && (
-                    <>
-                      {/* Connection type toggle: Basic | TNS | Custom */}
-                      <ToggleGroup
-                        type="single"
-                        value={dbSettings.oracleConnectionType ?? 'basic'}
-                        onValueChange={(val) => {
-                          if (!val) return;
-                          setDbSettings((prev) => ({
-                            protocol: 'oracle' as DbProtocol,
-                            databaseName: prev.databaseName,
-                            persistExecutionPlan: prev.persistExecutionPlan,
-                            oracleConnectionType: val as OracleConnectionType,
-                            oracleRole: prev.oracleRole,
-                            ...(val === 'basic' ? { oracleSid: prev.oracleSid, oracleServiceName: prev.oracleServiceName } : {}),
-                            ...(val === 'tns' ? { oracleTnsAlias: prev.oracleTnsAlias, oracleTnsDescriptor: prev.oracleTnsDescriptor } : {}),
-                            ...(val === 'custom' ? { oracleConnectString: prev.oracleConnectString } : {}),
-                          }));
-                        }}
-                        className="w-full"
-                      >
-                        <ToggleGroupItem value="basic" className="flex-1">Basic</ToggleGroupItem>
-                        <ToggleGroupItem value="tns" className="flex-1">TNS</ToggleGroupItem>
-                        <ToggleGroupItem value="custom" className="flex-1">Custom</ToggleGroupItem>
-                      </ToggleGroup>
-
-                      {/* Basic mode */}
-                      {(dbSettings.oracleConnectionType ?? 'basic') === 'basic' && (
-                        <div className="flex gap-3">
-                          <div className="w-[160px] space-y-2">
-                            <Label>Identifier Type</Label>
-                            <Select
-                              value={dbSettings.oracleSid ? 'sid' : 'service'}
-                              onValueChange={(v) => {
-                                if (v === 'sid') {
-                                  setDbSettings((prev) => ({ ...prev, oracleSid: prev.oracleServiceName || prev.oracleSid || '', oracleServiceName: undefined }));
-                                } else {
-                                  setDbSettings((prev) => ({ ...prev, oracleServiceName: prev.oracleSid || prev.oracleServiceName || '', oracleSid: undefined }));
-                                }
-                              }}
-                            >
-                              <SelectTrigger>
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="service">Service Name</SelectItem>
-                                <SelectItem value="sid">SID</SelectItem>
-                              </SelectContent>
-                            </Select>
-                          </div>
-                          <div className="flex-1 space-y-2">
-                            <Label>{dbSettings.oracleSid !== undefined ? 'SID' : 'Service Name'}</Label>
-                            <Input
-                              value={dbSettings.oracleSid ?? dbSettings.oracleServiceName ?? ''}
-                              onChange={(e) => {
-                                const val = e.target.value || undefined;
-                                if (dbSettings.oracleSid !== undefined) {
-                                  setDbSettings((prev) => ({ ...prev, oracleSid: val }));
-                                } else {
-                                  setDbSettings((prev) => ({ ...prev, oracleServiceName: val }));
-                                }
-                              }}
-                              placeholder={dbSettings.oracleSid !== undefined ? 'e.g. ORCL' : 'e.g. FREEPDB1'}
-                            />
-                          </div>
-                        </div>
-                      )}
-
-                      {/* TNS mode */}
-                      {dbSettings.oracleConnectionType === 'tns' && (
-                        <>
-                          <div className="space-y-2">
-                            <Label>TNS Alias</Label>
-                            <Input
-                              value={dbSettings.oracleTnsAlias ?? ''}
-                              onChange={(e) => setDbSettings((prev) => ({ ...prev, oracleTnsAlias: e.target.value || undefined }))}
-                              placeholder="e.g. MYDB"
-                            />
-                            <p className="text-xs text-muted-foreground">Alias from tnsnames.ora (resolved via TNS_ADMIN)</p>
-                          </div>
-                          <div className="space-y-2">
-                            <Label>TNS Descriptor</Label>
-                            <Textarea
-                              value={dbSettings.oracleTnsDescriptor ?? ''}
-                              onChange={(e) => setDbSettings((prev) => ({ ...prev, oracleTnsDescriptor: e.target.value || undefined }))}
-                              rows={3}
-                              placeholder="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=...)(PORT=...))(CONNECT_DATA=(SERVICE_NAME=...)))"
-                            />
-                            <p className="text-xs text-muted-foreground">Full TNS descriptor (overrides alias if both provided)</p>
-                          </div>
-                        </>
-                      )}
-
-                      {/* Custom mode */}
-                      {dbSettings.oracleConnectionType === 'custom' && (
-                        <div className="space-y-2">
-                          <Label>Connect String</Label>
-                          <Textarea
-                            value={dbSettings.oracleConnectString ?? ''}
-                            onChange={(e) => setDbSettings((prev) => ({ ...prev, oracleConnectString: e.target.value || undefined }))}
-                            rows={3}
-                            placeholder="host:port/service_name or full TNS descriptor"
-                          />
-                          <p className="text-xs text-muted-foreground">Raw connect string passed directly to the Oracle driver</p>
-                        </div>
-                      )}
-
-                      {/* Oracle Role (all modes) */}
-                      <div className="space-y-2">
-                        <Label>Role</Label>
-                        <Select
-                          value={dbSettings.oracleRole ?? 'normal'}
-                          onValueChange={(v) => setDbSettings((prev) => ({ ...prev, oracleRole: (v === 'normal' ? undefined : v) as OracleRole | undefined }))}
-                        >
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="normal">Normal</SelectItem>
-                            <SelectItem value="sysdba">SYSDBA</SelectItem>
-                            <SelectItem value="sysoper">SYSOPER</SelectItem>
-                            <SelectItem value="sysasm">SYSASM</SelectItem>
-                            <SelectItem value="sysbackup">SYSBACKUP</SelectItem>
-                            <SelectItem value="sysdg">SYSDG</SelectItem>
-                            <SelectItem value="syskm">SYSKM</SelectItem>
-                            <SelectItem value="sysrac">SYSRAC</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </>
-                  )}
-                  {dbSettings.protocol === 'mssql' && (
-                    <>
-                      <div className="space-y-2">
-                        <Label>Instance Name (optional)</Label>
-                        <Input
-                          value={dbSettings.mssqlInstanceName ?? ''}
-                          onChange={(e) => setDbSettings((prev) => ({ ...prev, mssqlInstanceName: e.target.value || undefined }))}
-                          placeholder="e.g. SQLEXPRESS"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label>Authentication Mode</Label>
-                        <Select
-                          value={dbSettings.mssqlAuthMode ?? 'sql'}
-                          onValueChange={(v) => setDbSettings((prev) => ({ ...prev, mssqlAuthMode: v as 'sql' | 'windows' }))}
-                        >
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="sql">SQL Server Authentication</SelectItem>
-                            <SelectItem value="windows">Windows Authentication (NTLM/Kerberos)</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </>
-                  )}
-                  {dbSettings.protocol === 'db2' && (
-                    <div className="space-y-2">
-                      <Label>Database Alias (optional)</Label>
-                      <Input
-                        value={dbSettings.db2DatabaseAlias ?? ''}
-                        onChange={(e) => setDbSettings((prev) => ({ ...prev, db2DatabaseAlias: e.target.value || undefined }))}
-                        placeholder="e.g. SAMPLE"
-                      />
-                      <p className="text-xs text-muted-foreground">Alias as cataloged on the DB2 Connect gateway</p>
-                    </div>
-                  )}
-                </div>
+              {activeSection === 'database' && supportsDatabaseSettings(type) && (
+                <ConnectionDialogDatabaseSection
+                  dbSettings={dbSettings}
+                  onChange={setDbSettings}
+                  onPortChange={type === 'DB_TUNNEL' ? setTargetDbPort : setPort}
+                />
               )}
 
               {/* DLP */}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseAISection.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseAISection.tsx
@@ -1,0 +1,149 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { Sparkles } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { DbSettings } from '../../api/connections.api';
+import type { AiConfig, AiFeatureConfig } from '../../api/aiQuery.api';
+
+interface ConnectionDialogDatabaseAISectionProps {
+  aiConfig: AiConfig | null;
+  dbSettings: Partial<DbSettings>;
+  onChange: Dispatch<SetStateAction<Partial<DbSettings>>>;
+  setOptionalString: <K extends keyof DbSettings>(key: K, value: string) => void;
+}
+
+function featureBackendLabel(feature: AiFeatureConfig | undefined) {
+  if (!feature?.backend) {
+    return 'Tenant default';
+  }
+  return `Tenant default (${feature.backend})`;
+}
+
+export default function ConnectionDialogDatabaseAISection({
+  aiConfig,
+  dbSettings,
+  onChange,
+  setOptionalString,
+}: ConnectionDialogDatabaseAISectionProps) {
+  const backendNames = aiConfig?.backends.map((backend) => backend.name) ?? [];
+  const generationEnabled = dbSettings.aiQueryGenerationEnabled ?? aiConfig?.queryGeneration.enabled ?? false;
+  const optimizerEnabled = dbSettings.aiQueryOptimizerEnabled ?? aiConfig?.queryOptimizer.enabled ?? false;
+
+  return (
+    <div className="rounded-lg border border-border/70 bg-card/40 p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Sparkles className="size-4 text-primary" />
+        <div>
+          <h4 className="text-sm font-semibold">Connection-level AI behavior</h4>
+          <p className="text-xs text-muted-foreground">Choose whether this connection exposes AI generation and optimization, and which backend/model it should prefer.</p>
+        </div>
+      </div>
+
+      {backendNames.length === 0 && (
+        <div className="mb-4 rounded-md border border-yellow-600/50 bg-yellow-600/10 px-4 py-3 text-sm text-yellow-500">
+          No named AI backends are configured yet. Per-connection backend selection will become available after an admin adds one in Settings.
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <div className="rounded-md border border-border/70 p-3">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <Label htmlFor="db-ai-generation" className="font-normal">AI query generation</Label>
+              <p className="text-xs text-muted-foreground">Natural-language query drafting inside the database editor.</p>
+            </div>
+            <Switch
+              id="db-ai-generation"
+              checked={generationEnabled}
+              onCheckedChange={(checked) => onChange((prev) => ({ ...prev, aiQueryGenerationEnabled: checked }))}
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Preferred backend</Label>
+              <Select
+                value={dbSettings.aiQueryGenerationBackend || '__default__'}
+                onValueChange={(value) => onChange((prev) => ({
+                  ...prev,
+                  aiQueryGenerationBackend: value === '__default__' ? undefined : value,
+                }))}
+                disabled={backendNames.length === 0}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={featureBackendLabel(aiConfig?.queryGeneration)} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__default__">{featureBackendLabel(aiConfig?.queryGeneration)}</SelectItem>
+                  {backendNames.map((backendName) => (
+                    <SelectItem key={backendName} value={backendName}>{backendName}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Model override</Label>
+              <Input
+                value={dbSettings.aiQueryGenerationModel ?? ''}
+                onChange={(event) => setOptionalString('aiQueryGenerationModel', event.target.value)}
+                placeholder={aiConfig?.queryGeneration.modelId || 'Use backend default model'}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-md border border-border/70 p-3">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <Label htmlFor="db-ai-optimizer" className="font-normal">AI query optimizer</Label>
+              <p className="text-xs text-muted-foreground">Execution-plan-aware optimization suggestions in the query visualizer.</p>
+            </div>
+            <Switch
+              id="db-ai-optimizer"
+              checked={optimizerEnabled}
+              onCheckedChange={(checked) => onChange((prev) => ({ ...prev, aiQueryOptimizerEnabled: checked }))}
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Preferred backend</Label>
+              <Select
+                value={dbSettings.aiQueryOptimizerBackend || '__default__'}
+                onValueChange={(value) => onChange((prev) => ({
+                  ...prev,
+                  aiQueryOptimizerBackend: value === '__default__' ? undefined : value,
+                }))}
+                disabled={backendNames.length === 0}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={featureBackendLabel(aiConfig?.queryOptimizer)} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__default__">{featureBackendLabel(aiConfig?.queryOptimizer)}</SelectItem>
+                  {backendNames.map((backendName) => (
+                    <SelectItem key={backendName} value={backendName}>{backendName}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Model override</Label>
+              <Input
+                value={dbSettings.aiQueryOptimizerModel ?? ''}
+                onChange={(event) => setOptionalString('aiQueryOptimizerModel', event.target.value)}
+                placeholder={aiConfig?.queryOptimizer.modelId || 'Use backend default model'}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseAdvancedFields.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseAdvancedFields.tsx
@@ -1,0 +1,209 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import type { DbSettings, OracleConnectionType, OracleRole } from '../../api/connections.api';
+
+interface ConnectionDialogDatabaseAdvancedFieldsProps {
+  dbSettings: Partial<DbSettings>;
+  onChange: Dispatch<SetStateAction<Partial<DbSettings>>>;
+  setOptionalString: <K extends keyof DbSettings>(key: K, value: string) => void;
+}
+
+export default function ConnectionDialogDatabaseAdvancedFields({
+  dbSettings,
+  onChange,
+  setOptionalString,
+}: ConnectionDialogDatabaseAdvancedFieldsProps) {
+  if (dbSettings.protocol === 'oracle') {
+    return (
+      <>
+        <ToggleGroup
+          type="single"
+          value={dbSettings.oracleConnectionType ?? 'basic'}
+          onValueChange={(value) => {
+            if (!value) return;
+            onChange((prev) => ({
+              ...prev,
+              protocol: 'oracle',
+              oracleConnectionType: value as OracleConnectionType,
+            }));
+          }}
+          className="w-full"
+        >
+          <ToggleGroupItem value="basic" className="flex-1">Basic</ToggleGroupItem>
+          <ToggleGroupItem value="tns" className="flex-1">TNS</ToggleGroupItem>
+          <ToggleGroupItem value="custom" className="flex-1">Custom</ToggleGroupItem>
+        </ToggleGroup>
+
+        {(dbSettings.oracleConnectionType ?? 'basic') === 'basic' && (
+          <div className="flex gap-3">
+            <div className="w-[160px] space-y-2">
+              <Label>Identifier Type</Label>
+              <Select
+                value={dbSettings.oracleSid ? 'sid' : 'service'}
+                onValueChange={(value) => {
+                  if (value === 'sid') {
+                    onChange((prev) => ({
+                      ...prev,
+                      oracleSid: prev.oracleServiceName || prev.oracleSid || '',
+                      oracleServiceName: undefined,
+                    }));
+                    return;
+                  }
+                  onChange((prev) => ({
+                    ...prev,
+                    oracleServiceName: prev.oracleSid || prev.oracleServiceName || '',
+                    oracleSid: undefined,
+                  }));
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="service">Service Name</SelectItem>
+                  <SelectItem value="sid">SID</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex-1 space-y-2">
+              <Label>{dbSettings.oracleSid !== undefined ? 'SID' : 'Service Name'}</Label>
+              <Input
+                value={dbSettings.oracleSid ?? dbSettings.oracleServiceName ?? ''}
+                onChange={(event) => {
+                  const value = event.target.value || undefined;
+                  onChange((prev) => (
+                    prev.oracleSid !== undefined
+                      ? { ...prev, oracleSid: value }
+                      : { ...prev, oracleServiceName: value }
+                  ));
+                }}
+                placeholder={dbSettings.oracleSid !== undefined ? 'e.g. ORCL' : 'e.g. FREEPDB1'}
+              />
+            </div>
+          </div>
+        )}
+
+        {dbSettings.oracleConnectionType === 'tns' && (
+          <>
+            <div className="space-y-2">
+              <Label>TNS Alias</Label>
+              <Input
+                value={dbSettings.oracleTnsAlias ?? ''}
+                onChange={(event) => setOptionalString('oracleTnsAlias', event.target.value)}
+                placeholder="e.g. MYDB"
+              />
+              <p className="text-xs text-muted-foreground">Alias from tnsnames.ora (resolved via TNS_ADMIN)</p>
+            </div>
+            <div className="space-y-2">
+              <Label>TNS Descriptor</Label>
+              <Textarea
+                value={dbSettings.oracleTnsDescriptor ?? ''}
+                onChange={(event) => setOptionalString('oracleTnsDescriptor', event.target.value)}
+                rows={3}
+                placeholder="(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=...)(PORT=...))(CONNECT_DATA=(SERVICE_NAME=...)))"
+              />
+              <p className="text-xs text-muted-foreground">Full TNS descriptor (overrides alias if both provided)</p>
+            </div>
+          </>
+        )}
+
+        {dbSettings.oracleConnectionType === 'custom' && (
+          <div className="space-y-2">
+            <Label>Connect String</Label>
+            <Textarea
+              value={dbSettings.oracleConnectString ?? ''}
+              onChange={(event) => setOptionalString('oracleConnectString', event.target.value)}
+              rows={3}
+              placeholder="host:port/service_name or full TNS descriptor"
+            />
+            <p className="text-xs text-muted-foreground">Raw connect string passed directly to the Oracle driver</p>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label>Role</Label>
+          <Select
+            value={dbSettings.oracleRole ?? 'normal'}
+            onValueChange={(value) => onChange((prev) => ({
+              ...prev,
+              oracleRole: (value === 'normal' ? undefined : value) as OracleRole | undefined,
+            }))}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="normal">Normal</SelectItem>
+              <SelectItem value="sysdba">SYSDBA</SelectItem>
+              <SelectItem value="sysoper">SYSOPER</SelectItem>
+              <SelectItem value="sysasm">SYSASM</SelectItem>
+              <SelectItem value="sysbackup">SYSBACKUP</SelectItem>
+              <SelectItem value="sysdg">SYSDG</SelectItem>
+              <SelectItem value="syskm">SYSKM</SelectItem>
+              <SelectItem value="sysrac">SYSRAC</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </>
+    );
+  }
+
+  if (dbSettings.protocol === 'mssql') {
+    return (
+      <>
+        <div className="space-y-2">
+          <Label>Instance Name (optional)</Label>
+          <Input
+            value={dbSettings.mssqlInstanceName ?? ''}
+            onChange={(event) => setOptionalString('mssqlInstanceName', event.target.value)}
+            placeholder="e.g. SQLEXPRESS"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Authentication Mode</Label>
+          <Select
+            value={dbSettings.mssqlAuthMode ?? 'sql'}
+            onValueChange={(value) => onChange((prev) => ({
+              ...prev,
+              mssqlAuthMode: value as 'sql' | 'windows',
+            }))}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="sql">SQL Server Authentication</SelectItem>
+              <SelectItem value="windows">Windows Authentication (NTLM/Kerberos)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </>
+    );
+  }
+
+  if (dbSettings.protocol === 'db2') {
+    return (
+      <div className="space-y-2">
+        <Label>Database Alias (optional)</Label>
+        <Input
+          value={dbSettings.db2DatabaseAlias ?? ''}
+          onChange={(event) => setOptionalString('db2DatabaseAlias', event.target.value)}
+          placeholder="e.g. SAMPLE"
+        />
+        <p className="text-xs text-muted-foreground">Alias as cataloged on the DB2 Connect gateway</p>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseFirewallOverrides.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseFirewallOverrides.tsx
@@ -1,0 +1,287 @@
+import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { Plus, Shield } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type {
+  ConnectionFirewallRule,
+  DbSettings,
+} from "../../api/connections.api";
+import { validateDbFirewallPattern } from "../../utils/dbFirewallPattern";
+import {
+  EMPTY_FIREWALL_RULE_FORM,
+  FIREWALL_ACTION_VARIANTS,
+  FIREWALL_RULE_TEMPLATES,
+} from "../Settings/dbFirewallPolicyConfig";
+import { PolicyMetadataBadge } from "../Settings/databasePolicyUi";
+import ConnectionDialogDatabasePolicyControls from "./ConnectionDialogDatabasePolicyControls";
+import ConnectionDialogDatabaseFirewallRuleDialog from "./ConnectionDialogDatabaseFirewallRuleDialog";
+import ConnectionDialogPolicyTable from "./ConnectionDialogPolicyTable";
+import {
+  CONNECTION_DB_POLICY_MODE_OPTIONS,
+  createConnectionPolicyId,
+  trimOptionalText,
+} from "./connectionDbPolicyHelpers";
+
+interface ConnectionDialogDatabaseFirewallOverridesProps {
+  dbSettings: Partial<DbSettings>;
+  onChange: Dispatch<SetStateAction<Partial<DbSettings>>>;
+}
+
+function emptyRuleForm(): ConnectionFirewallRule {
+  return { ...EMPTY_FIREWALL_RULE_FORM };
+}
+
+export default function ConnectionDialogDatabaseFirewallOverrides({
+  dbSettings,
+  onChange,
+}: ConnectionDialogDatabaseFirewallOverridesProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
+  const [patternError, setPatternError] = useState<string | null>(null);
+  const [formData, setFormData] =
+    useState<ConnectionFirewallRule>(emptyRuleForm());
+
+  const rules = dbSettings.firewallRules ?? [];
+  const mode = dbSettings.firewallPolicyMode ?? "inherit";
+  const modeOption = useMemo(
+    () =>
+      CONNECTION_DB_POLICY_MODE_OPTIONS.find((option) => option.value === mode),
+    [mode],
+  );
+
+  const resetForm = () => {
+    setFormData(emptyRuleForm());
+    setPatternError(null);
+  };
+
+  const closeDialog = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setEditingRuleId(null);
+      resetForm();
+    }
+  };
+
+  const updateField = <K extends keyof ConnectionFirewallRule>(
+    key: K,
+    value: ConnectionFirewallRule[K],
+  ) => {
+    setFormData((current) => ({ ...current, [key]: value }));
+  };
+
+  const openCreate = () => {
+    setEditingRuleId(null);
+    resetForm();
+    setDialogOpen(true);
+  };
+
+  const openEdit = (rule: ConnectionFirewallRule) => {
+    setEditingRuleId(rule.id ?? null);
+    setFormData({
+      ...rule,
+      scope: rule.scope ?? "",
+      description: rule.description ?? "",
+      enabled: rule.enabled ?? true,
+      priority: rule.priority ?? 0,
+    });
+    setPatternError(null);
+    setDialogOpen(true);
+  };
+
+  const applyTemplate = (templateName: string) => {
+    const template = FIREWALL_RULE_TEMPLATES.find(
+      (entry) => entry.name === templateName,
+    );
+    if (!template) {
+      return;
+    }
+    setFormData((current) => ({
+      ...current,
+      name: template.name,
+      pattern: template.pattern,
+      action: template.action,
+      description: template.description,
+    }));
+    setPatternError(validateDbFirewallPattern(template.pattern));
+  };
+
+  const handleSave = () => {
+    const regexError = validateDbFirewallPattern(formData.pattern ?? "");
+    if (regexError) {
+      setPatternError(regexError);
+      return;
+    }
+
+    const nextRule: ConnectionFirewallRule = {
+      ...formData,
+      id: formData.id ?? createConnectionPolicyId("firewall"),
+      name: formData.name.trim(),
+      pattern: formData.pattern.trim(),
+      action: formData.action,
+      scope: trimOptionalText(formData.scope),
+      description: trimOptionalText(formData.description),
+      enabled: formData.enabled !== false,
+      priority: Number.isFinite(formData.priority)
+        ? Number(formData.priority)
+        : 0,
+    };
+
+    onChange((prev) => {
+      const prevRules = prev.firewallRules ?? [];
+      const nextRules = editingRuleId
+        ? prevRules.map((rule) => (rule.id === editingRuleId ? nextRule : rule))
+        : [...prevRules, nextRule];
+      return { ...prev, firewallRules: nextRules };
+    });
+    closeDialog(false);
+  };
+
+  const handleDelete = (ruleId?: string) => {
+    if (!ruleId) {
+      return;
+    }
+    onChange((prev) => ({
+      ...prev,
+      firewallRules: (prev.firewallRules ?? []).filter(
+        (rule) => rule.id !== ruleId,
+      ),
+    }));
+  };
+
+  return (
+    <>
+      <section className="flex flex-col gap-4 border-t border-border/60 pt-6 first:border-t-0 first:pt-0">
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <Shield className="size-4 text-primary" />
+              <h5 className="text-sm font-semibold">DB Firewall</h5>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Block, alert, or log SQL patterns for this specific connection.
+              Built-in protections still apply while the firewall is enabled.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={openCreate}
+          >
+            <Plus />
+            Add Rule
+          </Button>
+        </div>
+
+        <ConnectionDialogDatabasePolicyControls
+          enabledTitle="Enable firewall enforcement"
+          enabledDescription="Disable this only when the connection must bypass both tenant-wide and connection-specific custom firewall rules."
+          enabled={dbSettings.firewallEnabled !== false}
+          onEnabledChange={(checked) =>
+            onChange((prev) => ({ ...prev, firewallEnabled: checked }))
+          }
+          mode={mode}
+          modeDescription={modeOption?.description}
+          selectId="db-firewall-mode"
+          onModeChange={(value) =>
+            onChange((prev) => ({
+              ...prev,
+              firewallPolicyMode: value,
+            }))
+          }
+        />
+
+        <ConnectionDialogPolicyTable
+          ariaLabel="Connection firewall rules"
+          items={rules}
+          columns={[
+            {
+              id: "name",
+              header: "Rule",
+              className: "align-top whitespace-normal",
+              cell: (rule) => (
+                <div className="flex min-w-[14rem] flex-col gap-1">
+                  <span className="font-medium text-foreground">
+                    {rule.name}
+                  </span>
+                  {rule.description ? (
+                    <span className="text-xs text-muted-foreground">
+                      {rule.description}
+                    </span>
+                  ) : null}
+                  <span className="text-xs text-muted-foreground">
+                    Priority {rule.priority ?? 0}
+                  </span>
+                </div>
+              ),
+            },
+            {
+              id: "pattern",
+              header: "Pattern",
+              className: "align-top whitespace-normal",
+              cell: (rule) => (
+                <code className="block max-w-[24rem] break-all rounded-md bg-muted/40 px-2 py-1 font-mono text-xs text-foreground">
+                  {rule.pattern}
+                </code>
+              ),
+            },
+            {
+              id: "action",
+              header: "Action",
+              cell: (rule) => (
+                <PolicyMetadataBadge
+                  variant={FIREWALL_ACTION_VARIANTS[rule.action]}
+                >
+                  {rule.action}
+                </PolicyMetadataBadge>
+              ),
+            },
+            {
+              id: "scope",
+              header: "Scope",
+              className: "align-top whitespace-normal",
+              cell: (rule) => (
+                <span className="text-sm text-muted-foreground">
+                  {rule.scope || "Global scope"}
+                </span>
+              ),
+            },
+            {
+              id: "status",
+              header: "Status",
+              cell: (rule) => (
+                <PolicyMetadataBadge
+                  variant={rule.enabled === false ? "outline" : "default"}
+                >
+                  {rule.enabled === false ? "Disabled" : "Enabled"}
+                </PolicyMetadataBadge>
+              ),
+            },
+          ]}
+          emptyTitle="No connection-specific firewall rules"
+          emptyDescription="Use tenant defaults only, or add rules here when this connection needs stricter or looser SQL guardrails than the rest of the tenant."
+          getKey={(rule, index) => rule.id ?? `${rule.name}-${index}`}
+          getRowLabel={(rule) => rule.name}
+          onEdit={openEdit}
+          onDelete={(rule) => handleDelete(rule.id)}
+        />
+      </section>
+
+      <ConnectionDialogDatabaseFirewallRuleDialog
+        open={dialogOpen}
+        editingRuleId={editingRuleId}
+        formData={formData}
+        patternError={patternError}
+        onOpenChange={closeDialog}
+        onApplyTemplate={applyTemplate}
+        onSave={handleSave}
+        onFieldChange={updateField}
+        onPatternChange={(value) => {
+          updateField("pattern", value);
+          setPatternError(
+            value.trim() ? validateDbFirewallPattern(value) : null,
+          );
+        }}
+      />
+    </>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseFirewallRuleDialog.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseFirewallRuleDialog.tsx
@@ -1,0 +1,203 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { ConnectionFirewallRule } from "../../api/connections.api";
+import { FIREWALL_RULE_TEMPLATES } from "../Settings/dbFirewallPolicyConfig";
+import {
+  PolicyDialogShell,
+  PolicyFormSection,
+} from "../Settings/databasePolicyUi";
+import { SettingsFieldCard, SettingsSwitchRow } from "../Settings/settings-ui";
+import ConnectionDialogPolicyPresetSelect from "./ConnectionDialogPolicyPresetSelect";
+
+interface ConnectionDialogDatabaseFirewallRuleDialogProps {
+  open: boolean;
+  editingRuleId: string | null;
+  formData: ConnectionFirewallRule;
+  patternError: string | null;
+  onOpenChange: (open: boolean) => void;
+  onApplyTemplate: (templateName: string) => void;
+  onSave: () => void;
+  onFieldChange: <K extends keyof ConnectionFirewallRule>(
+    key: K,
+    value: ConnectionFirewallRule[K],
+  ) => void;
+  onPatternChange: (value: string) => void;
+}
+
+export default function ConnectionDialogDatabaseFirewallRuleDialog({
+  open,
+  editingRuleId,
+  formData,
+  patternError,
+  onOpenChange,
+  onApplyTemplate,
+  onSave,
+  onFieldChange,
+  onPatternChange,
+}: ConnectionDialogDatabaseFirewallRuleDialogProps) {
+  return (
+    <PolicyDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={
+        editingRuleId
+          ? "Edit Connection Firewall Rule"
+          : "Create Connection Firewall Rule"
+      }
+      description="Define a SQL pattern and response action for this connection only."
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={onSave}
+            disabled={
+              !formData.name?.trim() ||
+              !formData.pattern?.trim() ||
+              Boolean(patternError)
+            }
+          >
+            {editingRuleId ? "Update Rule" : "Create Rule"}
+          </Button>
+        </>
+      }
+    >
+      {!editingRuleId && (
+        <ConnectionDialogPolicyPresetSelect
+          title="Start from a template"
+          description="Seed the rule with a proven pattern, then narrow the scope or adjust the priority for this connection."
+          comboboxLabel="Connection firewall preset"
+          templates={FIREWALL_RULE_TEMPLATES}
+          onApply={onApplyTemplate}
+        />
+      )}
+
+      <PolicyFormSection>
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard
+            label="Rule name"
+            description="Use a short name that reads well in audit events."
+          >
+            <Input
+              aria-label="Connection firewall rule name"
+              value={formData.name ?? ""}
+              onChange={(event) => onFieldChange("name", event.target.value)}
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Action"
+            description="Choose whether matching queries are blocked, alerted, or only logged."
+          >
+            <Select
+              value={formData.action ?? "BLOCK"}
+              onValueChange={(value) =>
+                onFieldChange(
+                  "action",
+                  value as ConnectionFirewallRule["action"],
+                )
+              }
+            >
+              <SelectTrigger aria-label="Connection firewall action">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="BLOCK">Block execution</SelectItem>
+                  <SelectItem value="ALERT">Allow and alert</SelectItem>
+                  <SelectItem value="LOG">Allow and log</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </SettingsFieldCard>
+        </div>
+
+        <SettingsFieldCard
+          label="Regex pattern"
+          description="Patterns are evaluated server-side on SQL text before execution."
+        >
+          <Input
+            aria-label="Connection firewall pattern"
+            value={formData.pattern ?? ""}
+            onChange={(event) => onPatternChange(event.target.value)}
+            className="font-mono text-xs"
+          />
+          <p
+            className={`text-xs ${patternError ? "text-destructive" : "text-muted-foreground"}`}
+          >
+            {patternError ??
+              "Basic regex safety checks run locally before the backend validates the final expression."}
+          </p>
+        </SettingsFieldCard>
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard
+            label="Scope"
+            description="Leave empty to apply the rule across every database or table reached through this connection."
+          >
+            <Input
+              aria-label="Connection firewall scope"
+              value={formData.scope ?? ""}
+              placeholder="database or table name"
+              onChange={(event) => onFieldChange("scope", event.target.value)}
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Priority"
+            description="Higher priority rules are evaluated before lower-priority rules."
+          >
+            <Input
+              type="number"
+              min={0}
+              aria-label="Connection firewall priority"
+              value={formData.priority ?? 0}
+              onChange={(event) =>
+                onFieldChange(
+                  "priority",
+                  Number.parseInt(event.target.value, 10) || 0,
+                )
+              }
+            />
+          </SettingsFieldCard>
+        </div>
+
+        <SettingsFieldCard
+          label="Description"
+          description="Optional context for why this connection needs this rule."
+        >
+          <Textarea
+            aria-label="Connection firewall description"
+            rows={3}
+            value={formData.description ?? ""}
+            onChange={(event) =>
+              onFieldChange("description", event.target.value)
+            }
+          />
+        </SettingsFieldCard>
+
+        <SettingsSwitchRow
+          title="Rule enabled"
+          description="Disabled rules stay attached to the connection but are ignored by the DB proxy."
+          checked={formData.enabled !== false}
+          onCheckedChange={(checked) => onFieldChange("enabled", checked)}
+        />
+      </PolicyFormSection>
+    </PolicyDialogShell>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseMaskingOverrides.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseMaskingOverrides.tsx
@@ -1,0 +1,305 @@
+import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { EyeOff, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type {
+  ConnectionMaskingPolicy,
+  DbSettings,
+} from "../../api/connections.api";
+import {
+  EMPTY_MASKING_POLICY_FORM,
+  MASKING_POLICY_TEMPLATES,
+  MASKING_STRATEGY_LABELS,
+  MASKING_STRATEGY_OPTIONS,
+  MASKING_STRATEGY_VARIANTS,
+  validateMaskingColumnPattern,
+} from "../Settings/dbMaskingPolicyConfig";
+import { PolicyMetadataBadge } from "../Settings/databasePolicyUi";
+import ConnectionDialogDatabasePolicyControls from "./ConnectionDialogDatabasePolicyControls";
+import ConnectionDialogDatabaseMaskingPolicyDialog from "./ConnectionDialogDatabaseMaskingPolicyDialog";
+import ConnectionDialogPolicyTable from "./ConnectionDialogPolicyTable";
+import {
+  CONNECTION_DB_POLICY_MODE_OPTIONS,
+  createConnectionPolicyId,
+  trimOptionalText,
+} from "./connectionDbPolicyHelpers";
+
+interface ConnectionDialogDatabaseMaskingOverridesProps {
+  dbSettings: Partial<DbSettings>;
+  onChange: Dispatch<SetStateAction<Partial<DbSettings>>>;
+}
+
+function emptyPolicyForm(): ConnectionMaskingPolicy {
+  return { ...EMPTY_MASKING_POLICY_FORM };
+}
+
+export default function ConnectionDialogDatabaseMaskingOverrides({
+  dbSettings,
+  onChange,
+}: ConnectionDialogDatabaseMaskingOverridesProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingPolicyId, setEditingPolicyId] = useState<string | null>(null);
+  const [patternError, setPatternError] = useState<string | null>(null);
+  const [formData, setFormData] =
+    useState<ConnectionMaskingPolicy>(emptyPolicyForm());
+
+  const policies = dbSettings.maskingPolicies ?? [];
+  const mode = dbSettings.maskingPolicyMode ?? "inherit";
+  const modeOption = useMemo(
+    () =>
+      CONNECTION_DB_POLICY_MODE_OPTIONS.find((option) => option.value === mode),
+    [mode],
+  );
+  const selectedStrategy = MASKING_STRATEGY_OPTIONS.find(
+    (entry) => entry.value === formData.strategy,
+  );
+
+  const resetForm = () => {
+    setFormData(emptyPolicyForm());
+    setPatternError(null);
+  };
+
+  const closeDialog = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setEditingPolicyId(null);
+      resetForm();
+    }
+  };
+
+  const updateField = <K extends keyof ConnectionMaskingPolicy>(
+    key: K,
+    value: ConnectionMaskingPolicy[K],
+  ) => {
+    setFormData((current) => ({ ...current, [key]: value }));
+  };
+
+  const openCreate = () => {
+    setEditingPolicyId(null);
+    resetForm();
+    setDialogOpen(true);
+  };
+
+  const openEdit = (policy: ConnectionMaskingPolicy) => {
+    setEditingPolicyId(policy.id ?? null);
+    setFormData({
+      ...policy,
+      scope: policy.scope ?? "",
+      description: policy.description ?? "",
+      exemptRoles: policy.exemptRoles ?? [],
+      enabled: policy.enabled ?? true,
+    });
+    setPatternError(null);
+    setDialogOpen(true);
+  };
+
+  const applyTemplate = (templateName: string) => {
+    const template = MASKING_POLICY_TEMPLATES.find(
+      (entry) => entry.name === templateName,
+    );
+    if (!template) {
+      return;
+    }
+
+    setFormData((current) => ({
+      ...current,
+      name: template.name,
+      columnPattern: template.columnPattern,
+      strategy: template.strategy,
+      description: template.description,
+    }));
+    setPatternError(validateMaskingColumnPattern(template.columnPattern));
+  };
+
+  const handleSave = () => {
+    const validationError = validateMaskingColumnPattern(
+      formData.columnPattern ?? "",
+    );
+    if (validationError) {
+      setPatternError(validationError);
+      return;
+    }
+
+    const nextPolicy: ConnectionMaskingPolicy = {
+      ...formData,
+      id: formData.id ?? createConnectionPolicyId("masking"),
+      name: formData.name.trim(),
+      columnPattern: formData.columnPattern.trim(),
+      strategy: formData.strategy,
+      exemptRoles: formData.exemptRoles ?? [],
+      scope: trimOptionalText(formData.scope),
+      description: trimOptionalText(formData.description),
+      enabled: formData.enabled !== false,
+    };
+
+    onChange((prev) => {
+      const prevPolicies = prev.maskingPolicies ?? [];
+      const nextPolicies = editingPolicyId
+        ? prevPolicies.map((policy) =>
+            policy.id === editingPolicyId ? nextPolicy : policy,
+          )
+        : [...prevPolicies, nextPolicy];
+      return { ...prev, maskingPolicies: nextPolicies };
+    });
+    closeDialog(false);
+  };
+
+  const handleDelete = (policyId?: string) => {
+    if (!policyId) {
+      return;
+    }
+    onChange((prev) => ({
+      ...prev,
+      maskingPolicies: (prev.maskingPolicies ?? []).filter(
+        (policy) => policy.id !== policyId,
+      ),
+    }));
+  };
+
+  return (
+    <>
+      <section className="flex flex-col gap-4 border-t border-border/60 pt-6 first:border-t-0 first:pt-0">
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <EyeOff className="size-4 text-primary" />
+              <h5 className="text-sm font-semibold">DB Masking</h5>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Redact, hash, or partially reveal sensitive columns for this
+              connection without forcing the same rules on every other database.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={openCreate}
+          >
+            <Plus />
+            Add Policy
+          </Button>
+        </div>
+
+        <ConnectionDialogDatabasePolicyControls
+          enabledTitle="Enable masking"
+          enabledDescription="Disable this only when query results from this connection must bypass both tenant-wide and connection-specific masking policies."
+          enabled={dbSettings.maskingEnabled !== false}
+          onEnabledChange={(checked) =>
+            onChange((prev) => ({ ...prev, maskingEnabled: checked }))
+          }
+          mode={mode}
+          modeDescription={modeOption?.description}
+          selectId="db-masking-mode"
+          onModeChange={(value) =>
+            onChange((prev) => ({
+              ...prev,
+              maskingPolicyMode: value,
+            }))
+          }
+        />
+
+        <ConnectionDialogPolicyTable
+          ariaLabel="Connection masking policies"
+          items={policies}
+          columns={[
+            {
+              id: "name",
+              header: "Policy",
+              className: "align-top whitespace-normal",
+              cell: (policy) => (
+                <div className="flex min-w-[14rem] flex-col gap-1">
+                  <span className="font-medium text-foreground">
+                    {policy.name}
+                  </span>
+                  {policy.description ? (
+                    <span className="text-xs text-muted-foreground">
+                      {policy.description}
+                    </span>
+                  ) : null}
+                </div>
+              ),
+            },
+            {
+              id: "pattern",
+              header: "Column pattern",
+              className: "align-top whitespace-normal",
+              cell: (policy) => (
+                <code className="block max-w-[24rem] break-all rounded-md bg-muted/40 px-2 py-1 font-mono text-xs text-foreground">
+                  {policy.columnPattern}
+                </code>
+              ),
+            },
+            {
+              id: "strategy",
+              header: "Strategy",
+              cell: (policy) => (
+                <PolicyMetadataBadge
+                  variant={MASKING_STRATEGY_VARIANTS[policy.strategy]}
+                >
+                  {MASKING_STRATEGY_LABELS[policy.strategy]}
+                </PolicyMetadataBadge>
+              ),
+            },
+            {
+              id: "scope",
+              header: "Scope",
+              className: "align-top whitespace-normal",
+              cell: (policy) => (
+                <span className="text-sm text-muted-foreground">
+                  {policy.scope || "Global scope"}
+                </span>
+              ),
+            },
+            {
+              id: "roles",
+              header: "Exempt roles",
+              className: "align-top whitespace-normal",
+              cell: (policy) => (
+                <span className="text-sm text-muted-foreground">
+                  {policy.exemptRoles?.length
+                    ? policy.exemptRoles.join(", ")
+                    : "None"}
+                </span>
+              ),
+            },
+            {
+              id: "status",
+              header: "Status",
+              cell: (policy) => (
+                <PolicyMetadataBadge
+                  variant={policy.enabled === false ? "outline" : "default"}
+                >
+                  {policy.enabled === false ? "Disabled" : "Enabled"}
+                </PolicyMetadataBadge>
+              ),
+            },
+          ]}
+          emptyTitle="No connection-specific masking policies"
+          emptyDescription="Use tenant defaults only, or add policies here when this connection needs its own masking behavior for PII, financial data, or secrets."
+          getKey={(policy, index) => policy.id ?? `${policy.name}-${index}`}
+          getRowLabel={(policy) => policy.name}
+          onEdit={openEdit}
+          onDelete={(policy) => handleDelete(policy.id)}
+        />
+      </section>
+
+      <ConnectionDialogDatabaseMaskingPolicyDialog
+        open={dialogOpen}
+        editingPolicyId={editingPolicyId}
+        formData={formData}
+        patternError={patternError}
+        selectedStrategyDescription={selectedStrategy?.description}
+        onOpenChange={closeDialog}
+        onApplyTemplate={applyTemplate}
+        onSave={handleSave}
+        onFieldChange={updateField}
+        onPatternChange={(value) => {
+          updateField("columnPattern", value);
+          setPatternError(
+            value.trim() ? validateMaskingColumnPattern(value) : null,
+          );
+        }}
+      />
+    </>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseMaskingPolicyDialog.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseMaskingPolicyDialog.tsx
@@ -1,0 +1,205 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { ConnectionMaskingPolicy } from "../../api/connections.api";
+import {
+  MASKING_EXEMPT_ROLES,
+  MASKING_POLICY_TEMPLATES,
+  MASKING_STRATEGY_OPTIONS,
+} from "../Settings/dbMaskingPolicyConfig";
+import {
+  PolicyDialogShell,
+  PolicyFormSection,
+  PolicyRoleChecklist,
+} from "../Settings/databasePolicyUi";
+import { SettingsFieldCard, SettingsSwitchRow } from "../Settings/settings-ui";
+import ConnectionDialogPolicyPresetSelect from "./ConnectionDialogPolicyPresetSelect";
+
+interface ConnectionDialogDatabaseMaskingPolicyDialogProps {
+  open: boolean;
+  editingPolicyId: string | null;
+  formData: ConnectionMaskingPolicy;
+  patternError: string | null;
+  selectedStrategyDescription?: string;
+  onOpenChange: (open: boolean) => void;
+  onApplyTemplate: (templateName: string) => void;
+  onSave: () => void;
+  onFieldChange: <K extends keyof ConnectionMaskingPolicy>(
+    key: K,
+    value: ConnectionMaskingPolicy[K],
+  ) => void;
+  onPatternChange: (value: string) => void;
+}
+
+export default function ConnectionDialogDatabaseMaskingPolicyDialog({
+  open,
+  editingPolicyId,
+  formData,
+  patternError,
+  selectedStrategyDescription,
+  onOpenChange,
+  onApplyTemplate,
+  onSave,
+  onFieldChange,
+  onPatternChange,
+}: ConnectionDialogDatabaseMaskingPolicyDialogProps) {
+  return (
+    <PolicyDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={
+        editingPolicyId
+          ? "Edit Connection Masking Policy"
+          : "Create Connection Masking Policy"
+      }
+      description="Choose how matching columns should be transformed and which roles can bypass the mask on this connection."
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={onSave}
+            disabled={
+              !formData.name?.trim() ||
+              !formData.columnPattern?.trim() ||
+              Boolean(patternError)
+            }
+          >
+            {editingPolicyId ? "Update Policy" : "Create Policy"}
+          </Button>
+        </>
+      }
+    >
+      {!editingPolicyId && (
+        <ConnectionDialogPolicyPresetSelect
+          title="Start from a template"
+          description="Use a proven pattern for sensitive columns, then adapt the scope or exemptions for this connection."
+          comboboxLabel="Connection masking preset"
+          templates={MASKING_POLICY_TEMPLATES}
+          onApply={onApplyTemplate}
+        />
+      )}
+
+      <PolicyFormSection>
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard
+            label="Policy name"
+            description="Use a readable name that makes incident review fast."
+          >
+            <Input
+              aria-label="Connection masking policy name"
+              value={formData.name ?? ""}
+              onChange={(event) => onFieldChange("name", event.target.value)}
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Masking strategy"
+            description="Choose how matched column values should be transformed."
+          >
+            <Select
+              value={formData.strategy ?? "REDACT"}
+              onValueChange={(value) =>
+                onFieldChange(
+                  "strategy",
+                  value as ConnectionMaskingPolicy["strategy"],
+                )
+              }
+            >
+              <SelectTrigger aria-label="Connection masking strategy">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {MASKING_STRATEGY_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {selectedStrategyDescription}
+            </p>
+          </SettingsFieldCard>
+        </div>
+
+        <SettingsFieldCard
+          label="Column pattern"
+          description="Use a regular expression that matches sensitive column names such as email, password, or credit_card."
+        >
+          <Input
+            aria-label="Connection masking pattern"
+            value={formData.columnPattern ?? ""}
+            onChange={(event) => onPatternChange(event.target.value)}
+            className="font-mono text-xs"
+          />
+          <p
+            className={`text-xs ${patternError ? "text-destructive" : "text-muted-foreground"}`}
+          >
+            {patternError ??
+              "The pattern is checked locally before save and validated again by the backend."}
+          </p>
+        </SettingsFieldCard>
+
+        <PolicyRoleChecklist
+          label="Exempt roles"
+          description="Selected roles receive raw values and bypass the mask entirely."
+          options={MASKING_EXEMPT_ROLES}
+          selected={formData.exemptRoles ?? []}
+          onChange={(selected) => onFieldChange("exemptRoles", selected)}
+        />
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard
+            label="Scope"
+            description="Leave empty to apply the policy across every database and table reached through this connection."
+          >
+            <Input
+              aria-label="Connection masking scope"
+              value={formData.scope ?? ""}
+              placeholder="database or table name"
+              onChange={(event) => onFieldChange("scope", event.target.value)}
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Description"
+            description="Optional context for why this connection needs its own masking policy."
+          >
+            <Textarea
+              aria-label="Connection masking description"
+              rows={3}
+              value={formData.description ?? ""}
+              onChange={(event) =>
+                onFieldChange("description", event.target.value)
+              }
+            />
+          </SettingsFieldCard>
+        </div>
+
+        <SettingsSwitchRow
+          title="Policy enabled"
+          description="Disabled policies stay attached to the connection but are ignored by the DB proxy."
+          checked={formData.enabled !== false}
+          onCheckedChange={(checked) => onFieldChange("enabled", checked)}
+        />
+      </PolicyFormSection>
+    </PolicyDialogShell>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabasePolicyControls.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabasePolicyControls.tsx
@@ -1,0 +1,72 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { DbPolicyOverrideMode } from "../../api/connections.api";
+import { SettingsSwitchRow } from "../Settings/settings-ui";
+import { CONNECTION_DB_POLICY_MODE_OPTIONS } from "./connectionDbPolicyHelpers";
+
+interface ConnectionDialogDatabasePolicyControlsProps {
+  enabledTitle: string;
+  enabledDescription: string;
+  enabled: boolean;
+  onEnabledChange: (checked: boolean) => void;
+  mode: DbPolicyOverrideMode;
+  modeDescription?: string;
+  selectId: string;
+  onModeChange: (mode: DbPolicyOverrideMode) => void;
+}
+
+export default function ConnectionDialogDatabasePolicyControls({
+  enabledTitle,
+  enabledDescription,
+  enabled,
+  onEnabledChange,
+  mode,
+  modeDescription,
+  selectId,
+  onModeChange,
+}: ConnectionDialogDatabasePolicyControlsProps) {
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_17rem] xl:items-start">
+      <SettingsSwitchRow
+        title={enabledTitle}
+        description={enabledDescription}
+        checked={enabled}
+        onCheckedChange={onEnabledChange}
+      />
+
+      <div className="flex flex-col gap-2 rounded-lg border border-border/60 px-4 py-3">
+        <Label
+          htmlFor={selectId}
+          className="text-sm font-medium text-foreground"
+        >
+          Policy source
+        </Label>
+        <Select
+          value={mode}
+          onValueChange={(value) => onModeChange(value as DbPolicyOverrideMode)}
+        >
+          <SelectTrigger id={selectId}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {CONNECTION_DB_POLICY_MODE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">{modeDescription}</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabasePolicyOverrides.test.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabasePolicyOverrides.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, waitFor } from "@testing-library/dom";
+import { render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import type { DbSettings } from "../../api/connections.api";
+import ConnectionDialogDatabasePolicyOverrides from "./ConnectionDialogDatabasePolicyOverrides";
+
+function TestHarness() {
+  const [dbSettings, setDbSettings] = useState<Partial<DbSettings>>({
+    protocol: "postgresql",
+  });
+
+  return (
+    <>
+      <ConnectionDialogDatabasePolicyOverrides
+        dbSettings={dbSettings}
+        onChange={setDbSettings}
+      />
+      <pre data-testid="db-settings-state">{JSON.stringify(dbSettings)}</pre>
+    </>
+  );
+}
+
+describe("ConnectionDialogDatabasePolicyOverrides", () => {
+  it("stores a connection-scoped firewall rule in dbSettings", async () => {
+    render(<TestHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Rule" }));
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Connection firewall preset" }),
+    );
+    fireEvent.change(screen.getByPlaceholderText("Search presets..."), {
+      target: { value: "drop table" },
+    });
+    fireEvent.click(screen.getByText("Block DROP TABLE"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Connection firewall rule name"),
+      ).toHaveValue("Block DROP TABLE");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Rule" }));
+
+    await waitFor(() => {
+      const payload = JSON.parse(
+        screen.getByTestId("db-settings-state").textContent ?? "{}",
+      );
+      expect(payload.firewallRules).toHaveLength(1);
+      expect(payload.firewallRules[0]).toEqual(
+        expect.objectContaining({
+          name: "Block DROP TABLE",
+          pattern: "\\bDROP\\s+TABLE\\b",
+          action: "BLOCK",
+        }),
+      );
+    });
+
+    expect(
+      screen.getByRole("table", { name: "Connection firewall rules" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Block DROP TABLE")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Dialogs/ConnectionDialogDatabasePolicyOverrides.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabasePolicyOverrides.tsx
@@ -1,0 +1,44 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { DbSettings } from "../../api/connections.api";
+import ConnectionDialogDatabaseFirewallOverrides from "./ConnectionDialogDatabaseFirewallOverrides";
+import ConnectionDialogDatabaseMaskingOverrides from "./ConnectionDialogDatabaseMaskingOverrides";
+import ConnectionDialogDatabaseRateLimitOverrides from "./ConnectionDialogDatabaseRateLimitOverrides";
+
+interface ConnectionDialogDatabasePolicyOverridesProps {
+  dbSettings: Partial<DbSettings>;
+  onChange: Dispatch<SetStateAction<Partial<DbSettings>>>;
+}
+
+export default function ConnectionDialogDatabasePolicyOverrides({
+  dbSettings,
+  onChange,
+}: ConnectionDialogDatabasePolicyOverridesProps) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-card/30 p-4">
+      <div className="flex flex-col gap-1">
+        <h4 className="text-sm font-semibold">
+          Connection-level query controls
+        </h4>
+        <p className="text-xs text-muted-foreground">
+          Keep tenant-wide defaults in Settings, then inherit, merge, or
+          override them per connection for maximum flexibility.
+        </p>
+      </div>
+
+      <div className="mt-6 flex flex-col gap-6">
+        <ConnectionDialogDatabaseFirewallOverrides
+          dbSettings={dbSettings}
+          onChange={onChange}
+        />
+        <ConnectionDialogDatabaseMaskingOverrides
+          dbSettings={dbSettings}
+          onChange={onChange}
+        />
+        <ConnectionDialogDatabaseRateLimitOverrides
+          dbSettings={dbSettings}
+          onChange={onChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseRateLimitOverrides.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseRateLimitOverrides.tsx
@@ -1,0 +1,211 @@
+import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { Gauge, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type {
+  ConnectionRateLimitPolicy,
+  DbSettings,
+} from "../../api/connections.api";
+import {
+  EMPTY_RATE_LIMIT_POLICY_FORM,
+  RATE_LIMIT_POLICY_TEMPLATES,
+} from "../Settings/dbRateLimitPolicyConfig";
+import ConnectionDialogDatabasePolicyControls from "./ConnectionDialogDatabasePolicyControls";
+import ConnectionDialogDatabaseRateLimitPolicyDialog from "./ConnectionDialogDatabaseRateLimitPolicyDialog";
+import ConnectionDialogDatabaseRateLimitTable from "./ConnectionDialogDatabaseRateLimitTable";
+import {
+  CONNECTION_DB_POLICY_MODE_OPTIONS,
+  createConnectionPolicyId,
+  trimOptionalText,
+} from "./connectionDbPolicyHelpers";
+
+interface ConnectionDialogDatabaseRateLimitOverridesProps {
+  dbSettings: Partial<DbSettings>;
+  onChange: Dispatch<SetStateAction<Partial<DbSettings>>>;
+}
+
+function emptyPolicyForm(): ConnectionRateLimitPolicy {
+  return { ...EMPTY_RATE_LIMIT_POLICY_FORM };
+}
+
+export default function ConnectionDialogDatabaseRateLimitOverrides({
+  dbSettings,
+  onChange,
+}: ConnectionDialogDatabaseRateLimitOverridesProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingPolicyId, setEditingPolicyId] = useState<string | null>(null);
+  const [formData, setFormData] =
+    useState<ConnectionRateLimitPolicy>(emptyPolicyForm());
+
+  const policies = dbSettings.rateLimitPolicies ?? [];
+  const mode = dbSettings.rateLimitPolicyMode ?? "inherit";
+  const modeOption = useMemo(
+    () =>
+      CONNECTION_DB_POLICY_MODE_OPTIONS.find((option) => option.value === mode),
+    [mode],
+  );
+
+  const resetForm = () => {
+    setFormData(emptyPolicyForm());
+  };
+
+  const closeDialog = (open: boolean) => {
+    setDialogOpen(open);
+    if (!open) {
+      setEditingPolicyId(null);
+      resetForm();
+    }
+  };
+
+  const updateField = <K extends keyof ConnectionRateLimitPolicy>(
+    key: K,
+    value: ConnectionRateLimitPolicy[K],
+  ) => {
+    setFormData((current) => ({ ...current, [key]: value }));
+  };
+
+  const openCreate = () => {
+    setEditingPolicyId(null);
+    resetForm();
+    setDialogOpen(true);
+  };
+
+  const openEdit = (policy: ConnectionRateLimitPolicy) => {
+    setEditingPolicyId(policy.id ?? null);
+    setFormData({
+      ...policy,
+      queryType: policy.queryType ?? null,
+      exemptRoles: policy.exemptRoles ?? [],
+      scope: policy.scope ?? "",
+      enabled: policy.enabled ?? true,
+      priority: policy.priority ?? 0,
+      windowMs: policy.windowMs ?? 60000,
+      maxQueries: policy.maxQueries ?? 100,
+      burstMax: policy.burstMax ?? 10,
+      action: policy.action ?? "REJECT",
+    });
+    setDialogOpen(true);
+  };
+
+  const applyTemplate = (templateName: string) => {
+    const template = RATE_LIMIT_POLICY_TEMPLATES.find(
+      (entry) => entry.name === templateName,
+    );
+    if (!template) {
+      return;
+    }
+
+    setFormData((current) => ({
+      ...current,
+      name: template.name,
+      queryType: template.queryType,
+      windowMs: template.windowMs,
+      maxQueries: template.maxQueries,
+      burstMax: template.burstMax,
+      action: template.action,
+    }));
+  };
+
+  const handleSave = () => {
+    const nextPolicy: ConnectionRateLimitPolicy = {
+      ...formData,
+      id: formData.id ?? createConnectionPolicyId("rate-limit"),
+      name: formData.name.trim(),
+      queryType: formData.queryType || null,
+      windowMs: Math.max(1, formData.windowMs ?? 60000),
+      maxQueries: Math.max(1, formData.maxQueries ?? 100),
+      burstMax: Math.max(1, formData.burstMax ?? 10),
+      exemptRoles: formData.exemptRoles ?? [],
+      scope: trimOptionalText(formData.scope) ?? null,
+      action: formData.action ?? "REJECT",
+      enabled: formData.enabled !== false,
+      priority: Number.isFinite(formData.priority)
+        ? Number(formData.priority)
+        : 0,
+    };
+
+    onChange((prev) => {
+      const prevPolicies = prev.rateLimitPolicies ?? [];
+      const nextPolicies = editingPolicyId
+        ? prevPolicies.map((policy) =>
+            policy.id === editingPolicyId ? nextPolicy : policy,
+          )
+        : [...prevPolicies, nextPolicy];
+      return { ...prev, rateLimitPolicies: nextPolicies };
+    });
+    closeDialog(false);
+  };
+
+  const handleDelete = (policyId?: string) => {
+    if (!policyId) {
+      return;
+    }
+    onChange((prev) => ({
+      ...prev,
+      rateLimitPolicies: (prev.rateLimitPolicies ?? []).filter(
+        (policy) => policy.id !== policyId,
+      ),
+    }));
+  };
+
+  return (
+    <>
+      <section className="flex flex-col gap-4 border-t border-border/60 pt-6 first:border-t-0 first:pt-0">
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <Gauge className="size-4 text-primary" />
+              <h5 className="text-sm font-semibold">DB Rate Limits</h5>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Throttle noisy workloads on this connection without forcing the
+              same ceilings on every database in the tenant.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={openCreate}
+          >
+            <Plus />
+            Add Policy
+          </Button>
+        </div>
+
+        <ConnectionDialogDatabasePolicyControls
+          enabledTitle="Enable rate limiting"
+          enabledDescription="Disable this only when the connection must bypass both tenant-wide and connection-specific rate-limit policies."
+          enabled={dbSettings.rateLimitEnabled !== false}
+          onEnabledChange={(checked) =>
+            onChange((prev) => ({ ...prev, rateLimitEnabled: checked }))
+          }
+          mode={mode}
+          modeDescription={modeOption?.description}
+          selectId="db-rate-limit-mode"
+          onModeChange={(value) =>
+            onChange((prev) => ({
+              ...prev,
+              rateLimitPolicyMode: value,
+            }))
+          }
+        />
+
+        <ConnectionDialogDatabaseRateLimitTable
+          policies={policies}
+          onEdit={openEdit}
+          onDelete={handleDelete}
+        />
+      </section>
+
+      <ConnectionDialogDatabaseRateLimitPolicyDialog
+        open={dialogOpen}
+        editingPolicyId={editingPolicyId}
+        formData={formData}
+        onOpenChange={closeDialog}
+        onApplyTemplate={applyTemplate}
+        onSave={handleSave}
+        onFieldChange={updateField}
+      />
+    </>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseRateLimitPolicyDialog.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseRateLimitPolicyDialog.tsx
@@ -1,0 +1,268 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ConnectionRateLimitPolicy } from "../../api/connections.api";
+import type { DbQueryType } from "../../api/dbAudit.api";
+import {
+  ALL_QUERY_TYPES,
+  RATE_LIMIT_EXEMPT_ROLES,
+  RATE_LIMIT_POLICY_TEMPLATES,
+  RATE_LIMIT_QUERY_TYPE_OPTIONS,
+  RATE_LIMIT_WINDOW_OPTIONS,
+} from "../Settings/dbRateLimitPolicyConfig";
+import {
+  PolicyDialogShell,
+  PolicyFormSection,
+  PolicyRoleChecklist,
+} from "../Settings/databasePolicyUi";
+import { SettingsFieldCard, SettingsSwitchRow } from "../Settings/settings-ui";
+import ConnectionDialogPolicyPresetSelect from "./ConnectionDialogPolicyPresetSelect";
+
+interface ConnectionDialogDatabaseRateLimitPolicyDialogProps {
+  open: boolean;
+  editingPolicyId: string | null;
+  formData: ConnectionRateLimitPolicy;
+  onOpenChange: (open: boolean) => void;
+  onApplyTemplate: (templateName: string) => void;
+  onSave: () => void;
+  onFieldChange: <K extends keyof ConnectionRateLimitPolicy>(
+    key: K,
+    value: ConnectionRateLimitPolicy[K],
+  ) => void;
+}
+
+export default function ConnectionDialogDatabaseRateLimitPolicyDialog({
+  open,
+  editingPolicyId,
+  formData,
+  onOpenChange,
+  onApplyTemplate,
+  onSave,
+  onFieldChange,
+}: ConnectionDialogDatabaseRateLimitPolicyDialogProps) {
+  return (
+    <PolicyDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={
+        editingPolicyId
+          ? "Edit Connection Rate Limit Policy"
+          : "Create Connection Rate Limit Policy"
+      }
+      description="Set the query type, rolling window, and response when this connection crosses the limit."
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={onSave}
+            disabled={!formData.name?.trim()}
+          >
+            {editingPolicyId ? "Update Policy" : "Create Policy"}
+          </Button>
+        </>
+      }
+    >
+      {!editingPolicyId && (
+        <ConnectionDialogPolicyPresetSelect
+          title="Start from a template"
+          description="Choose a baseline limit and then tune the scope, burst allowance, or exemptions for this connection."
+          comboboxLabel="Connection rate limit preset"
+          templates={RATE_LIMIT_POLICY_TEMPLATES}
+          onApply={onApplyTemplate}
+        />
+      )}
+
+      <PolicyFormSection>
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard
+            label="Policy name"
+            description="Keep the name readable in alerts and audit logs."
+          >
+            <Input
+              aria-label="Connection rate limit policy name"
+              value={formData.name ?? ""}
+              onChange={(event) => onFieldChange("name", event.target.value)}
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Response"
+            description="Reject overages immediately or log them for review."
+          >
+            <Select
+              value={formData.action ?? "REJECT"}
+              onValueChange={(value) =>
+                onFieldChange(
+                  "action",
+                  value as ConnectionRateLimitPolicy["action"],
+                )
+              }
+            >
+              <SelectTrigger aria-label="Connection rate limit action">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="REJECT">Reject excess queries</SelectItem>
+                  <SelectItem value="LOG_ONLY">Log excess queries</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </SettingsFieldCard>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard
+            label="Query type"
+            description="Limit a specific SQL class or all statements together."
+          >
+            <Select
+              value={formData.queryType ?? ALL_QUERY_TYPES}
+              onValueChange={(value) =>
+                onFieldChange(
+                  "queryType",
+                  value === ALL_QUERY_TYPES ? null : (value as DbQueryType),
+                )
+              }
+            >
+              <SelectTrigger aria-label="Connection rate limit query type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {RATE_LIMIT_QUERY_TYPE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Time window"
+            description="The rolling window used to count matching queries."
+          >
+            <Select
+              value={String(formData.windowMs ?? 60000)}
+              onValueChange={(value) =>
+                onFieldChange("windowMs", Number(value))
+              }
+            >
+              <SelectTrigger aria-label="Connection rate limit time window">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {RATE_LIMIT_WINDOW_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={String(option.value)}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </SettingsFieldCard>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-3">
+          <SettingsFieldCard
+            label="Max queries"
+            description="How many matching queries fit inside the window."
+          >
+            <Input
+              type="number"
+              min={1}
+              aria-label="Connection rate limit max queries"
+              value={formData.maxQueries ?? 100}
+              onChange={(event) =>
+                onFieldChange(
+                  "maxQueries",
+                  Math.max(1, Number.parseInt(event.target.value, 10) || 1),
+                )
+              }
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Burst allowance"
+            description="Short-term tokens available above the steady limit."
+          >
+            <Input
+              type="number"
+              min={1}
+              aria-label="Connection rate limit burst max"
+              value={formData.burstMax ?? 10}
+              onChange={(event) =>
+                onFieldChange(
+                  "burstMax",
+                  Math.max(1, Number.parseInt(event.target.value, 10) || 1),
+                )
+              }
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard
+            label="Priority"
+            description="Higher priority policies are evaluated before lower-priority policies."
+          >
+            <Input
+              type="number"
+              min={0}
+              aria-label="Connection rate limit priority"
+              value={formData.priority ?? 0}
+              onChange={(event) =>
+                onFieldChange(
+                  "priority",
+                  Number.parseInt(event.target.value, 10) || 0,
+                )
+              }
+            />
+          </SettingsFieldCard>
+        </div>
+
+        <PolicyRoleChecklist
+          label="Exempt roles"
+          description="Selected roles bypass the rate limit entirely for this connection."
+          options={RATE_LIMIT_EXEMPT_ROLES}
+          selected={formData.exemptRoles ?? []}
+          onChange={(selected) => onFieldChange("exemptRoles", selected)}
+        />
+
+        <SettingsFieldCard
+          label="Scope"
+          description="Leave empty to apply the policy across every database and table reached through this connection."
+        >
+          <Input
+            aria-label="Connection rate limit scope"
+            value={formData.scope ?? ""}
+            placeholder="database or table name"
+            onChange={(event) => onFieldChange("scope", event.target.value)}
+          />
+        </SettingsFieldCard>
+
+        <SettingsSwitchRow
+          title="Policy enabled"
+          description="Disabled policies stay attached to the connection but are ignored by the DB proxy."
+          checked={formData.enabled !== false}
+          onCheckedChange={(checked) => onFieldChange("enabled", checked)}
+        />
+      </PolicyFormSection>
+    </PolicyDialogShell>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseRateLimitTable.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseRateLimitTable.tsx
@@ -1,0 +1,104 @@
+import type { ConnectionRateLimitPolicy } from "../../api/connections.api";
+import {
+  formatRateLimitWindow,
+  RATE_LIMIT_ACTION_VARIANTS,
+} from "../Settings/dbRateLimitPolicyConfig";
+import { PolicyMetadataBadge } from "../Settings/databasePolicyUi";
+import ConnectionDialogPolicyTable from "./ConnectionDialogPolicyTable";
+
+interface ConnectionDialogDatabaseRateLimitTableProps {
+  policies: ConnectionRateLimitPolicy[];
+  onEdit: (policy: ConnectionRateLimitPolicy) => void;
+  onDelete: (policyId?: string) => void;
+}
+
+export default function ConnectionDialogDatabaseRateLimitTable({
+  policies,
+  onEdit,
+  onDelete,
+}: ConnectionDialogDatabaseRateLimitTableProps) {
+  return (
+    <ConnectionDialogPolicyTable
+      ariaLabel="Connection rate limit policies"
+      items={policies}
+      columns={[
+        {
+          id: "name",
+          header: "Policy",
+          className: "align-top whitespace-normal",
+          cell: (policy) => (
+            <div className="flex min-w-[14rem] flex-col gap-1">
+              <span className="font-medium text-foreground">{policy.name}</span>
+              <span className="text-xs text-muted-foreground">
+                Priority {policy.priority ?? 0}
+              </span>
+            </div>
+          ),
+        },
+        {
+          id: "query-type",
+          header: "Query type",
+          cell: (policy) => (
+            <PolicyMetadataBadge variant="outline">
+              {policy.queryType || "All query types"}
+            </PolicyMetadataBadge>
+          ),
+        },
+        {
+          id: "window",
+          header: "Window",
+          cell: (policy) => (
+            <span className="text-sm text-muted-foreground">
+              {formatRateLimitWindow(policy.windowMs ?? 60000)}
+            </span>
+          ),
+        },
+        {
+          id: "limits",
+          header: "Limits",
+          className: "align-top whitespace-normal",
+          cell: (policy) => (
+            <div className="flex flex-col gap-1 text-sm text-muted-foreground">
+              <span>Max {policy.maxQueries ?? 100}</span>
+              <span>Burst {policy.burstMax ?? 10}</span>
+            </div>
+          ),
+        },
+        {
+          id: "response",
+          header: "Response",
+          className: "align-top whitespace-normal",
+          cell: (policy) => (
+            <div className="flex flex-col gap-2">
+              <PolicyMetadataBadge
+                variant={RATE_LIMIT_ACTION_VARIANTS[policy.action ?? "REJECT"]}
+              >
+                {policy.action === "LOG_ONLY" ? "Log only" : "Reject"}
+              </PolicyMetadataBadge>
+              <span className="text-xs text-muted-foreground">
+                {policy.scope || "Global scope"}
+              </span>
+            </div>
+          ),
+        },
+        {
+          id: "status",
+          header: "Status",
+          cell: (policy) => (
+            <PolicyMetadataBadge
+              variant={policy.enabled === false ? "outline" : "default"}
+            >
+              {policy.enabled === false ? "Disabled" : "Enabled"}
+            </PolicyMetadataBadge>
+          ),
+        },
+      ]}
+      emptyTitle="No connection-specific rate limits"
+      emptyDescription="Use tenant defaults only, or add policies here when this connection needs its own throughput ceiling or abuse controls."
+      getKey={(policy, index) => policy.id ?? `${policy.name}-${index}`}
+      getRowLabel={(policy) => policy.name}
+      onEdit={onEdit}
+      onDelete={(policy) => onDelete(policy.id)}
+    />
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogDatabaseSection.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogDatabaseSection.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { DbProtocol, DbSettings } from '../../api/connections.api';
+import { getAiConfig, type AiConfig } from '../../api/aiQuery.api';
+import {
+  cloudProviderHint,
+  nextSSLModeForCloudProvider,
+  normalizeCloudProviderSelection,
+  remapSSLModeOnProtocolChange,
+  supportsCloudProviderPresets,
+  tlsModeOptions,
+} from '../../utils/dbConnectionSecurity';
+import ConnectionDialogDatabaseAdvancedFields from './ConnectionDialogDatabaseAdvancedFields';
+import ConnectionDialogDatabaseAISection from './ConnectionDialogDatabaseAISection';
+import ConnectionDialogDatabasePolicyOverrides from './ConnectionDialogDatabasePolicyOverrides';
+
+interface ConnectionDialogDatabaseSectionProps {
+  dbSettings: Partial<DbSettings>;
+  onChange: Dispatch<SetStateAction<Partial<DbSettings>>>;
+  onPortChange: (port: string) => void;
+}
+
+const protocolPorts: Record<DbProtocol, string> = {
+  postgresql: '5432',
+  mysql: '3306',
+  mongodb: '27017',
+  oracle: '1521',
+  mssql: '1433',
+  db2: '50000',
+};
+
+function supportsPersistedExecutionPlans(protocol?: DbProtocol): boolean {
+  return protocol === 'postgresql' || protocol === 'mysql' || protocol === 'oracle' || protocol === 'mssql';
+}
+
+export default function ConnectionDialogDatabaseSection({
+  dbSettings,
+  onChange,
+  onPortChange,
+}: ConnectionDialogDatabaseSectionProps) {
+  const [aiConfig, setAiConfig] = useState<AiConfig | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAiConfig()
+      .then((config) => {
+        if (!cancelled) {
+          setAiConfig(config);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAiConfig(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const dbTLSOptions = useMemo(() => tlsModeOptions(dbSettings.protocol), [dbSettings.protocol]);
+  const currentDbTLSOption = dbTLSOptions.find((option) => option.value === (dbSettings.sslMode || '__default__'))
+    ?? dbTLSOptions[0];
+  const dbCloudHint = cloudProviderHint(dbSettings.protocol, dbSettings.cloudProvider);
+
+  const updateDbSettings = (updater: (prev: Partial<DbSettings>) => Partial<DbSettings>) => {
+    onChange((prev) => updater(prev));
+  };
+
+  const setOptionalString = <K extends keyof DbSettings>(key: K, value: string) => {
+    updateDbSettings((prev) => ({
+      ...prev,
+      [key]: value.trim() === '' ? undefined : value,
+    }));
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="space-y-2">
+        <Label>Database Protocol</Label>
+        <Select
+          value={dbSettings.protocol ?? 'postgresql'}
+          onValueChange={(value) => {
+            const protocol = value as DbProtocol;
+            updateDbSettings((prev) => ({
+              ...prev,
+              protocol,
+              cloudProvider: supportsCloudProviderPresets(protocol) ? prev.cloudProvider : undefined,
+              sslMode: remapSSLModeOnProtocolChange(
+                prev.protocol,
+                protocol,
+                prev.sslMode,
+                supportsCloudProviderPresets(protocol) ? prev.cloudProvider : undefined,
+              ),
+              persistExecutionPlan: supportsPersistedExecutionPlans(protocol)
+                ? prev.persistExecutionPlan
+                : undefined,
+              ...(protocol === 'oracle'
+                ? { oracleConnectionType: prev.oracleConnectionType ?? 'basic' }
+                : {}),
+            }));
+            onPortChange(protocolPorts[protocol]);
+          }}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="postgresql">PostgreSQL</SelectItem>
+            <SelectItem value="mysql">MySQL / MariaDB</SelectItem>
+            <SelectItem value="mongodb">MongoDB</SelectItem>
+            <SelectItem value="oracle">Oracle (TNS)</SelectItem>
+            <SelectItem value="mssql">Microsoft SQL Server (TDS)</SelectItem>
+            <SelectItem value="db2">IBM DB2 (DRDA)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="db-name">Database Name (optional)</Label>
+        <Input
+          id="db-name"
+          value={dbSettings.databaseName ?? ''}
+          onChange={(event) => setOptionalString('databaseName', event.target.value)}
+          placeholder="e.g. mydb"
+        />
+      </div>
+
+      {supportsCloudProviderPresets(dbSettings.protocol) && (
+        <>
+          <div className="space-y-2">
+            <Label>Cloud Provider Preset</Label>
+            <Select
+              value={dbSettings.cloudProvider ?? 'generic'}
+              onValueChange={(value) => {
+                const nextProvider = normalizeCloudProviderSelection(value);
+                updateDbSettings((prev) => ({
+                  ...prev,
+                  cloudProvider: nextProvider,
+                  sslMode: nextSSLModeForCloudProvider(
+                    prev.protocol,
+                    prev.sslMode,
+                    prev.cloudProvider,
+                    nextProvider,
+                  ),
+                }));
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="generic">Generic / self-hosted</SelectItem>
+                <SelectItem value="azure">Azure Database</SelectItem>
+                <SelectItem value="aws">AWS RDS / Aurora</SelectItem>
+                <SelectItem value="gcp">GCP Cloud SQL</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>TLS Mode</Label>
+            <Select
+              value={dbSettings.sslMode || '__default__'}
+              onValueChange={(value) => updateDbSettings((prev) => ({
+                ...prev,
+                sslMode: value === '__default__' ? undefined : value,
+              }))}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {dbTLSOptions.map((option) => (
+                  <SelectItem key={option.value || 'default'} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <p className="text-xs text-muted-foreground">{currentDbTLSOption.helperText}</p>
+          {dbCloudHint && (
+            <div className="rounded-md border border-blue-600/50 bg-blue-600/10 px-4 py-3 text-sm text-blue-400">
+              {dbCloudHint}
+            </div>
+          )}
+          {dbSettings.sslMode === 'skip-verify' && (
+            <div className="rounded-md border border-yellow-600/50 bg-yellow-600/10 px-4 py-3 text-sm text-yellow-500">
+              Skip verification accepts any server certificate. Use it only when you control the network and cannot trust the certificate chain yet.
+            </div>
+          )}
+        </>
+      )}
+
+      {supportsPersistedExecutionPlans(dbSettings.protocol ?? 'postgresql') && (
+        <div>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="persist-plan"
+              checked={Boolean(dbSettings.persistExecutionPlan)}
+              onCheckedChange={(checked) => updateDbSettings((prev) => ({
+                ...prev,
+                persistExecutionPlan: checked || undefined,
+              }))}
+            />
+            <Label htmlFor="persist-plan" className="font-normal">Persist execution plans in audit logs</Label>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Store the DB proxy execution plan with each audited query so it remains visible after the session closes.
+          </p>
+        </div>
+      )}
+
+      <ConnectionDialogDatabasePolicyOverrides dbSettings={dbSettings} onChange={onChange} />
+      <ConnectionDialogDatabaseAISection
+        aiConfig={aiConfig}
+        dbSettings={dbSettings}
+        onChange={onChange}
+        setOptionalString={setOptionalString}
+      />
+      <ConnectionDialogDatabaseAdvancedFields
+        dbSettings={dbSettings}
+        onChange={onChange}
+        setOptionalString={setOptionalString}
+      />
+    </div>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogPolicyPresetSelect.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogPolicyPresetSelect.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { PolicyTemplateOption } from "../Settings/databasePolicyUi";
+
+const badgeToneClasses = {
+  neutral: "border-border bg-background text-foreground",
+  success: "border-primary/25 bg-primary/10 text-primary",
+  warning: "border-chart-5/25 bg-chart-5/10 text-foreground",
+  destructive: "border-destructive/25 bg-destructive/10 text-destructive",
+};
+
+interface ConnectionDialogPolicyPresetSelectProps {
+  title: string;
+  description: string;
+  templates: PolicyTemplateOption[];
+  comboboxLabel: string;
+  searchPlaceholder?: string;
+  emptyStateLabel?: string;
+  onApply: (templateName: string) => void;
+}
+
+export default function ConnectionDialogPolicyPresetSelect({
+  title,
+  description,
+  templates,
+  comboboxLabel,
+  searchPlaceholder = "Search presets...",
+  emptyStateLabel = "No presets matched your search.",
+  onApply,
+}: ConnectionDialogPolicyPresetSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedTemplateName, setSelectedTemplateName] = useState<string | null>(null);
+
+  const groupedTemplates = useMemo(() => {
+    return templates.reduce<Record<string, PolicyTemplateOption[]>>((groups, template) => {
+      if (!groups[template.category]) {
+        groups[template.category] = [];
+      }
+      groups[template.category].push(template);
+      return groups;
+    }, {});
+  }, [templates]);
+
+  const selectedTemplate =
+    templates.find((template) => template.name === selectedTemplateName) ?? null;
+
+  return (
+    <div className="space-y-3 border-t border-border/60 pt-5 first:border-t-0 first:pt-0">
+      <div className="space-y-1">
+        <h4 className="text-sm font-semibold text-foreground">{title}</h4>
+        <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+      </div>
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-label={comboboxLabel}
+            className="w-full justify-between rounded-xl px-4"
+          >
+            <span
+              className={cn(
+                "truncate text-left",
+                selectedTemplate ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {selectedTemplate?.name ?? "Choose a preset"}
+            </span>
+            <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-[min(32rem,calc(100vw-3rem))] p-0"
+        >
+          <Command>
+            <CommandInput placeholder={searchPlaceholder} />
+            <CommandList className="max-h-80">
+              <CommandEmpty>{emptyStateLabel}</CommandEmpty>
+              {Object.entries(groupedTemplates).map(([category, categoryTemplates]) => (
+                <CommandGroup key={category} heading={category}>
+                  {categoryTemplates.map((template) => {
+                    const isSelected = template.name === selectedTemplate?.name;
+                    return (
+                      <CommandItem
+                        key={template.name}
+                        value={[
+                          template.name,
+                          template.category,
+                          template.description,
+                          template.summary,
+                          template.badge,
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                        onSelect={() => {
+                          setSelectedTemplateName(template.name);
+                          onApply(template.name);
+                          setOpen(false);
+                        }}
+                        className="items-start gap-3 rounded-md px-3 py-3"
+                      >
+                        <div className="flex h-5 w-5 items-center justify-center pt-0.5">
+                          <Check
+                            className={cn(
+                              "size-4 text-primary transition-opacity",
+                              isSelected ? "opacity-100" : "opacity-0",
+                            )}
+                          />
+                        </div>
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium text-foreground">
+                              {template.name}
+                            </span>
+                            <Badge variant="outline">{template.category}</Badge>
+                            {template.badge ? (
+                              <span
+                                className={cn(
+                                  "inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium",
+                                  badgeToneClasses[template.badgeTone ?? "neutral"],
+                                )}
+                              >
+                                {template.badge}
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="text-xs leading-5 text-muted-foreground">
+                            {template.description}
+                          </p>
+                          {template.summary ? (
+                            <p className="text-xs text-muted-foreground">
+                              {template.summary}
+                            </p>
+                          ) : null}
+                        </div>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              ))}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {selectedTemplate ? (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <Badge variant="secondary">Preset applied</Badge>
+          <Badge variant="outline">{selectedTemplate.category}</Badge>
+          {selectedTemplate.badge ? (
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full border px-2 py-0.5 font-medium",
+                badgeToneClasses[selectedTemplate.badgeTone ?? "neutral"],
+              )}
+            >
+              {selectedTemplate.badge}
+            </span>
+          ) : null}
+          {selectedTemplate.summary ? (
+            <span className="truncate">{selectedTemplate.summary}</span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/components/Dialogs/ConnectionDialogPolicyTable.tsx
+++ b/client/src/components/Dialogs/ConnectionDialogPolicyTable.tsx
@@ -1,0 +1,2 @@
+export { default } from "@/components/shared/PolicyTable";
+export type { PolicyTableColumn as ConnectionDialogPolicyTableColumn } from "@/components/shared/PolicyTable";

--- a/client/src/components/Dialogs/connectionDbPolicyHelpers.ts
+++ b/client/src/components/Dialogs/connectionDbPolicyHelpers.ts
@@ -1,0 +1,32 @@
+import type { DbPolicyOverrideMode } from '../../api/connections.api';
+
+export const CONNECTION_DB_POLICY_MODE_OPTIONS: Array<{
+  value: DbPolicyOverrideMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'inherit',
+    label: 'Tenant defaults',
+    description: 'Use only the tenant-wide policies configured in Settings.',
+  },
+  {
+    value: 'merge',
+    label: 'Merge',
+    description: 'Apply this connection’s policies before the tenant-wide policies.',
+  },
+  {
+    value: 'override',
+    label: 'Connection only',
+    description: 'Use only this connection’s policies and ignore tenant-wide policies.',
+  },
+];
+
+export function createConnectionPolicyId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function trimOptionalText(value?: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/client/src/components/Settings/AiQueryConfigSection.test.tsx
+++ b/client/src/components/Settings/AiQueryConfigSection.test.tsx
@@ -20,20 +20,68 @@ describe('AiQueryConfigSection', () => {
     useNotificationStore.setState({ notification: null });
 
     getAiConfig.mockResolvedValue({
+      backends: [
+        {
+          name: 'primary',
+          provider: 'openai',
+          hasApiKey: true,
+          baseUrl: null,
+          defaultModel: 'gpt-4o',
+        },
+      ],
+      queryGeneration: {
+        enabled: false,
+        backend: 'primary',
+        modelId: 'gpt-4o',
+        maxTokensPerRequest: 4096,
+        dailyRequestLimit: 100,
+      },
+      queryOptimizer: {
+        enabled: true,
+        backend: 'primary',
+        modelId: 'gpt-4o-mini',
+        maxTokensPerRequest: 4096,
+      },
+      temperature: 0.2,
+      timeoutMs: 60000,
       provider: 'openai',
       hasApiKey: true,
       modelId: 'gpt-4o',
       baseUrl: null,
-      maxTokensPerRequest: 4000,
+      maxTokensPerRequest: 4096,
       dailyRequestLimit: 100,
       enabled: false,
     });
     updateAiConfig.mockResolvedValue({
+      backends: [
+        {
+          name: 'primary',
+          provider: 'openai',
+          hasApiKey: true,
+          baseUrl: null,
+          defaultModel: 'gpt-4o',
+        },
+      ],
+      queryGeneration: {
+        enabled: true,
+        backend: 'primary',
+        modelId: 'gpt-4.1',
+        maxTokensPerRequest: 4096,
+        dailyRequestLimit: 100,
+      },
+      queryOptimizer: {
+        enabled: true,
+        backend: 'primary',
+        modelId: 'gpt-4o-mini',
+        maxTokensPerRequest: 4096,
+      },
+      temperature: 0.2,
+      timeoutMs: 60000,
       provider: 'openai',
       hasApiKey: true,
       modelId: 'gpt-4.1',
       baseUrl: null,
-      maxTokensPerRequest: 4000,
+      maxTokensPerRequest: 4096,
       dailyRequestLimit: 100,
       enabled: true,
     });
@@ -42,20 +90,37 @@ describe('AiQueryConfigSection', () => {
   it('loads AI settings and saves the updated configuration', async () => {
     render(<AiQueryConfigSection />);
 
-    fireEvent.click(await screen.findByRole('switch', { name: 'Enable AI Query Generation' }));
-    fireEvent.change(screen.getByLabelText('AI Model'), {
+    fireEvent.click(await screen.findByRole('switch', { name: 'Enable Query Generation' }));
+    fireEvent.change(screen.getByLabelText('Query generation model'), {
       target: { value: 'gpt-4.1' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(updateAiConfig).toHaveBeenCalledWith({
-        provider: 'openai',
-        modelId: 'gpt-4.1',
-        baseUrl: null,
-        maxTokensPerRequest: 4000,
-        dailyRequestLimit: 100,
-        enabled: true,
+        backends: [
+          {
+            name: 'primary',
+            provider: 'openai',
+            baseUrl: null,
+            defaultModel: 'gpt-4o',
+          },
+        ],
+        queryGeneration: {
+          enabled: true,
+          backend: 'primary',
+          modelId: 'gpt-4.1',
+          maxTokensPerRequest: 4096,
+          dailyRequestLimit: 100,
+        },
+        queryOptimizer: {
+          enabled: true,
+          backend: 'primary',
+          modelId: 'gpt-4o-mini',
+          maxTokensPerRequest: 4096,
+        },
+        temperature: 0.2,
+        timeoutMs: 60000,
       });
     });
 

--- a/client/src/components/Settings/AiQueryConfigSection.tsx
+++ b/client/src/components/Settings/AiQueryConfigSection.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react';
-import { Sparkles, Loader2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  KeyRound, Loader2, Plus, Sparkles, Trash2,
+} from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -13,69 +15,185 @@ import {
   SettingsSwitchRow,
 } from './settings-ui';
 import { getAiConfig, updateAiConfig } from '../../api/aiQuery.api';
-import type { AiConfig } from '../../api/aiQuery.api';
+import type {
+  AiBackendUpdate,
+  AiConfig,
+  AiFeatureConfig,
+  AiFeatureUpdate,
+  AiProvider,
+} from '../../api/aiQuery.api';
 import { useNotificationStore } from '../../store/notificationStore';
 import { extractApiError } from '../../utils/apiError';
 
-const PROVIDERS = [
-  { value: 'none', label: 'None (Disabled)' },
+interface EditableBackend {
+  name: string;
+  provider: AiProvider;
+  apiKey: string;
+  hasApiKey: boolean;
+  clearApiKey: boolean;
+  baseUrl: string;
+  defaultModel: string;
+}
+
+const PROVIDERS: Array<{ value: AiProvider; label: string }> = [
   { value: 'anthropic', label: 'Anthropic (Claude)' },
   { value: 'openai', label: 'OpenAI' },
   { value: 'ollama', label: 'Ollama (Local)' },
   { value: 'openai-compatible', label: 'OpenAI-Compatible' },
 ];
 
+function normalizePositiveInt(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.round(value);
+}
+
+function nextBackendName(backends: EditableBackend[]): string {
+  let index = backends.length + 1;
+  while (backends.some((backend) => backend.name.trim().toLowerCase() === `backend-${index}`)) {
+    index += 1;
+  }
+  return `backend-${index}`;
+}
+
+function toEditableBackends(config: AiConfig): EditableBackend[] {
+  return config.backends.map((backend) => ({
+    name: backend.name,
+    provider: backend.provider,
+    apiKey: '',
+    hasApiKey: backend.hasApiKey,
+    clearApiKey: false,
+    baseUrl: backend.baseUrl ?? '',
+    defaultModel: backend.defaultModel ?? '',
+  }));
+}
+
+function toFeatureUpdate(feature: AiFeatureConfig, includeDailyLimit: boolean): AiFeatureUpdate {
+  const update: AiFeatureUpdate = {
+    enabled: feature.enabled,
+    backend: feature.backend?.trim() || undefined,
+    modelId: feature.modelId?.trim() || undefined,
+    maxTokensPerRequest: normalizePositiveInt(feature.maxTokensPerRequest, 4096),
+  };
+  if (includeDailyLimit) {
+    update.dailyRequestLimit = normalizePositiveInt(feature.dailyRequestLimit ?? 100, 100);
+  }
+  return update;
+}
+
 export default function AiQueryConfigSection() {
   const notify = useNotificationStore((state) => state.notify);
-  const [config, setConfig] = useState<AiConfig | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
-  const [provider, setProvider] = useState('none');
-  const [apiKey, setApiKey] = useState('');
-  const [modelId, setModelId] = useState('');
-  const [baseUrl, setBaseUrl] = useState('');
-  const [maxTokens, setMaxTokens] = useState(4000);
-  const [dailyLimit, setDailyLimit] = useState(100);
-  const [enabled, setEnabled] = useState(false);
+  const [backends, setBackends] = useState<EditableBackend[]>([]);
+  const [queryGeneration, setQueryGeneration] = useState<AiFeatureConfig>({
+    enabled: false,
+    backend: '',
+    modelId: '',
+    maxTokensPerRequest: 4096,
+    dailyRequestLimit: 100,
+  });
+  const [queryOptimizer, setQueryOptimizer] = useState<AiFeatureConfig>({
+    enabled: false,
+    backend: '',
+    modelId: '',
+    maxTokensPerRequest: 4096,
+  });
+  const [temperature, setTemperature] = useState(0.2);
+  const [timeoutMs, setTimeoutMs] = useState(60000);
+
+  const backendNames = useMemo(
+    () => backends.map((backend) => backend.name.trim()).filter(Boolean),
+    [backends],
+  );
+
+  const syncFromConfig = (nextConfig: AiConfig) => {
+    setBackends(toEditableBackends(nextConfig));
+    setQueryGeneration({
+      enabled: nextConfig.queryGeneration.enabled,
+      backend: nextConfig.queryGeneration.backend ?? '',
+      modelId: nextConfig.queryGeneration.modelId ?? '',
+      maxTokensPerRequest: nextConfig.queryGeneration.maxTokensPerRequest,
+      dailyRequestLimit: nextConfig.queryGeneration.dailyRequestLimit ?? 100,
+    });
+    setQueryOptimizer({
+      enabled: nextConfig.queryOptimizer.enabled,
+      backend: nextConfig.queryOptimizer.backend ?? '',
+      modelId: nextConfig.queryOptimizer.modelId ?? '',
+      maxTokensPerRequest: nextConfig.queryOptimizer.maxTokensPerRequest,
+    });
+    setTemperature(nextConfig.temperature);
+    setTimeoutMs(nextConfig.timeoutMs);
+  };
 
   useEffect(() => {
     getAiConfig()
-      .then((nextConfig) => {
-        setConfig(nextConfig);
-        setProvider(nextConfig.provider);
-        setModelId(nextConfig.modelId);
-        setBaseUrl(nextConfig.baseUrl ?? '');
-        setMaxTokens(nextConfig.maxTokensPerRequest);
-        setDailyLimit(nextConfig.dailyRequestLimit);
-        setEnabled(nextConfig.enabled);
-        setApiKey('');
-      })
+      .then(syncFromConfig)
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
+
+  const updateBackend = (index: number, updater: (backend: EditableBackend) => EditableBackend) => {
+    setBackends((current) => current.map((backend, itemIndex) => (
+      itemIndex === index ? updater(backend) : backend
+    )));
+  };
+
+  const removeBackend = (name: string) => {
+    setBackends((current) => current.filter((backend) => backend.name !== name));
+    setQueryGeneration((current) => ({
+      ...current,
+      backend: current.backend === name ? '' : current.backend,
+    }));
+    setQueryOptimizer((current) => ({
+      ...current,
+      backend: current.backend === name ? '' : current.backend,
+    }));
+  };
 
   const handleSave = async () => {
     setError('');
     setSaving(true);
 
     try {
-      const payload: Record<string, unknown> = {
-        provider,
-        modelId,
-        baseUrl: baseUrl || null,
-        maxTokensPerRequest: maxTokens,
-        dailyRequestLimit: dailyLimit,
-        enabled,
-      };
+      const seenNames = new Set<string>();
+      const backendPayload: AiBackendUpdate[] = backends.map((backend) => {
+        const name = backend.name.trim();
+        if (!name) {
+          throw new Error('Each AI backend needs a name');
+        }
+        const normalizedName = name.toLowerCase();
+        if (seenNames.has(normalizedName)) {
+          throw new Error(`AI backend name "${name}" is duplicated`);
+        }
+        seenNames.add(normalizedName);
 
-      if (apiKey) {
-        payload.apiKey = apiKey;
-      }
+        const payload: AiBackendUpdate = {
+          name,
+          provider: backend.provider,
+          baseUrl: backend.baseUrl.trim() || null,
+          defaultModel: backend.defaultModel.trim() || null,
+        };
+        if (backend.apiKey.trim()) {
+          payload.apiKey = backend.apiKey.trim();
+        }
+        if (!backend.apiKey.trim() && backend.clearApiKey) {
+          payload.clearApiKey = true;
+        }
+        return payload;
+      });
 
-      const nextConfig = await updateAiConfig(payload);
-      setConfig(nextConfig);
-      setApiKey('');
+      const nextConfig = await updateAiConfig({
+        backends: backendPayload,
+        queryGeneration: toFeatureUpdate(queryGeneration, true),
+        queryOptimizer: toFeatureUpdate(queryOptimizer, false),
+        temperature,
+        timeoutMs: normalizePositiveInt(timeoutMs, 60000),
+      });
+
+      syncFromConfig(nextConfig);
       notify('AI configuration saved', 'success');
     } catch (err: unknown) {
       setError(extractApiError(err, 'Failed to save AI configuration'));
@@ -98,14 +216,19 @@ export default function AiQueryConfigSection() {
   return (
     <SettingsPanel
       title="AI Query"
-      description="Configure natural-language SQL generation and the provider behind it."
+      description="Configure named AI backends, then choose the default backend/model used for query generation and optimization."
       heading={(
         <div className="flex flex-wrap items-center gap-2">
-          <SettingsStatusBadge tone={enabled ? 'success' : 'neutral'}>
+          <SettingsStatusBadge tone={queryGeneration.enabled ? 'success' : 'neutral'}>
             <Sparkles className="mr-1 size-3.5" />
-            {enabled ? 'Enabled' : 'Disabled'}
+            Generation {queryGeneration.enabled ? 'on' : 'off'}
           </SettingsStatusBadge>
-          {provider !== 'none' && <SettingsStatusBadge tone="neutral">{provider}</SettingsStatusBadge>}
+          <SettingsStatusBadge tone={queryOptimizer.enabled ? 'success' : 'neutral'}>
+            Optimizer {queryOptimizer.enabled ? 'on' : 'off'}
+          </SettingsStatusBadge>
+          <SettingsStatusBadge tone="neutral">
+            {backends.length} backend{backends.length === 1 ? '' : 's'}
+          </SettingsStatusBadge>
         </div>
       )}
       contentClassName="space-y-4"
@@ -117,115 +240,272 @@ export default function AiQueryConfigSection() {
       )}
 
       <SettingsFieldGroup>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold">Named backends</h3>
+            <p className="text-sm text-muted-foreground">Each backend can point at a different remote or local AI host and can keep its own API key.</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setBackends((current) => [...current, {
+              name: nextBackendName(current),
+              provider: 'openai',
+              apiKey: '',
+              hasApiKey: false,
+              clearApiKey: false,
+              baseUrl: '',
+              defaultModel: '',
+            }])}
+          >
+            <Plus className="size-4" />
+            Add backend
+          </Button>
+        </div>
+
+        {backends.length === 0 && (
+          <Alert>
+            <AlertDescription>No AI backends are configured yet. Add at least one backend before enabling query generation or query optimization.</AlertDescription>
+          </Alert>
+        )}
+
+        {backends.map((backend, index) => (
+          <div key={`${backend.name}-${index}`} className="rounded-xl border border-border/70 bg-card/40 p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <KeyRound className="size-4 text-primary" />
+                <span className="text-sm font-semibold">{backend.name || `Backend ${index + 1}`}</span>
+              </div>
+              <Button type="button" variant="ghost" size="sm" onClick={() => removeBackend(backend.name)}>
+                <Trash2 className="size-4" />
+                Remove
+              </Button>
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-2">
+              <SettingsFieldCard label="Backend name" description="Used in the feature selectors below.">
+                <Input
+                  value={backend.name}
+                  onChange={(event) => updateBackend(index, (current) => ({ ...current, name: event.target.value }))}
+                  aria-label={`Backend name ${index + 1}`}
+                />
+              </SettingsFieldCard>
+
+              <SettingsFieldCard label="Provider" description="OpenAI, Anthropic, Ollama, or another OpenAI-compatible API.">
+                <Select
+                  value={backend.provider}
+                  onValueChange={(value) => updateBackend(index, (current) => ({ ...current, provider: value as AiProvider }))}
+                >
+                  <SelectTrigger aria-label={`Backend provider ${index + 1}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PROVIDERS.map((provider) => (
+                      <SelectItem key={provider.value} value={provider.value}>
+                        {provider.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </SettingsFieldCard>
+
+              <SettingsFieldCard label="Host / base URL" description="Optional for hosted APIs. Required for local or OpenAI-compatible backends.">
+                <Input
+                  value={backend.baseUrl}
+                  onChange={(event) => updateBackend(index, (current) => ({ ...current, baseUrl: event.target.value }))}
+                  placeholder={backend.provider === 'ollama' ? 'http://localhost:11434' : 'https://api.example.com'}
+                  aria-label={`Backend base URL ${index + 1}`}
+                />
+              </SettingsFieldCard>
+
+              <SettingsFieldCard label="Default model" description="Used when a feature does not override the model for this backend.">
+                <Input
+                  value={backend.defaultModel}
+                  onChange={(event) => updateBackend(index, (current) => ({ ...current, defaultModel: event.target.value }))}
+                  placeholder={backend.provider === 'anthropic' ? 'claude-sonnet-4-20250514' : 'gpt-4.1'}
+                  aria-label={`Backend default model ${index + 1}`}
+                />
+              </SettingsFieldCard>
+
+              <SettingsFieldCard
+                label="API key"
+                description={backend.hasApiKey && !backend.clearApiKey
+                  ? 'A key is already stored. Leave this blank to keep it.'
+                  : 'Stored encrypted at rest. Ollama usually does not need one.'}
+              >
+                <div className="space-y-2">
+                  <Input
+                    type="password"
+                    value={backend.apiKey}
+                    onChange={(event) => updateBackend(index, (current) => ({
+                      ...current,
+                      apiKey: event.target.value,
+                      clearApiKey: event.target.value ? false : current.clearApiKey,
+                    }))}
+                    placeholder={backend.hasApiKey ? 'Leave blank to keep existing key' : 'Enter API key'}
+                    aria-label={`Backend API key ${index + 1}`}
+                  />
+                  {backend.hasApiKey && (
+                    <Button
+                      type="button"
+                      variant={backend.clearApiKey ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => updateBackend(index, (current) => ({
+                        ...current,
+                        apiKey: '',
+                        clearApiKey: !current.clearApiKey,
+                      }))}
+                    >
+                      {backend.clearApiKey ? 'Stored key will be removed' : 'Remove stored key'}
+                    </Button>
+                  )}
+                </div>
+              </SettingsFieldCard>
+            </div>
+          </div>
+        ))}
+      </SettingsFieldGroup>
+
+      <SettingsFieldGroup>
         <SettingsSwitchRow
-          title="Enable AI Query Generation"
-          description="Allow users to ask questions in plain English and receive validated SELECT queries."
-          checked={enabled}
-          onCheckedChange={setEnabled}
+          title="Enable Query Generation"
+          description="Allow natural-language query drafting for database users."
+          checked={queryGeneration.enabled}
+          onCheckedChange={(enabled) => setQueryGeneration((current) => ({ ...current, enabled }))}
         />
 
         <div className="grid gap-4 xl:grid-cols-2">
-          <SettingsFieldCard
-            label="AI Provider"
-            description="Choose the backing provider or disable the feature entirely."
-          >
-            <Select value={provider} onValueChange={setProvider}>
-              <SelectTrigger aria-label="AI Provider">
+          <SettingsFieldCard label="Query generation backend" description="Default backend used for natural-language query drafting.">
+            <Select
+              value={queryGeneration.backend || '__none__'}
+              onValueChange={(value) => setQueryGeneration((current) => ({ ...current, backend: value === '__none__' ? '' : value }))}
+            >
+              <SelectTrigger aria-label="Query generation backend">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {PROVIDERS.map((providerOption) => (
-                  <SelectItem key={providerOption.value} value={providerOption.value}>
-                    {providerOption.label}
-                  </SelectItem>
+                <SelectItem value="__none__">No backend selected</SelectItem>
+                {backendNames.map((backendName) => (
+                  <SelectItem key={backendName} value={backendName}>{backendName}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </SettingsFieldCard>
 
-          {provider !== 'none' && (
-            <SettingsFieldCard
-              label="Model"
-              description="Leave empty to use the provider default."
-            >
-              <Input
-                value={modelId}
-                onChange={(event) => setModelId(event.target.value)}
-                placeholder={provider === 'anthropic' ? 'claude-sonnet-4-20250514' : 'gpt-4o'}
-                aria-label="AI Model"
-              />
-            </SettingsFieldCard>
-          )}
+          <SettingsFieldCard label="Query generation model" description="Optional per-feature model override.">
+            <Input
+              value={queryGeneration.modelId ?? ''}
+              onChange={(event) => setQueryGeneration((current) => ({ ...current, modelId: event.target.value }))}
+              aria-label="Query generation model"
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard label="Generation max tokens" description="Upper bound for one generated response.">
+            <Input
+              type="number"
+              min={100}
+              max={32000}
+              value={queryGeneration.maxTokensPerRequest}
+              onChange={(event) => setQueryGeneration((current) => ({
+                ...current,
+                maxTokensPerRequest: Number.parseInt(event.target.value, 10) || 4096,
+              }))}
+              aria-label="Query generation max tokens"
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard label="Generation daily limit" description="Tenant-wide generation cap per day.">
+            <Input
+              type="number"
+              min={1}
+              max={100000}
+              value={queryGeneration.dailyRequestLimit ?? 100}
+              onChange={(event) => setQueryGeneration((current) => ({
+                ...current,
+                dailyRequestLimit: Number.parseInt(event.target.value, 10) || 100,
+              }))}
+              aria-label="Query generation daily limit"
+            />
+          </SettingsFieldCard>
         </div>
+      </SettingsFieldGroup>
 
-        {provider !== 'none' && (
-          <>
-            <SettingsFieldCard
-              label="API Key"
-              description={
-                config?.hasApiKey
-                  ? 'An API key is already configured. Leave this blank to keep it.'
-                  : 'Required. The key is encrypted at rest.'
-              }
+      <SettingsFieldGroup>
+        <SettingsSwitchRow
+          title="Enable Query Optimizer"
+          description="Allow execution-plan-aware optimization suggestions in the query visualizer."
+          checked={queryOptimizer.enabled}
+          onCheckedChange={(enabled) => setQueryOptimizer((current) => ({ ...current, enabled }))}
+        />
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard label="Query optimizer backend" description="Default backend used for optimization analysis.">
+            <Select
+              value={queryOptimizer.backend || '__none__'}
+              onValueChange={(value) => setQueryOptimizer((current) => ({ ...current, backend: value === '__none__' ? '' : value }))}
             >
-              <Input
-                type="password"
-                value={apiKey}
-                onChange={(event) => setApiKey(event.target.value)}
-                placeholder={config?.hasApiKey ? 'Leave empty to keep existing key' : 'Enter API key'}
-                aria-label="API Key"
-              />
-            </SettingsFieldCard>
+              <SelectTrigger aria-label="Query optimizer backend">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">No backend selected</SelectItem>
+                {backendNames.map((backendName) => (
+                  <SelectItem key={backendName} value={backendName}>{backendName}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingsFieldCard>
 
-            {(provider === 'openai' || provider === 'ollama' || provider === 'openai-compatible') && (
-              <SettingsFieldCard
-                label="Base URL"
-                description={
-                  provider === 'ollama'
-                    ? 'Required for Ollama.'
-                    : 'Leave empty for the provider default API endpoint.'
-                }
-              >
-                <Input
-                  value={baseUrl}
-                  onChange={(event) => setBaseUrl(event.target.value)}
-                  placeholder={provider === 'ollama' ? 'http://localhost:11434' : 'https://api.openai.com/v1'}
-                  aria-label="Base URL"
-                />
-              </SettingsFieldCard>
-            )}
+          <SettingsFieldCard label="Query optimizer model" description="Optional per-feature model override.">
+            <Input
+              value={queryOptimizer.modelId ?? ''}
+              onChange={(event) => setQueryOptimizer((current) => ({ ...current, modelId: event.target.value }))}
+              aria-label="Query optimizer model"
+            />
+          </SettingsFieldCard>
 
-            <div className="grid gap-4 xl:grid-cols-2">
-              <SettingsFieldCard
-                label="Max Tokens"
-                description="Upper bound for one generated response."
-              >
-                <Input
-                  type="number"
-                  min={100}
-                  max={16000}
-                  value={maxTokens}
-                  onChange={(event) => setMaxTokens(Number.parseInt(event.target.value, 10) || 4000)}
-                  aria-label="Max Tokens"
-                />
-              </SettingsFieldCard>
+          <SettingsFieldCard label="Optimizer max tokens" description="Upper bound for one optimization response.">
+            <Input
+              type="number"
+              min={100}
+              max={32000}
+              value={queryOptimizer.maxTokensPerRequest}
+              onChange={(event) => setQueryOptimizer((current) => ({
+                ...current,
+                maxTokensPerRequest: Number.parseInt(event.target.value, 10) || 4096,
+              }))}
+              aria-label="Query optimizer max tokens"
+            />
+          </SettingsFieldCard>
+        </div>
+      </SettingsFieldGroup>
 
-              <SettingsFieldCard
-                label="Daily Request Limit"
-                description="Tenant-wide cap per day."
-              >
-                <Input
-                  type="number"
-                  min={1}
-                  max={10000}
-                  value={dailyLimit}
-                  onChange={(event) => setDailyLimit(Number.parseInt(event.target.value, 10) || 100)}
-                  aria-label="Daily Request Limit"
-                />
-              </SettingsFieldCard>
-            </div>
-          </>
-        )}
+      <SettingsFieldGroup>
+        <div className="grid gap-4 xl:grid-cols-2">
+          <SettingsFieldCard label="Temperature" description="Sampling temperature shared by generation and optimizer requests.">
+            <Input
+              type="number"
+              min={0}
+              max={2}
+              step={0.1}
+              value={temperature}
+              onChange={(event) => setTemperature(Number.parseFloat(event.target.value) || 0)}
+              aria-label="AI temperature"
+            />
+          </SettingsFieldCard>
+
+          <SettingsFieldCard label="Timeout (ms)" description="Request timeout used for both remote and local AI backends.">
+            <Input
+              type="number"
+              min={1000}
+              max={600000}
+              value={timeoutMs}
+              onChange={(event) => setTimeoutMs(Number.parseInt(event.target.value, 10) || 60000)}
+              aria-label="AI timeout"
+            />
+          </SettingsFieldCard>
+        </div>
 
         <div className="flex justify-start">
           <Button type="button" onClick={handleSave} disabled={saving}>

--- a/client/src/components/Settings/DbFirewallSection.test.tsx
+++ b/client/src/components/Settings/DbFirewallSection.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/dom';
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import DbFirewallSection from './DbFirewallSection';
+import { fireEvent, waitFor } from "@testing-library/dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DbFirewallSection from "./DbFirewallSection";
 
 const {
   createFirewallRule,
@@ -15,8 +15,10 @@ const {
   updateFirewallRule: vi.fn(),
 }));
 
-vi.mock('../../api/dbAudit.api', async () => {
-  const actual = await vi.importActual<typeof import('../../api/dbAudit.api')>('../../api/dbAudit.api');
+vi.mock("../../api/dbAudit.api", async () => {
+  const actual = await vi.importActual<typeof import("../../api/dbAudit.api")>(
+    "../../api/dbAudit.api",
+  );
   return {
     ...actual,
     createFirewallRule,
@@ -26,22 +28,22 @@ vi.mock('../../api/dbAudit.api', async () => {
   };
 });
 
-describe('DbFirewallSection', () => {
+describe("DbFirewallSection", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     getFirewallRules.mockResolvedValue([
       {
-        id: 'rule-1',
-        tenantId: 'tenant-1',
-        name: 'Existing Rule',
-        pattern: '\\bDELETE\\b',
-        action: 'ALERT',
+        id: "rule-1",
+        tenantId: "tenant-1",
+        name: "Existing Rule",
+        pattern: "\\bDELETE\\b",
+        action: "ALERT",
         scope: null,
-        description: 'Existing description',
+        description: "Existing description",
         enabled: true,
         priority: 3,
-        createdAt: '2026-04-07T12:00:00.000Z',
-        updatedAt: '2026-04-07T12:00:00.000Z',
+        createdAt: "2026-04-07T12:00:00.000Z",
+        updatedAt: "2026-04-07T12:00:00.000Z",
       },
     ]);
     createFirewallRule.mockResolvedValue(undefined);
@@ -49,25 +51,41 @@ describe('DbFirewallSection', () => {
     deleteFirewallRule.mockResolvedValue(undefined);
   });
 
-  it('loads rules and creates a rule from a template', async () => {
+  it("loads rules and creates a rule from a template", async () => {
     render(<DbFirewallSection />);
 
-    expect(await screen.findByText('Existing Rule')).toBeInTheDocument();
+    expect(await screen.findByText("Existing Rule")).toBeInTheDocument();
+    expect(
+      screen.getByRole("table", { name: "Firewall rules" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open actions for Existing Rule" }),
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add Rule' }));
-    fireEvent.click(screen.getByText('Block DROP TABLE'));
-    await waitFor(() => {
-      expect(screen.getByLabelText('Rule name')).toHaveValue('Block DROP TABLE');
+    fireEvent.click(screen.getByRole("button", { name: "Add Rule" }));
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Start from a template" }),
+    );
+    fireEvent.change(screen.getByPlaceholderText("Search presets..."), {
+      target: { value: "drop table" },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create Rule' }));
+    fireEvent.click(screen.getByText("Block DROP TABLE"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Rule name")).toHaveValue(
+        "Block DROP TABLE",
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Rule" }));
 
     await waitFor(() => {
-      expect(createFirewallRule).toHaveBeenCalledWith(expect.objectContaining({
-        name: 'Block DROP TABLE',
-        pattern: '\\bDROP\\s+TABLE\\b',
-        action: 'BLOCK',
-        description: 'Prevent accidental or hostile table deletion.',
-      }));
+      expect(createFirewallRule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Block DROP TABLE",
+          pattern: "\\bDROP\\s+TABLE\\b",
+          action: "BLOCK",
+          description: "Prevent accidental or hostile table deletion.",
+        }),
+      );
     });
   });
 });

--- a/client/src/components/Settings/DbFirewallSection.tsx
+++ b/client/src/components/Settings/DbFirewallSection.tsx
@@ -1,16 +1,17 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Plus } from 'lucide-react';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { useCallback, useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import PolicyTable from "@/components/shared/PolicyTable";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import {
   createFirewallRule,
   deleteFirewallRule,
@@ -19,28 +20,27 @@ import {
   type FirewallAction,
   type FirewallRule,
   type FirewallRuleInput,
-} from '../../api/dbAudit.api';
-import { useAsyncAction } from '../../hooks/useAsyncAction';
-import { validateDbFirewallPattern } from '../../utils/dbFirewallPattern';
+} from "../../api/dbAudit.api";
+import { useAsyncAction } from "../../hooks/useAsyncAction";
+import { validateDbFirewallPattern } from "../../utils/dbFirewallPattern";
 import {
   EMPTY_FIREWALL_RULE_FORM,
   FIREWALL_ACTION_VARIANTS,
   FIREWALL_RULE_TEMPLATES,
-} from './dbFirewallPolicyConfig';
+} from "./dbFirewallPolicyConfig";
 import {
   PolicyDialogShell,
   PolicyEmptyState,
   PolicyFormSection,
   PolicyMetadataBadge,
-  PolicyRecordCard,
   PolicyTemplatePicker,
-} from './databasePolicyUi';
+} from "./databasePolicyUi";
 import {
   SettingsFieldCard,
   SettingsLoadingState,
   SettingsPanel,
   SettingsSwitchRow,
-} from './settings-ui';
+} from "./settings-ui";
 
 export default function DbFirewallSection() {
   const [rules, setRules] = useState<FirewallRule[]>([]);
@@ -48,7 +48,9 @@ export default function DbFirewallSection() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingRule, setEditingRule] = useState<FirewallRule | null>(null);
   const [patternError, setPatternError] = useState<string | null>(null);
-  const [formData, setFormData] = useState<FirewallRuleInput>(EMPTY_FIREWALL_RULE_FORM);
+  const [formData, setFormData] = useState<FirewallRuleInput>(
+    EMPTY_FIREWALL_RULE_FORM,
+  );
   const { loading: saving, error, run, clearError } = useAsyncAction();
 
   const fetchRules = useCallback(async () => {
@@ -84,8 +86,8 @@ export default function DbFirewallSection() {
       name: rule.name,
       pattern: rule.pattern,
       action: rule.action,
-      scope: rule.scope ?? '',
-      description: rule.description ?? '',
+      scope: rule.scope ?? "",
+      description: rule.description ?? "",
       enabled: rule.enabled,
       priority: rule.priority,
     });
@@ -102,17 +104,22 @@ export default function DbFirewallSection() {
     }
   };
 
-  const updateField = <K extends keyof FirewallRuleInput>(key: K, value: FirewallRuleInput[K]) => {
+  const updateField = <K extends keyof FirewallRuleInput>(
+    key: K,
+    value: FirewallRuleInput[K],
+  ) => {
     setFormData((current) => ({ ...current, [key]: value }));
   };
 
   const updatePattern = (value: string) => {
-    updateField('pattern', value);
+    updateField("pattern", value);
     setPatternError(value.trim() ? validateDbFirewallPattern(value) : null);
   };
 
   const applyTemplate = (templateName: string) => {
-    const template = FIREWALL_RULE_TEMPLATES.find((entry) => entry.name === templateName);
+    const template = FIREWALL_RULE_TEMPLATES.find(
+      (entry) => entry.name === templateName,
+    );
     if (!template) {
       return;
     }
@@ -140,7 +147,7 @@ export default function DbFirewallSection() {
       } else {
         await createFirewallRule(formData);
       }
-    }, 'Failed to save firewall rule');
+    }, "Failed to save firewall rule");
 
     if (!isSuccessful) {
       return;
@@ -153,7 +160,7 @@ export default function DbFirewallSection() {
   const handleDelete = async (ruleId: string) => {
     const isSuccessful = await run(async () => {
       await deleteFirewallRule(ruleId);
-    }, 'Failed to delete firewall rule');
+    }, "Failed to delete firewall rule");
 
     if (isSuccessful) {
       await fetchRules();
@@ -165,12 +172,17 @@ export default function DbFirewallSection() {
       <SettingsPanel
         title="SQL Firewall Rules"
         description="Block, alert, or log suspicious SQL patterns before they become an incident."
-        heading={(
-          <Button type="button" size="sm" variant="outline" onClick={openCreate}>
+        heading={
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={openCreate}
+          >
             <Plus />
             Add Rule
           </Button>
-        )}
+        }
         contentClassName="space-y-4"
       >
         {error && (
@@ -187,59 +199,125 @@ export default function DbFirewallSection() {
             description="Built-in protections still apply. Add custom rules when you need tenant-specific blocking, alerting, or audit coverage."
           />
         ) : (
-          <div className="space-y-3">
-            {rules.map((rule) => (
-              <PolicyRecordCard
-                key={rule.id}
-                title={rule.name}
-                description={rule.description}
-                code={rule.pattern}
-                badges={(
-                  <>
-                    <PolicyMetadataBadge variant={FIREWALL_ACTION_VARIANTS[rule.action]}>
-                      {rule.action}
-                    </PolicyMetadataBadge>
-                    <PolicyMetadataBadge variant={rule.enabled ? 'default' : 'outline'}>
-                      {rule.enabled ? 'Enabled' : 'Disabled'}
-                    </PolicyMetadataBadge>
-                    <PolicyMetadataBadge variant="outline">
-                      {rule.scope || 'Global scope'}
-                    </PolicyMetadataBadge>
-                  </>
-                )}
-                metadata={(
-                  <>
-                    <span>Priority {rule.priority}</span>
-                    <span>Updated {new Date(rule.updatedAt).toLocaleString()}</span>
-                  </>
-                )}
-                onEdit={() => openEdit(rule)}
-                onDelete={() => void handleDelete(rule.id)}
-              />
-            ))}
-          </div>
+          <PolicyTable
+            ariaLabel="Firewall rules"
+            items={rules}
+            columns={[
+              {
+                id: "name",
+                header: "Rule",
+                className: "align-top whitespace-normal",
+                cell: (rule) => (
+                  <div className="flex min-w-[14rem] flex-col gap-1">
+                    <span className="font-medium text-foreground">
+                      {rule.name}
+                    </span>
+                    {rule.description ? (
+                      <span className="text-xs text-muted-foreground">
+                        {rule.description}
+                      </span>
+                    ) : null}
+                    <span className="text-xs text-muted-foreground">
+                      Priority {rule.priority}
+                    </span>
+                  </div>
+                ),
+              },
+              {
+                id: "pattern",
+                header: "Pattern",
+                className: "align-top whitespace-normal",
+                cell: (rule) => (
+                  <code className="block max-w-[24rem] break-all rounded-md bg-muted/40 px-2 py-1 font-mono text-xs text-foreground">
+                    {rule.pattern}
+                  </code>
+                ),
+              },
+              {
+                id: "action",
+                header: "Action",
+                cell: (rule) => (
+                  <PolicyMetadataBadge
+                    variant={FIREWALL_ACTION_VARIANTS[rule.action]}
+                  >
+                    {rule.action}
+                  </PolicyMetadataBadge>
+                ),
+              },
+              {
+                id: "scope",
+                header: "Scope",
+                className: "align-top whitespace-normal",
+                cell: (rule) => (
+                  <span className="text-sm text-muted-foreground">
+                    {rule.scope || "Global scope"}
+                  </span>
+                ),
+              },
+              {
+                id: "status",
+                header: "Status",
+                cell: (rule) => (
+                  <PolicyMetadataBadge
+                    variant={rule.enabled ? "default" : "outline"}
+                  >
+                    {rule.enabled ? "Enabled" : "Disabled"}
+                  </PolicyMetadataBadge>
+                ),
+              },
+              {
+                id: "updated",
+                header: "Updated",
+                className: "align-top whitespace-normal",
+                cell: (rule) => (
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(rule.updatedAt).toLocaleString()}
+                  </span>
+                ),
+              },
+            ]}
+            emptyTitle="No custom firewall rules"
+            emptyDescription="Built-in protections still apply. Add custom rules when you need tenant-specific blocking, alerting, or audit coverage."
+            getKey={(rule) => rule.id}
+            getRowLabel={(rule) => rule.name}
+            onEdit={openEdit}
+            onDelete={(rule) => void handleDelete(rule.id)}
+          />
         )}
       </SettingsPanel>
 
       <PolicyDialogShell
         open={dialogOpen}
         onOpenChange={closeDialog}
-        title={editingRule ? 'Edit Firewall Rule' : 'Create Firewall Rule'}
+        title={editingRule ? "Edit Firewall Rule" : "Create Firewall Rule"}
         description="Define the SQL pattern, response action, and optional scope for this rule."
-        footer={(
+        footer={
           <>
-            <Button type="button" variant="outline" onClick={() => closeDialog(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => closeDialog(false)}
+            >
               Cancel
             </Button>
             <Button
               type="button"
               onClick={() => void handleSave()}
-              disabled={saving || !formData.name || !formData.pattern || Boolean(patternError)}
+              disabled={
+                saving ||
+                !formData.name ||
+                !formData.pattern ||
+                Boolean(patternError)
+              }
             >
-              {saving ? 'Saving...' : editingRule ? 'Update Rule' : 'Create Rule'}
+              {saving
+                ? "Saving..."
+                : editingRule
+                  ? "Update Rule"
+                  : "Create Rule"}
             </Button>
           </>
-        )}
+        }
       >
         {error && (
           <Alert variant="destructive">
@@ -258,18 +336,26 @@ export default function DbFirewallSection() {
 
         <PolicyFormSection>
           <div className="grid gap-4 xl:grid-cols-2">
-            <SettingsFieldCard label="Rule name" description="Use a short name that reads well in audit events.">
+            <SettingsFieldCard
+              label="Rule name"
+              description="Use a short name that reads well in audit events."
+            >
               <Input
                 aria-label="Rule name"
                 value={formData.name}
-                onChange={(event) => updateField('name', event.target.value)}
+                onChange={(event) => updateField("name", event.target.value)}
               />
             </SettingsFieldCard>
 
-            <SettingsFieldCard label="Action" description="Choose whether matching queries are blocked, alerted, or only logged.">
+            <SettingsFieldCard
+              label="Action"
+              description="Choose whether matching queries are blocked, alerted, or only logged."
+            >
               <Select
                 value={formData.action}
-                onValueChange={(value) => updateField('action', value as FirewallAction)}
+                onValueChange={(value) =>
+                  updateField("action", value as FirewallAction)
+                }
               >
                 <SelectTrigger aria-label="Firewall action">
                   <SelectValue />
@@ -293,8 +379,11 @@ export default function DbFirewallSection() {
               onChange={(event) => updatePattern(event.target.value)}
               className="font-mono text-xs"
             />
-            <p className={`mt-2 text-xs ${patternError ? 'text-destructive' : 'text-muted-foreground'}`}>
-              {patternError ?? 'Basic regex safety checks run locally before the backend validates the final expression.'}
+            <p
+              className={`mt-2 text-xs ${patternError ? "text-destructive" : "text-muted-foreground"}`}
+            >
+              {patternError ??
+                "Basic regex safety checks run locally before the backend validates the final expression."}
             </p>
           </SettingsFieldCard>
 
@@ -305,9 +394,9 @@ export default function DbFirewallSection() {
             >
               <Input
                 aria-label="Rule scope"
-                value={formData.scope ?? ''}
+                value={formData.scope ?? ""}
                 placeholder="database or table name"
-                onChange={(event) => updateField('scope', event.target.value)}
+                onChange={(event) => updateField("scope", event.target.value)}
               />
             </SettingsFieldCard>
 
@@ -321,8 +410,9 @@ export default function DbFirewallSection() {
                 aria-label="Rule priority"
                 value={formData.priority ?? 0}
                 onChange={(event) => {
-                  const nextValue = Number.parseInt(event.target.value, 10) || 0;
-                  updateField('priority', Math.max(0, nextValue));
+                  const nextValue =
+                    Number.parseInt(event.target.value, 10) || 0;
+                  updateField("priority", Math.max(0, nextValue));
                 }}
               />
             </SettingsFieldCard>
@@ -334,8 +424,10 @@ export default function DbFirewallSection() {
           >
             <Textarea
               aria-label="Rule description"
-              value={formData.description ?? ''}
-              onChange={(event) => updateField('description', event.target.value)}
+              value={formData.description ?? ""}
+              onChange={(event) =>
+                updateField("description", event.target.value)
+              }
             />
           </SettingsFieldCard>
 
@@ -343,7 +435,7 @@ export default function DbFirewallSection() {
             title="Enable this rule"
             description="Disabled rules stay defined but are ignored during query evaluation."
             checked={formData.enabled ?? true}
-            onCheckedChange={(checked) => updateField('enabled', checked)}
+            onCheckedChange={(checked) => updateField("enabled", checked)}
           />
         </PolicyFormSection>
       </PolicyDialogShell>

--- a/client/src/components/Settings/DbMaskingSection.test.tsx
+++ b/client/src/components/Settings/DbMaskingSection.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/dom';
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import DbMaskingSection from './DbMaskingSection';
+import { fireEvent, waitFor } from "@testing-library/dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DbMaskingSection from "./DbMaskingSection";
 
 const {
   createMaskingPolicy,
@@ -15,8 +15,10 @@ const {
   updateMaskingPolicy: vi.fn(),
 }));
 
-vi.mock('../../api/dbAudit.api', async () => {
-  const actual = await vi.importActual<typeof import('../../api/dbAudit.api')>('../../api/dbAudit.api');
+vi.mock("../../api/dbAudit.api", async () => {
+  const actual = await vi.importActual<typeof import("../../api/dbAudit.api")>(
+    "../../api/dbAudit.api",
+  );
   return {
     ...actual,
     createMaskingPolicy,
@@ -26,22 +28,22 @@ vi.mock('../../api/dbAudit.api', async () => {
   };
 });
 
-describe('DbMaskingSection', () => {
+describe("DbMaskingSection", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     getMaskingPolicies.mockResolvedValue([
       {
-        id: 'mask-1',
-        tenantId: 'tenant-1',
-        name: 'Existing Mask',
-        columnPattern: '(email|phone)',
-        strategy: 'PARTIAL',
-        exemptRoles: ['OWNER'],
+        id: "mask-1",
+        tenantId: "tenant-1",
+        name: "Existing Mask",
+        columnPattern: "(email|phone)",
+        strategy: "PARTIAL",
+        exemptRoles: ["OWNER"],
         scope: null,
-        description: 'Existing masking rule',
+        description: "Existing masking rule",
         enabled: true,
-        createdAt: '2026-04-07T12:00:00.000Z',
-        updatedAt: '2026-04-07T12:00:00.000Z',
+        createdAt: "2026-04-07T12:00:00.000Z",
+        updatedAt: "2026-04-07T12:00:00.000Z",
       },
     ]);
     createMaskingPolicy.mockResolvedValue(undefined);
@@ -49,24 +51,46 @@ describe('DbMaskingSection', () => {
     deleteMaskingPolicy.mockResolvedValue(undefined);
   });
 
-  it('loads masking policies and creates one from a template', async () => {
+  it("loads masking policies and creates one from a template", async () => {
     render(<DbMaskingSection />);
 
-    expect(await screen.findByText('Existing Mask')).toBeInTheDocument();
+    expect(await screen.findByText("Existing Mask")).toBeInTheDocument();
+    expect(
+      screen.getByRole("table", { name: "Masking policies" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open actions for Existing Mask" }),
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add Policy' }));
-    fireEvent.click(screen.getByText('Mask Credit Cards'));
-    await waitFor(() => {
-      expect(screen.getByLabelText('Policy name')).toHaveValue('Mask Credit Cards');
-    }, { timeout: 5000 });
-    fireEvent.click(screen.getByRole('button', { name: 'Create Policy' }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Policy" }));
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Start from a template" }),
+    );
+    fireEvent.change(screen.getByPlaceholderText("Search presets..."), {
+      target: { value: "credit card" },
+    });
+    fireEvent.click(screen.getByText("Mask Credit Cards"));
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("Policy name")).toHaveValue(
+          "Mask Credit Cards",
+        );
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create Policy" }));
 
-    await waitFor(() => {
-      expect(createMaskingPolicy).toHaveBeenCalledWith(expect.objectContaining({
-        name: 'Mask Credit Cards',
-        columnPattern: '(credit_card|card_number|pan|cc_number)',
-        strategy: 'PARTIAL',
-      }));
-    }, { timeout: 5000 });
+    await waitFor(
+      () => {
+        expect(createMaskingPolicy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Mask Credit Cards",
+            columnPattern: "(credit_card|card_number|pan|cc_number)",
+            strategy: "PARTIAL",
+          }),
+        );
+      },
+      { timeout: 5000 },
+    );
   }, 10000);
 });

--- a/client/src/components/Settings/DbMaskingSection.tsx
+++ b/client/src/components/Settings/DbMaskingSection.tsx
@@ -1,16 +1,17 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Plus } from 'lucide-react';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { useCallback, useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import PolicyTable from "@/components/shared/PolicyTable";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import {
   createMaskingPolicy,
   deleteMaskingPolicy,
@@ -19,8 +20,8 @@ import {
   type MaskingPolicy,
   type MaskingPolicyInput,
   type MaskingStrategy,
-} from '../../api/dbAudit.api';
-import { useAsyncAction } from '../../hooks/useAsyncAction';
+} from "../../api/dbAudit.api";
+import { useAsyncAction } from "../../hooks/useAsyncAction";
 import {
   EMPTY_MASKING_POLICY_FORM,
   MASKING_EXEMPT_ROLES,
@@ -29,30 +30,33 @@ import {
   MASKING_STRATEGY_OPTIONS,
   MASKING_STRATEGY_VARIANTS,
   validateMaskingColumnPattern,
-} from './dbMaskingPolicyConfig';
+} from "./dbMaskingPolicyConfig";
 import {
   PolicyDialogShell,
   PolicyEmptyState,
   PolicyFormSection,
   PolicyMetadataBadge,
-  PolicyRecordCard,
   PolicyRoleChecklist,
   PolicyTemplatePicker,
-} from './databasePolicyUi';
+} from "./databasePolicyUi";
 import {
   SettingsFieldCard,
   SettingsLoadingState,
   SettingsPanel,
   SettingsSwitchRow,
-} from './settings-ui';
+} from "./settings-ui";
 
 export default function DbMaskingSection() {
   const [policies, setPolicies] = useState<MaskingPolicy[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingPolicy, setEditingPolicy] = useState<MaskingPolicy | null>(null);
+  const [editingPolicy, setEditingPolicy] = useState<MaskingPolicy | null>(
+    null,
+  );
   const [patternError, setPatternError] = useState<string | null>(null);
-  const [formData, setFormData] = useState<MaskingPolicyInput>(EMPTY_MASKING_POLICY_FORM);
+  const [formData, setFormData] = useState<MaskingPolicyInput>(
+    EMPTY_MASKING_POLICY_FORM,
+  );
   const { loading: saving, error, run, clearError } = useAsyncAction();
 
   const fetchPolicies = useCallback(async () => {
@@ -84,12 +88,15 @@ export default function DbMaskingSection() {
     }
   };
 
-  const updateField = <K extends keyof MaskingPolicyInput>(key: K, value: MaskingPolicyInput[K]) => {
+  const updateField = <K extends keyof MaskingPolicyInput>(
+    key: K,
+    value: MaskingPolicyInput[K],
+  ) => {
     setFormData((current) => ({ ...current, [key]: value }));
   };
 
   const updatePattern = (value: string) => {
-    updateField('columnPattern', value);
+    updateField("columnPattern", value);
     setPatternError(value.trim() ? validateMaskingColumnPattern(value) : null);
   };
 
@@ -106,8 +113,8 @@ export default function DbMaskingSection() {
       columnPattern: policy.columnPattern,
       strategy: policy.strategy,
       exemptRoles: policy.exemptRoles,
-      scope: policy.scope ?? '',
-      description: policy.description ?? '',
+      scope: policy.scope ?? "",
+      description: policy.description ?? "",
       enabled: policy.enabled,
     });
     setPatternError(null);
@@ -116,7 +123,9 @@ export default function DbMaskingSection() {
   };
 
   const applyTemplate = (templateName: string) => {
-    const template = MASKING_POLICY_TEMPLATES.find((entry) => entry.name === templateName);
+    const template = MASKING_POLICY_TEMPLATES.find(
+      (entry) => entry.name === templateName,
+    );
     if (!template) {
       return;
     }
@@ -132,7 +141,9 @@ export default function DbMaskingSection() {
   };
 
   const handleSave = async () => {
-    const validationError = validateMaskingColumnPattern(formData.columnPattern);
+    const validationError = validateMaskingColumnPattern(
+      formData.columnPattern,
+    );
     if (validationError) {
       setPatternError(validationError);
       return;
@@ -150,7 +161,7 @@ export default function DbMaskingSection() {
       } else {
         await createMaskingPolicy(payload);
       }
-    }, 'Failed to save masking policy');
+    }, "Failed to save masking policy");
 
     if (!isSuccessful) {
       return;
@@ -163,26 +174,33 @@ export default function DbMaskingSection() {
   const handleDelete = async (policyId: string) => {
     const isSuccessful = await run(async () => {
       await deleteMaskingPolicy(policyId);
-    }, 'Failed to delete masking policy');
+    }, "Failed to delete masking policy");
 
     if (isSuccessful) {
       await fetchPolicies();
     }
   };
 
-  const selectedStrategy = MASKING_STRATEGY_OPTIONS.find((entry) => entry.value === formData.strategy);
+  const selectedStrategy = MASKING_STRATEGY_OPTIONS.find(
+    (entry) => entry.value === formData.strategy,
+  );
 
   return (
     <>
       <SettingsPanel
         title="Data Masking Policies"
         description="Redact, hash, or partially reveal sensitive columns before query results leave the proxy."
-        heading={(
-          <Button type="button" size="sm" variant="outline" onClick={openCreate}>
+        heading={
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={openCreate}
+          >
             <Plus />
             Add Policy
           </Button>
-        )}
+        }
         contentClassName="space-y-4"
       >
         {error && (
@@ -199,63 +217,134 @@ export default function DbMaskingSection() {
             description="Query results currently return raw column values. Add policies when you need tenant-specific protection for PII, financial data, or credentials."
           />
         ) : (
-          <div className="space-y-3">
-            {policies.map((policy) => (
-              <PolicyRecordCard
-                key={policy.id}
-                title={policy.name}
-                description={policy.description}
-                code={policy.columnPattern}
-                badges={(
-                  <>
-                    <PolicyMetadataBadge variant={MASKING_STRATEGY_VARIANTS[policy.strategy]}>
-                      {MASKING_STRATEGY_LABELS[policy.strategy]}
-                    </PolicyMetadataBadge>
-                    <PolicyMetadataBadge variant={policy.enabled ? 'default' : 'outline'}>
-                      {policy.enabled ? 'Enabled' : 'Disabled'}
-                    </PolicyMetadataBadge>
-                    <PolicyMetadataBadge variant="outline">
-                      {policy.scope || 'Global scope'}
-                    </PolicyMetadataBadge>
-                  </>
-                )}
-                metadata={(
-                  <>
-                    <span>
-                      {policy.exemptRoles.length > 0
-                        ? `Exempt roles: ${policy.exemptRoles.join(', ')}`
-                        : 'No exempt roles'}
+          <PolicyTable
+            ariaLabel="Masking policies"
+            items={policies}
+            columns={[
+              {
+                id: "name",
+                header: "Policy",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <div className="flex min-w-[14rem] flex-col gap-1">
+                    <span className="font-medium text-foreground">
+                      {policy.name}
                     </span>
-                    <span>Updated {new Date(policy.updatedAt).toLocaleString()}</span>
-                  </>
-                )}
-                onEdit={() => openEdit(policy)}
-                onDelete={() => void handleDelete(policy.id)}
-              />
-            ))}
-          </div>
+                    {policy.description ? (
+                      <span className="text-xs text-muted-foreground">
+                        {policy.description}
+                      </span>
+                    ) : null}
+                  </div>
+                ),
+              },
+              {
+                id: "pattern",
+                header: "Column pattern",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <code className="block max-w-[24rem] break-all rounded-md bg-muted/40 px-2 py-1 font-mono text-xs text-foreground">
+                    {policy.columnPattern}
+                  </code>
+                ),
+              },
+              {
+                id: "strategy",
+                header: "Strategy",
+                cell: (policy) => (
+                  <PolicyMetadataBadge
+                    variant={MASKING_STRATEGY_VARIANTS[policy.strategy]}
+                  >
+                    {MASKING_STRATEGY_LABELS[policy.strategy]}
+                  </PolicyMetadataBadge>
+                ),
+              },
+              {
+                id: "roles",
+                header: "Exempt roles",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <span className="text-sm text-muted-foreground">
+                    {policy.exemptRoles.length > 0
+                      ? policy.exemptRoles.join(", ")
+                      : "None"}
+                  </span>
+                ),
+              },
+              {
+                id: "scope",
+                header: "Scope",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <span className="text-sm text-muted-foreground">
+                    {policy.scope || "Global scope"}
+                  </span>
+                ),
+              },
+              {
+                id: "status",
+                header: "Status",
+                cell: (policy) => (
+                  <PolicyMetadataBadge
+                    variant={policy.enabled ? "default" : "outline"}
+                  >
+                    {policy.enabled ? "Enabled" : "Disabled"}
+                  </PolicyMetadataBadge>
+                ),
+              },
+              {
+                id: "updated",
+                header: "Updated",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(policy.updatedAt).toLocaleString()}
+                  </span>
+                ),
+              },
+            ]}
+            emptyTitle="No masking policies"
+            emptyDescription="Query results currently return raw column values. Add policies when you need tenant-specific protection for PII, financial data, or credentials."
+            getKey={(policy) => policy.id}
+            getRowLabel={(policy) => policy.name}
+            onEdit={openEdit}
+            onDelete={(policy) => void handleDelete(policy.id)}
+          />
         )}
       </SettingsPanel>
 
       <PolicyDialogShell
         open={dialogOpen}
         onOpenChange={closeDialog}
-        title={editingPolicy ? 'Edit Masking Policy' : 'Create Masking Policy'}
+        title={editingPolicy ? "Edit Masking Policy" : "Create Masking Policy"}
         description="Choose how matching columns should be transformed and which tenant roles can bypass the mask."
-        footer={(
+        footer={
           <>
-            <Button type="button" variant="outline" onClick={() => closeDialog(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => closeDialog(false)}
+            >
               Cancel
             </Button>
             <Button
               type="button"
               onClick={() => void handleSave()}
-              disabled={saving || !formData.name || !formData.columnPattern || Boolean(patternError)}
+              disabled={
+                saving ||
+                !formData.name ||
+                !formData.columnPattern ||
+                Boolean(patternError)
+              }
             >
-              {saving ? 'Saving...' : editingPolicy ? 'Update Policy' : 'Create Policy'}
+              {saving
+                ? "Saving..."
+                : editingPolicy
+                  ? "Update Policy"
+                  : "Create Policy"}
             </Button>
           </>
-        )}
+        }
       >
         {error && (
           <Alert variant="destructive">
@@ -274,18 +363,26 @@ export default function DbMaskingSection() {
 
         <PolicyFormSection>
           <div className="grid gap-4 xl:grid-cols-2">
-            <SettingsFieldCard label="Policy name" description="Use a readable name that makes incident review fast.">
+            <SettingsFieldCard
+              label="Policy name"
+              description="Use a readable name that makes incident review fast."
+            >
               <Input
                 aria-label="Policy name"
                 value={formData.name}
-                onChange={(event) => updateField('name', event.target.value)}
+                onChange={(event) => updateField("name", event.target.value)}
               />
             </SettingsFieldCard>
 
-            <SettingsFieldCard label="Masking strategy" description="Choose how matched column values should be transformed.">
+            <SettingsFieldCard
+              label="Masking strategy"
+              description="Choose how matched column values should be transformed."
+            >
               <Select
                 value={formData.strategy}
-                onValueChange={(value) => updateField('strategy', value as MaskingStrategy)}
+                onValueChange={(value) =>
+                  updateField("strategy", value as MaskingStrategy)
+                }
               >
                 <SelectTrigger aria-label="Masking strategy">
                   <SelectValue />
@@ -314,8 +411,11 @@ export default function DbMaskingSection() {
               onChange={(event) => updatePattern(event.target.value)}
               className="font-mono text-xs"
             />
-            <p className={`mt-2 text-xs ${patternError ? 'text-destructive' : 'text-muted-foreground'}`}>
-              {patternError ?? 'The pattern is checked locally before save and validated again by the backend.'}
+            <p
+              className={`mt-2 text-xs ${patternError ? "text-destructive" : "text-muted-foreground"}`}
+            >
+              {patternError ??
+                "The pattern is checked locally before save and validated again by the backend."}
             </p>
           </SettingsFieldCard>
 
@@ -324,7 +424,7 @@ export default function DbMaskingSection() {
             description="Selected roles receive raw values and bypass the mask entirely."
             options={MASKING_EXEMPT_ROLES}
             selected={formData.exemptRoles ?? []}
-            onChange={(selected) => updateField('exemptRoles', selected)}
+            onChange={(selected) => updateField("exemptRoles", selected)}
           />
 
           <div className="grid gap-4 xl:grid-cols-2">
@@ -334,9 +434,9 @@ export default function DbMaskingSection() {
             >
               <Input
                 aria-label="Policy scope"
-                value={formData.scope ?? ''}
+                value={formData.scope ?? ""}
                 placeholder="database or table name"
-                onChange={(event) => updateField('scope', event.target.value)}
+                onChange={(event) => updateField("scope", event.target.value)}
               />
             </SettingsFieldCard>
 
@@ -346,8 +446,10 @@ export default function DbMaskingSection() {
             >
               <Textarea
                 aria-label="Policy description"
-                value={formData.description ?? ''}
-                onChange={(event) => updateField('description', event.target.value)}
+                value={formData.description ?? ""}
+                onChange={(event) =>
+                  updateField("description", event.target.value)
+                }
               />
             </SettingsFieldCard>
           </div>
@@ -356,7 +458,7 @@ export default function DbMaskingSection() {
             title="Enable this policy"
             description="Disabled policies stay defined but no longer transform query results."
             checked={formData.enabled ?? true}
-            onCheckedChange={(checked) => updateField('enabled', checked)}
+            onCheckedChange={(checked) => updateField("enabled", checked)}
           />
         </PolicyFormSection>
       </PolicyDialogShell>

--- a/client/src/components/Settings/DbRateLimitSection.test.tsx
+++ b/client/src/components/Settings/DbRateLimitSection.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, waitFor } from '@testing-library/dom';
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import DbRateLimitSection from './DbRateLimitSection';
+import { fireEvent, waitFor } from "@testing-library/dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DbRateLimitSection from "./DbRateLimitSection";
 
 const {
   createRateLimitPolicy,
@@ -15,8 +15,10 @@ const {
   updateRateLimitPolicy: vi.fn(),
 }));
 
-vi.mock('../../api/dbAudit.api', async () => {
-  const actual = await vi.importActual<typeof import('../../api/dbAudit.api')>('../../api/dbAudit.api');
+vi.mock("../../api/dbAudit.api", async () => {
+  const actual = await vi.importActual<typeof import("../../api/dbAudit.api")>(
+    "../../api/dbAudit.api",
+  );
   return {
     ...actual,
     createRateLimitPolicy,
@@ -26,25 +28,25 @@ vi.mock('../../api/dbAudit.api', async () => {
   };
 });
 
-describe('DbRateLimitSection', () => {
+describe("DbRateLimitSection", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     getRateLimitPolicies.mockResolvedValue([
       {
-        id: 'policy-1',
-        tenantId: 'tenant-1',
-        name: 'Existing Limit',
-        queryType: 'SELECT',
+        id: "policy-1",
+        tenantId: "tenant-1",
+        name: "Existing Limit",
+        queryType: "SELECT",
         windowMs: 60000,
         maxQueries: 100,
         burstMax: 10,
-        exemptRoles: ['ADMIN'],
+        exemptRoles: ["ADMIN"],
         scope: null,
-        action: 'REJECT',
+        action: "REJECT",
         enabled: true,
         priority: 2,
-        createdAt: '2026-04-07T12:00:00.000Z',
-        updatedAt: '2026-04-07T12:00:00.000Z',
+        createdAt: "2026-04-07T12:00:00.000Z",
+        updatedAt: "2026-04-07T12:00:00.000Z",
       },
     ]);
     createRateLimitPolicy.mockResolvedValue(undefined);
@@ -52,27 +54,49 @@ describe('DbRateLimitSection', () => {
     deleteRateLimitPolicy.mockResolvedValue(undefined);
   });
 
-  it('loads policies and creates one from a template', async () => {
+  it("loads policies and creates one from a template", async () => {
     render(<DbRateLimitSection />);
 
-    expect(await screen.findByText('Existing Limit')).toBeInTheDocument();
+    expect(await screen.findByText("Existing Limit")).toBeInTheDocument();
+    expect(
+      screen.getByRole("table", { name: "Rate limit policies" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open actions for Existing Limit" }),
+    ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add Policy' }));
-    fireEvent.click(screen.getByText('DDL Rate Limit'));
-    await waitFor(() => {
-      expect(screen.getByLabelText('Policy name')).toHaveValue('DDL Rate Limit');
-    }, { timeout: 5000 });
-    fireEvent.click(screen.getByRole('button', { name: 'Create Policy' }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Policy" }));
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Start from a template" }),
+    );
+    fireEvent.change(screen.getByPlaceholderText("Search presets..."), {
+      target: { value: "ddl" },
+    });
+    fireEvent.click(screen.getByText("DDL Rate Limit"));
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("Policy name")).toHaveValue(
+          "DDL Rate Limit",
+        );
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create Policy" }));
 
-    await waitFor(() => {
-      expect(createRateLimitPolicy).toHaveBeenCalledWith(expect.objectContaining({
-        name: 'DDL Rate Limit',
-        queryType: 'DDL',
-        windowMs: 300000,
-        maxQueries: 5,
-        burstMax: 2,
-        action: 'REJECT',
-      }));
-    }, { timeout: 5000 });
+    await waitFor(
+      () => {
+        expect(createRateLimitPolicy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "DDL Rate Limit",
+            queryType: "DDL",
+            windowMs: 300000,
+            maxQueries: 5,
+            burstMax: 2,
+            action: "REJECT",
+          }),
+        );
+      },
+      { timeout: 5000 },
+    );
   }, 10000);
 });

--- a/client/src/components/Settings/DbRateLimitSection.tsx
+++ b/client/src/components/Settings/DbRateLimitSection.tsx
@@ -1,15 +1,16 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Plus } from 'lucide-react';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { useCallback, useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import PolicyTable from "@/components/shared/PolicyTable";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
+} from "@/components/ui/select";
 import {
   createRateLimitPolicy,
   deleteRateLimitPolicy,
@@ -19,8 +20,8 @@ import {
   type RateLimitAction,
   type RateLimitPolicy,
   type RateLimitPolicyInput,
-} from '../../api/dbAudit.api';
-import { useAsyncAction } from '../../hooks/useAsyncAction';
+} from "../../api/dbAudit.api";
+import { useAsyncAction } from "../../hooks/useAsyncAction";
 import {
   ALL_QUERY_TYPES,
   EMPTY_RATE_LIMIT_POLICY_FORM,
@@ -30,29 +31,32 @@ import {
   RATE_LIMIT_POLICY_TEMPLATES,
   RATE_LIMIT_QUERY_TYPE_OPTIONS,
   RATE_LIMIT_WINDOW_OPTIONS,
-} from './dbRateLimitPolicyConfig';
+} from "./dbRateLimitPolicyConfig";
 import {
   PolicyDialogShell,
   PolicyEmptyState,
   PolicyFormSection,
   PolicyMetadataBadge,
-  PolicyRecordCard,
   PolicyRoleChecklist,
   PolicyTemplatePicker,
-} from './databasePolicyUi';
+} from "./databasePolicyUi";
 import {
   SettingsFieldCard,
   SettingsLoadingState,
   SettingsPanel,
   SettingsSwitchRow,
-} from './settings-ui';
+} from "./settings-ui";
 
 export default function DbRateLimitSection() {
   const [policies, setPolicies] = useState<RateLimitPolicy[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingPolicy, setEditingPolicy] = useState<RateLimitPolicy | null>(null);
-  const [formData, setFormData] = useState<RateLimitPolicyInput>(EMPTY_RATE_LIMIT_POLICY_FORM);
+  const [editingPolicy, setEditingPolicy] = useState<RateLimitPolicy | null>(
+    null,
+  );
+  const [formData, setFormData] = useState<RateLimitPolicyInput>(
+    EMPTY_RATE_LIMIT_POLICY_FORM,
+  );
   const { loading: saving, error, run, clearError } = useAsyncAction();
 
   const fetchPolicies = useCallback(async () => {
@@ -83,7 +87,10 @@ export default function DbRateLimitSection() {
     }
   };
 
-  const updateField = <K extends keyof RateLimitPolicyInput>(key: K, value: RateLimitPolicyInput[K]) => {
+  const updateField = <K extends keyof RateLimitPolicyInput>(
+    key: K,
+    value: RateLimitPolicyInput[K],
+  ) => {
     setFormData((current) => ({ ...current, [key]: value }));
   };
 
@@ -102,7 +109,7 @@ export default function DbRateLimitSection() {
       maxQueries: policy.maxQueries,
       burstMax: policy.burstMax,
       exemptRoles: policy.exemptRoles,
-      scope: policy.scope ?? '',
+      scope: policy.scope ?? "",
       action: policy.action,
       enabled: policy.enabled,
       priority: policy.priority,
@@ -112,7 +119,9 @@ export default function DbRateLimitSection() {
   };
 
   const applyTemplate = (templateName: string) => {
-    const template = RATE_LIMIT_POLICY_TEMPLATES.find((entry) => entry.name === templateName);
+    const template = RATE_LIMIT_POLICY_TEMPLATES.find(
+      (entry) => entry.name === templateName,
+    );
     if (!template) {
       return;
     }
@@ -141,7 +150,7 @@ export default function DbRateLimitSection() {
       } else {
         await createRateLimitPolicy(payload);
       }
-    }, 'Failed to save rate limit policy');
+    }, "Failed to save rate limit policy");
 
     if (!isSuccessful) {
       return;
@@ -154,7 +163,7 @@ export default function DbRateLimitSection() {
   const handleDelete = async (policyId: string) => {
     const isSuccessful = await run(async () => {
       await deleteRateLimitPolicy(policyId);
-    }, 'Failed to delete rate limit policy');
+    }, "Failed to delete rate limit policy");
 
     if (isSuccessful) {
       await fetchPolicies();
@@ -166,12 +175,17 @@ export default function DbRateLimitSection() {
       <SettingsPanel
         title="Query Rate Limits"
         description="Cap noisy workloads, slow abuse, and decide whether overages are rejected or simply logged."
-        heading={(
-          <Button type="button" size="sm" variant="outline" onClick={openCreate}>
+        heading={
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={openCreate}
+          >
             <Plus />
             Add Policy
           </Button>
-        )}
+        }
         contentClassName="space-y-4"
       >
         {error && (
@@ -188,56 +202,134 @@ export default function DbRateLimitSection() {
             description="Queries are currently unrestricted. Add a policy when you need hard ceilings on read or write throughput."
           />
         ) : (
-          <div className="space-y-3">
-            {policies.map((policy) => (
-              <PolicyRecordCard
-                key={policy.id}
-                title={policy.name}
-                badges={(
-                  <>
-                    <PolicyMetadataBadge variant={RATE_LIMIT_ACTION_VARIANTS[policy.action]}>
-                      {policy.action === 'REJECT' ? 'Reject' : 'Log only'}
-                    </PolicyMetadataBadge>
-                    <PolicyMetadataBadge variant="outline">
-                      {policy.queryType || 'All query types'}
-                    </PolicyMetadataBadge>
-                    <PolicyMetadataBadge variant={policy.enabled ? 'default' : 'outline'}>
-                      {policy.enabled ? 'Enabled' : 'Disabled'}
-                    </PolicyMetadataBadge>
-                  </>
-                )}
-                metadata={(
-                  <>
-                    <span>Window {formatRateLimitWindow(policy.windowMs)}</span>
+          <PolicyTable
+            ariaLabel="Rate limit policies"
+            items={policies}
+            columns={[
+              {
+                id: "name",
+                header: "Policy",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <div className="flex min-w-[14rem] flex-col gap-1">
+                    <span className="font-medium text-foreground">
+                      {policy.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      Priority {policy.priority}
+                    </span>
+                  </div>
+                ),
+              },
+              {
+                id: "query-type",
+                header: "Query type",
+                cell: (policy) => (
+                  <PolicyMetadataBadge variant="outline">
+                    {policy.queryType || "All query types"}
+                  </PolicyMetadataBadge>
+                ),
+              },
+              {
+                id: "window",
+                header: "Window",
+                cell: (policy) => (
+                  <span className="text-sm text-muted-foreground">
+                    {formatRateLimitWindow(policy.windowMs)}
+                  </span>
+                ),
+              },
+              {
+                id: "limits",
+                header: "Limits",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <div className="flex flex-col gap-1 text-sm text-muted-foreground">
                     <span>Max {policy.maxQueries}</span>
                     <span>Burst {policy.burstMax}</span>
-                    <span>Priority {policy.priority}</span>
-                    <span>{policy.scope || 'Global scope'}</span>
-                  </>
-                )}
-                onEdit={() => openEdit(policy)}
-                onDelete={() => void handleDelete(policy.id)}
-              />
-            ))}
-          </div>
+                  </div>
+                ),
+              },
+              {
+                id: "response",
+                header: "Response",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <div className="flex flex-col gap-2">
+                    <PolicyMetadataBadge
+                      variant={RATE_LIMIT_ACTION_VARIANTS[policy.action]}
+                    >
+                      {policy.action === "REJECT" ? "Reject" : "Log only"}
+                    </PolicyMetadataBadge>
+                    <span className="text-xs text-muted-foreground">
+                      {policy.scope || "Global scope"}
+                    </span>
+                  </div>
+                ),
+              },
+              {
+                id: "roles",
+                header: "Exempt roles",
+                className: "align-top whitespace-normal",
+                cell: (policy) => (
+                  <span className="text-sm text-muted-foreground">
+                    {policy.exemptRoles.length > 0
+                      ? policy.exemptRoles.join(", ")
+                      : "None"}
+                  </span>
+                ),
+              },
+              {
+                id: "status",
+                header: "Status",
+                cell: (policy) => (
+                  <PolicyMetadataBadge
+                    variant={policy.enabled ? "default" : "outline"}
+                  >
+                    {policy.enabled ? "Enabled" : "Disabled"}
+                  </PolicyMetadataBadge>
+                ),
+              },
+            ]}
+            emptyTitle="No query rate limits"
+            emptyDescription="Queries are currently unrestricted. Add a policy when you need hard ceilings on read or write throughput."
+            getKey={(policy) => policy.id}
+            getRowLabel={(policy) => policy.name}
+            onEdit={openEdit}
+            onDelete={(policy) => void handleDelete(policy.id)}
+          />
         )}
       </SettingsPanel>
 
       <PolicyDialogShell
         open={dialogOpen}
         onOpenChange={closeDialog}
-        title={editingPolicy ? 'Edit Rate Limit Policy' : 'Create Rate Limit Policy'}
+        title={
+          editingPolicy ? "Edit Rate Limit Policy" : "Create Rate Limit Policy"
+        }
         description="Set the query type, time window, exempt roles, and response when a tenant crosses the limit."
-        footer={(
+        footer={
           <>
-            <Button type="button" variant="outline" onClick={() => closeDialog(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => closeDialog(false)}
+            >
               Cancel
             </Button>
-            <Button type="button" onClick={() => void handleSave()} disabled={saving || !formData.name}>
-              {saving ? 'Saving...' : editingPolicy ? 'Update Policy' : 'Create Policy'}
+            <Button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={saving || !formData.name}
+            >
+              {saving
+                ? "Saving..."
+                : editingPolicy
+                  ? "Update Policy"
+                  : "Create Policy"}
             </Button>
           </>
-        )}
+        }
       >
         {error && (
           <Alert variant="destructive">
@@ -256,18 +348,26 @@ export default function DbRateLimitSection() {
 
         <PolicyFormSection>
           <div className="grid gap-4 xl:grid-cols-2">
-            <SettingsFieldCard label="Policy name" description="Keep the name readable in alerts and audit logs.">
+            <SettingsFieldCard
+              label="Policy name"
+              description="Keep the name readable in alerts and audit logs."
+            >
               <Input
                 aria-label="Policy name"
                 value={formData.name}
-                onChange={(event) => updateField('name', event.target.value)}
+                onChange={(event) => updateField("name", event.target.value)}
               />
             </SettingsFieldCard>
 
-            <SettingsFieldCard label="Response" description="Reject overages immediately or log them for review.">
+            <SettingsFieldCard
+              label="Response"
+              description="Reject overages immediately or log them for review."
+            >
               <Select
-                value={formData.action ?? 'REJECT'}
-                onValueChange={(value) => updateField('action', value as RateLimitAction)}
+                value={formData.action ?? "REJECT"}
+                onValueChange={(value) =>
+                  updateField("action", value as RateLimitAction)
+                }
               >
                 <SelectTrigger aria-label="Rate limit action">
                   <SelectValue />
@@ -281,10 +381,18 @@ export default function DbRateLimitSection() {
           </div>
 
           <div className="grid gap-4 xl:grid-cols-2">
-            <SettingsFieldCard label="Query type" description="Limit a specific SQL class or all statements together.">
+            <SettingsFieldCard
+              label="Query type"
+              description="Limit a specific SQL class or all statements together."
+            >
               <Select
                 value={formData.queryType ?? ALL_QUERY_TYPES}
-                onValueChange={(value) => updateField('queryType', value === ALL_QUERY_TYPES ? null : value as DbQueryType)}
+                onValueChange={(value) =>
+                  updateField(
+                    "queryType",
+                    value === ALL_QUERY_TYPES ? null : (value as DbQueryType),
+                  )
+                }
               >
                 <SelectTrigger aria-label="Query type">
                   <SelectValue />
@@ -299,10 +407,15 @@ export default function DbRateLimitSection() {
               </Select>
             </SettingsFieldCard>
 
-            <SettingsFieldCard label="Time window" description="The rolling window used to count matching queries.">
+            <SettingsFieldCard
+              label="Time window"
+              description="The rolling window used to count matching queries."
+            >
               <Select
                 value={String(formData.windowMs ?? 60000)}
-                onValueChange={(value) => updateField('windowMs', Number(value))}
+                onValueChange={(value) =>
+                  updateField("windowMs", Number(value))
+                }
               >
                 <SelectTrigger aria-label="Time window">
                   <SelectValue />
@@ -319,52 +432,67 @@ export default function DbRateLimitSection() {
           </div>
 
           <div className="grid gap-4 xl:grid-cols-3">
-            <SettingsFieldCard label="Max queries" description="How many matching queries fit inside the window.">
+            <SettingsFieldCard
+              label="Max queries"
+              description="How many matching queries fit inside the window."
+            >
               <Input
                 type="number"
                 min={1}
                 aria-label="Max queries"
                 value={formData.maxQueries ?? 100}
                 onChange={(event) => {
-                  const nextValue = Number.parseInt(event.target.value, 10) || 1;
-                  updateField('maxQueries', Math.max(1, nextValue));
+                  const nextValue =
+                    Number.parseInt(event.target.value, 10) || 1;
+                  updateField("maxQueries", Math.max(1, nextValue));
                 }}
               />
             </SettingsFieldCard>
 
-            <SettingsFieldCard label="Burst allowance" description="Short-term tokens available above the steady limit.">
+            <SettingsFieldCard
+              label="Burst allowance"
+              description="Short-term tokens available above the steady limit."
+            >
               <Input
                 type="number"
                 min={1}
                 aria-label="Burst max"
                 value={formData.burstMax ?? 10}
                 onChange={(event) => {
-                  const nextValue = Number.parseInt(event.target.value, 10) || 1;
-                  updateField('burstMax', Math.max(1, nextValue));
+                  const nextValue =
+                    Number.parseInt(event.target.value, 10) || 1;
+                  updateField("burstMax", Math.max(1, nextValue));
                 }}
               />
             </SettingsFieldCard>
 
-            <SettingsFieldCard label="Priority" description="Higher priority policies are evaluated first.">
+            <SettingsFieldCard
+              label="Priority"
+              description="Higher priority policies are evaluated first."
+            >
               <Input
                 type="number"
                 min={0}
                 aria-label="Policy priority"
                 value={formData.priority ?? 0}
                 onChange={(event) => {
-                  const nextValue = Number.parseInt(event.target.value, 10) || 0;
-                  updateField('priority', Math.max(0, nextValue));
+                  const nextValue =
+                    Number.parseInt(event.target.value, 10) || 0;
+                  updateField("priority", Math.max(0, nextValue));
                 }}
               />
             </SettingsFieldCard>
           </div>
 
-          <SettingsFieldCard label="Scope" description="Leave empty to apply the policy across every proxied database.">
+          <SettingsFieldCard
+            label="Scope"
+            description="Leave empty to apply the policy across every proxied database."
+          >
             <Input
               aria-label="Policy scope"
-              value={formData.scope ?? ''}
+              value={formData.scope ?? ""}
               placeholder="database or table name"
-              onChange={(event) => updateField('scope', event.target.value)}
+              onChange={(event) => updateField("scope", event.target.value)}
             />
           </SettingsFieldCard>
 
@@ -373,14 +501,14 @@ export default function DbRateLimitSection() {
             description="Selected tenant roles bypass this policy entirely."
             options={RATE_LIMIT_EXEMPT_ROLES}
             selected={formData.exemptRoles ?? []}
-            onChange={(selected) => updateField('exemptRoles', selected)}
+            onChange={(selected) => updateField("exemptRoles", selected)}
           />
 
           <SettingsSwitchRow
             title="Enable this policy"
             description="Disabled policies stay saved but do not participate in rate-limit decisions."
             checked={formData.enabled ?? true}
-            onCheckedChange={(checked) => updateField('enabled', checked)}
+            onCheckedChange={(checked) => updateField("enabled", checked)}
           />
         </PolicyFormSection>
       </PolicyDialogShell>

--- a/client/src/components/Settings/databasePolicyUi.tsx
+++ b/client/src/components/Settings/databasePolicyUi.tsx
@@ -1,7 +1,15 @@
-import type { ReactNode } from 'react';
-import { Edit3, Trash2 } from 'lucide-react';
+import { useMemo, useState, type ReactNode } from 'react';
+import { Check, ChevronsUpDown, Edit3, Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
 import {
   Dialog,
   DialogContent,
@@ -11,6 +19,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import {
   SettingsButtonRow,
@@ -33,58 +42,141 @@ export function PolicyTemplatePicker({
   title,
   description,
   templates,
+  comboboxLabel,
+  searchPlaceholder = 'Search presets...',
+  emptyStateLabel = 'No presets matched your search.',
   onApply,
 }: {
   title: string;
   description: string;
   templates: PolicyTemplateOption[];
+  comboboxLabel?: string;
+  searchPlaceholder?: string;
+  emptyStateLabel?: string;
   onApply: (templateName: string) => void;
 }) {
-  const groupedTemplates = templates.reduce<Record<string, PolicyTemplateOption[]>>((groups, template) => {
-    if (!groups[template.category]) {
-      groups[template.category] = [];
-    }
-    groups[template.category].push(template);
-    return groups;
-  }, {});
+  const [open, setOpen] = useState(false);
+  const [selectedTemplateName, setSelectedTemplateName] = useState<string | null>(null);
+
+  const groupedTemplates = useMemo(
+    () => templates.reduce<Record<string, PolicyTemplateOption[]>>((groups, template) => {
+      if (!groups[template.category]) {
+        groups[template.category] = [];
+      }
+      groups[template.category].push(template);
+      return groups;
+    }, {}),
+    [templates],
+  );
+
+  const selectedTemplate = templates.find((template) => template.name === selectedTemplateName) ?? null;
 
   return (
     <SettingsSectionBlock title={title} description={description}>
-      <div className="space-y-4">
-        {Object.entries(groupedTemplates).map(([category, categoryTemplates]) => (
-          <div key={category} className="space-y-3">
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-              {category}
-            </div>
-            <div className="grid gap-3 xl:grid-cols-2">
-              {categoryTemplates.map((template) => (
-                <button
-                  key={template.name}
-                  type="button"
-                  onClick={() => onApply(template.name)}
-                  className="rounded-xl border border-border/70 bg-background/70 p-4 text-left transition-colors hover:border-primary/30 hover:bg-accent/30"
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <div className="text-sm font-semibold text-foreground">{template.name}</div>
-                      <p className="text-sm leading-6 text-muted-foreground">{template.description}</p>
-                    </div>
-                    {template.badge && (
-                      <SettingsStatusBadge tone={template.badgeTone ?? 'neutral'}>
-                        {template.badge}
-                      </SettingsStatusBadge>
-                    )}
-                  </div>
-                  {template.summary && (
-                    <div className="mt-3 text-xs text-muted-foreground">
-                      {template.summary}
-                    </div>
-                  )}
-                </button>
-              ))}
-            </div>
+      <div className="space-y-3">
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              role="combobox"
+              aria-expanded={open}
+              aria-label={comboboxLabel ?? title}
+              className="w-full justify-between rounded-xl px-4"
+            >
+              <span
+                className={cn(
+                  'truncate text-left',
+                  selectedTemplate ? 'text-foreground' : 'text-muted-foreground',
+                )}
+              >
+                {selectedTemplate?.name ?? 'Choose a preset'}
+              </span>
+              <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            className="w-[min(32rem,calc(100vw-3rem))] p-0"
+          >
+            <Command>
+              <CommandInput placeholder={searchPlaceholder} />
+              <CommandList className="max-h-80">
+                <CommandEmpty>{emptyStateLabel}</CommandEmpty>
+                {Object.entries(groupedTemplates).map(([category, categoryTemplates]) => (
+                  <CommandGroup key={category} heading={category}>
+                    {categoryTemplates.map((template) => {
+                      const isSelected = template.name === selectedTemplate?.name;
+                      return (
+                        <CommandItem
+                          key={template.name}
+                          value={[
+                            template.name,
+                            template.category,
+                            template.description,
+                            template.summary,
+                            template.badge,
+                          ]
+                            .filter(Boolean)
+                            .join(' ')}
+                          onSelect={() => {
+                            setSelectedTemplateName(template.name);
+                            onApply(template.name);
+                            setOpen(false);
+                          }}
+                          className="items-start gap-3 rounded-md px-3 py-3"
+                        >
+                          <div className="flex h-5 w-5 items-center justify-center pt-0.5">
+                            <Check
+                              className={cn(
+                                'size-4 text-primary transition-opacity',
+                                isSelected ? 'opacity-100' : 'opacity-0',
+                              )}
+                            />
+                          </div>
+                          <div className="min-w-0 flex-1 space-y-1.5">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="font-medium text-foreground">{template.name}</span>
+                              <Badge variant="outline">{template.category}</Badge>
+                              {template.badge ? (
+                                <SettingsStatusBadge tone={template.badgeTone ?? 'neutral'}>
+                                  {template.badge}
+                                </SettingsStatusBadge>
+                              ) : null}
+                            </div>
+                            <p className="text-xs leading-5 text-muted-foreground">
+                              {template.description}
+                            </p>
+                            {template.summary ? (
+                              <p className="text-xs text-muted-foreground">
+                                {template.summary}
+                              </p>
+                            ) : null}
+                          </div>
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                ))}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        {selectedTemplate ? (
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <Badge variant="secondary">Preset applied</Badge>
+            <Badge variant="outline">{selectedTemplate.category}</Badge>
+            {selectedTemplate.badge ? (
+              <SettingsStatusBadge tone={selectedTemplate.badgeTone ?? 'neutral'}>
+                {selectedTemplate.badge}
+              </SettingsStatusBadge>
+            ) : null}
+            {selectedTemplate.summary ? (
+              <span className="truncate">{selectedTemplate.summary}</span>
+            ) : null}
           </div>
-        ))}
+        ) : null}
       </div>
     </SettingsSectionBlock>
   );

--- a/client/src/components/Tabs/TabPanel.tsx
+++ b/client/src/components/Tabs/TabPanel.tsx
@@ -59,6 +59,7 @@ export default function TabPanel() {
                 isActive={tab.id === activeTabId}
                 credentials={tab.credentials}
                 initialProtocol={tab.connection.dbSettings?.protocol}
+                dbSettings={tab.connection.dbSettings}
               />
             ) : (
               <RdpViewer

--- a/client/src/components/shared/PolicyTable.tsx
+++ b/client/src/components/shared/PolicyTable.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from "react";
+import { Edit3, MoreHorizontal, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export interface PolicyTableColumn<T> {
+  id: string;
+  header: string;
+  className?: string;
+  headerClassName?: string;
+  cell: (item: T) => ReactNode;
+}
+
+interface PolicyTableProps<T> {
+  ariaLabel: string;
+  items: T[];
+  columns: PolicyTableColumn<T>[];
+  emptyTitle: string;
+  emptyDescription: string;
+  getKey: (item: T, index: number) => string;
+  getRowLabel: (item: T) => string;
+  onEdit: (item: T) => void;
+  onDelete: (item: T) => void;
+}
+
+export default function PolicyTable<T>({
+  ariaLabel,
+  items,
+  columns,
+  emptyTitle,
+  emptyDescription,
+  getKey,
+  getRowLabel,
+  onEdit,
+  onDelete,
+}: PolicyTableProps<T>) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/70 bg-muted/15 px-4 py-8 text-center">
+        <div className="text-sm font-semibold text-foreground">
+          {emptyTitle}
+        </div>
+        <p className="mx-auto mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+          {emptyDescription}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border/70">
+      <Table aria-label={ariaLabel}>
+        <TableHeader>
+          <TableRow>
+            {columns.map((column) => (
+              <TableHead key={column.id} className={column.headerClassName}>
+                {column.header}
+              </TableHead>
+            ))}
+            <TableHead className="w-[3.5rem] text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((item, index) => {
+            const rowLabel = getRowLabel(item);
+
+            return (
+              <TableRow key={getKey(item, index)}>
+                {columns.map((column) => (
+                  <TableCell key={column.id} className={column.className}>
+                    {column.cell(item)}
+                  </TableCell>
+                ))}
+                <TableCell className="text-right">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        variant="ghost"
+                        aria-label={`Open actions for ${rowLabel}`}
+                      >
+                        <MoreHorizontal />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => onEdit(item)}>
+                        <Edit3 />
+                        Edit
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        onClick={() => onDelete(item)}
+                      >
+                        <Trash2 />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -1,0 +1,113 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -28,6 +28,10 @@ if (!HTMLElement.prototype.releasePointerCapture) {
   HTMLElement.prototype.releasePointerCapture = () => {};
 }
 
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => {};
+}
+
 if (!window.ResizeObserver) {
   class ResizeObserverMock implements ResizeObserver {
     observe() {}

--- a/docs/.docs-manifest.json
+++ b/docs/.docs-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-11T11:45:00Z",
+  "generated_at": "2026-04-12T00:00:00Z",
   "visual_richness": "tiny",
   "sections": [
     {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -338,6 +338,13 @@ DB audit endpoints:
 
 The persisted execution-plan feature is controlled per connection through `dbSettings.persistExecutionPlan`. When enabled for a supported SQL protocol, the plan is stored in the DB audit log and remains visible after the session closes.
 
+Connection-level DB controls also live under `dbSettings`:
+
+- `firewallEnabled`, `maskingEnabled`, and `rateLimitEnabled` decide whether firewall, masking, and query rate limiting are active at all for that connection.
+- `firewallPolicyMode`, `maskingPolicyMode`, and `rateLimitPolicyMode` choose whether the connection inherits tenant defaults, merges local policies with tenant-wide policies, or uses connection-only policy sets.
+- `firewallRules`, `maskingPolicies`, and `rateLimitPolicies` hold full connection-scoped policy objects so the DB proxy can enforce per-connection overrides instead of only tenant-wide rules.
+- `aiQueryGenerationEnabled`, `aiQueryGenerationBackend`, `aiQueryGenerationModel`, `aiQueryOptimizerEnabled`, `aiQueryOptimizerBackend`, and `aiQueryOptimizerModel` let a database connection override the tenant AI defaults for generation and optimization.
+
 ## ⚙️ Gateways, Recordings, Admin, AI, And Misc Operations
 
 Operational domains under `routes_operations.go` include:
@@ -345,7 +352,7 @@ Operational domains under `routes_operations.go` include:
 | Path prefix | Purpose |
 |-------------|---------|
 | `/api/admin/*` | Email status, app config, and system settings |
-| `/api/ai/*` | AI provider config, SQL generation, and optimization |
+| `/api/ai/*` | Named AI backend config, per-feature defaults, SQL generation, and optimization |
 | `/api/access-policies` | Access policy CRUD |
 | `/api/keystroke-policies` | Keystroke policy CRUD |
 | `/api/gateways` | Gateway CRUD, tunnel overview, templates, scaling, deploy, and tunnel controls |

--- a/docs/api/connections.md
+++ b/docs/api/connections.md
@@ -17,7 +17,23 @@ List all connections (own + shared + team).
 
 Create a new connection.
 
-**Body**: `{ name, type, host, port, username?, password?, domain?, folderId?, teamId?, description?, sshTerminalConfig?, rdpSettings?, vncSettings?, gatewayId?, enableDrive?, defaultCredentialMode?, credentialSecretId? }`
+**Body**: `{ name, type, host, port, username?, password?, domain?, folderId?, teamId?, description?, sshTerminalConfig?, rdpSettings?, vncSettings?, dbSettings?, gatewayId?, enableDrive?, defaultCredentialMode?, credentialSecretId? }`
+
+For `DATABASE` connections, `dbSettings` now carries both transport options and per-connection enforcement/AI overrides. Common fields include:
+
+- `protocol`, `databaseName`, `cloudProvider`, `sslMode`, `persistExecutionPlan`
+- `firewallEnabled`, `maskingEnabled`, `rateLimitEnabled`
+- `firewallPolicyMode`, `maskingPolicyMode`, `rateLimitPolicyMode`
+- `firewallRules[]`, `maskingPolicies[]`, `rateLimitPolicies[]`
+- `aiQueryGenerationEnabled`, `aiQueryGenerationBackend`, `aiQueryGenerationModel`
+- `aiQueryOptimizerEnabled`, `aiQueryOptimizerBackend`, `aiQueryOptimizerModel`
+- protocol-specific fields such as `oracleConnectionType`, `oracleServiceName`, `mssqlAuthMode`, and `db2DatabaseAlias`
+
+The policy mode fields accept:
+
+- `inherit`: use only the tenant-wide firewall, masking, or rate-limit policies
+- `merge`: evaluate connection-specific policies before the tenant-wide policies
+- `override`: use only the connection-specific policies for that category
 
 ### `GET /api/connections/:id`
 
@@ -26,6 +42,8 @@ Get a single connection.
 ### `PUT /api/connections/:id`
 
 Update a connection.
+
+`dbSettings` follows the same shape as `POST /api/connections`.
 
 ### `DELETE /api/connections/:id`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -222,8 +222,9 @@ Important design details:
   - `POST /v1/schema:fetch`
   - `POST /v1/query-plans:explain`
   - `POST /v1/introspection:run`
-- The control plane applies masking, firewall, rate-limit, and audit logic after the DB proxy returns data.
+- The control plane applies masking, firewall, rate-limit, and audit logic after the DB proxy returns data, and each connection can now both enable or disable those controls and supply full connection-scoped policy objects through `dbSettings.firewall*`, `dbSettings.masking*`, and `dbSettings.rateLimit*`.
 - Persisted execution plans are opt-in per connection via `dbSettings.persistExecutionPlan`.
+- AI query generation and AI query optimization resolve from tenant-scoped named backends, then apply any per-connection overrides from `dbSettings.aiQueryGeneration*` and `dbSettings.aiQueryOptimizer*`.
 
 Supported interactive query protocols come from `backend/internal/queryrunner/protocols.go`:
 

--- a/docs/components/api-layer.md
+++ b/docs/components/api-layer.md
@@ -10,7 +10,7 @@
 | `client.ts` | Axios instance with JWT interceptor and auto-refresh |
 | `accessPolicy.api.ts` | ABAC access policy CRUD and evaluation |
 | `admin.api.ts` | Admin config (email status, self-signup, system settings) |
-| `aiQuery.api.ts` | AI-powered natural-language-to-SQL generation and query optimization |
+| `aiQuery.api.ts` | Named AI backend config, feature defaults, natural-language-to-SQL generation, and query optimization |
 | `audit.api.ts` | Personal, tenant, and connection audit logs, geo data, geo summary |
 | `auth.api.ts` | Passkey-first login, password fallback, MFA flows, refresh, logout, public config |
 | `checkout.api.ts` | Credential checkout/check-in with approval workflow |

--- a/docs/components/ui-components.md
+++ b/docs/components/ui-components.md
@@ -150,11 +150,11 @@ All full-screen dialogs use the MUI `Dialog` component with `fullScreen` prop an
 
 | Component | Purpose |
 |-----------|---------|
-| `DbEditor` | Monaco-based database editor with AI-assisted query generation plus protocol-aware SQL and Mongo query templates |
+| `DbEditor` | Monaco-based database editor with protocol-aware SQL and Mongo query templates plus connection-aware AI query generation controls |
 | `DbSchemaBrowser` | Protocol-aware schema browser that adapts labels, hierarchy, and context-menu actions to SQL and Mongo-style databases |
 | `DbResultsTable` | Paginated query results table with sorting, column resizing, and export |
-| `QueryVisualizer` | Execution plan tree visualization with node cost analysis |
-| `AiQueryOptimizer` | Natural-language-to-SQL conversion panel with AI-powered query optimization |
+| `QueryVisualizer` | Execution plan tree visualization with node cost analysis and connection-aware AI optimization entry points |
+| `AiQueryOptimizer` | Multi-turn AI query optimization flow that respects per-connection optimizer enablement and backend/model defaults |
 | `DbQueryHistory` | Per-session query execution history with replay and timing |
 | `DbConnectionStatus` | Database connection health indicator and protocol info |
 | `DbSessionConfigPopover` | Session configuration popover (schema, search path, read-only mode) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,6 +290,13 @@ That nginx config accepts both `localhost` and `arsenale.home.arpa.viti`. For We
 | `AI_QUERY_GENERATION_MODEL` | Override model for query generation |
 | `AI_MAX_REQUESTS_PER_DAY` | Tenant daily request limit (default: 100) |
 
+Runtime precedence:
+
+- `/api/ai/config` stores tenant-scoped named AI backends plus separate defaults for query generation and query optimization.
+- Database connections can further override those defaults with `dbSettings.aiQueryGeneration*` and `dbSettings.aiQueryOptimizer*`.
+- Database audit controls keep tenant-wide defaults in Settings, but each connection can now choose `inherit`, `merge`, or `override` for firewall rules, masking policies, and query rate limits through `dbSettings.firewallPolicyMode`, `dbSettings.maskingPolicyMode`, `dbSettings.rateLimitPolicyMode`, and the matching local policy arrays.
+- The `AI_*` environment variables remain the fallback execution path when a tenant has not configured named AI backends yet.
+
 ## 📌 Precedence And Gotchas
 
 - The repo uses a single root `.env`; do not create service-local `.env` files.

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -146,7 +146,7 @@ Highest-value public prefixes:
 - `/api/recordings` — recording list, stream, analyze, video export, audit trail
 - `/api/tenants` — tenant CRUD, users, invite, permissions, IP allowlist, MFA stats
 - `/api/admin` — email status, app config, system settings, auth providers
-- `/api/ai` — AI config, natural-language-to-SQL generation, query optimization
+- `/api/ai` — named AI backend config, per-feature defaults, natural-language-to-SQL generation, query optimization
 - `/api/audit` — audit log search, geo summary, connection/tenant audit
 - `/api/notifications` — notification list, preferences, read state
 - `/api/access-policies` — access policy CRUD

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,10 +99,11 @@ make logs SVC=arsenale-dev-tunnel-db-proxy
 
 | Symptom | Likely cause | Action |
 |---------|--------------|--------|
-| AI tab missing in database UI | `agenticAIEnabled` is off or no tenant/env AI provider is configured | Set `FEATURE_AGENTIC_AI_ENABLED=true` and configure `/api/ai/config` or the `AI_*` env vars |
+| AI tab missing in database UI | AI query generation is disabled globally or the connection has `dbSettings.aiQueryGenerationEnabled=false` | Enable generation in `/api/ai/config`, verify a named backend exists, or remove the connection-level override |
 | "Query generation failed" error | Provider API error, model unavailable, or `control-plane-api` lacks outbound DNS/egress | Check tenant AI settings, `AI_API_KEY`, `AI_BASE_URL`, model name, and `arsenale-control-plane-api` connectivity |
 | Daily limit reached | Tenant hit `AI_MAX_REQUESTS_PER_DAY` | Wait for reset or increase the limit |
 | Ollama connection refused | Ollama service not running or wrong URL | Verify `AI_BASE_URL` points to the correct Ollama endpoint |
+| AI optimizer button missing | Query optimizer disabled globally or the connection has `dbSettings.aiQueryOptimizerEnabled=false` | Enable the optimizer in `/api/ai/config` or clear the connection-level disable flag |
 
 ## 🔑 Credential Checkout And Policy Issues
 

--- a/tools/arsenale-cli/cmd/ai.go
+++ b/tools/arsenale-cli/cmd/ai.go
@@ -55,9 +55,14 @@ func runAiConfigGet(cmd *cobra.Command, args []string) {
 	}
 	checkAPIError(status, body)
 	printer().PrintSingle(body, []Column{
-		{Header: "PROVIDER", Field: "provider"},
-		{Header: "MODEL", Field: "modelId"},
-		{Header: "ENABLED", Field: "enabled"},
+		{Header: "GEN_ENABLED", Field: "enabled"},
+		{Header: "GEN_BACKEND", Field: "queryGeneration.backend"},
+		{Header: "GEN_MODEL", Field: "modelId"},
+		{Header: "OPT_ENABLED", Field: "queryOptimizer.enabled"},
+		{Header: "OPT_BACKEND", Field: "queryOptimizer.backend"},
+		{Header: "OPT_MODEL", Field: "queryOptimizer.modelId"},
+		{Header: "TEMP", Field: "temperature"},
+		{Header: "TIMEOUT_MS", Field: "timeoutMs"},
 	})
 }
 


### PR DESCRIPTION
## What changed
- added named AI backend configuration with per-backend host and API key settings, plus backend/model selection for query generation and optimizer flows
- moved DB firewall, masking, and rate-limit settings to full per-connection overrideable configurations and wired the runtime/gateway paths to honor them connection by connection
- updated the web UI so connection-level and global DB policy management use searchable preset selectors and shadcn table-based list management instead of cards
- updated the CLI and docs for the new API/configuration shape

## Why
The previous setup only exposed toggle-style connection controls and card-based management in the UI, which was not flexible enough for real tenant and per-connection policy management. This change lets tenants keep global defaults while overriding policy sets and AI behavior per database connection.

## Impact
- database connections can inherit, merge, or override global DB firewall, masking, and rate-limit policies
- AI query generation and optimizer settings can be enabled per connection and tied to configured named backends
- global Governance settings and connection dialogs now manage policy items in searchable, tabular UIs

## Validation
- `npx eslint client/src/components/shared/PolicyTable.tsx client/src/components/Dialogs/ConnectionDialogPolicyTable.tsx client/src/components/Settings/DbFirewallSection.tsx client/src/components/Settings/DbMaskingSection.tsx client/src/components/Settings/DbRateLimitSection.tsx client/src/components/Settings/DbFirewallSection.test.tsx client/src/components/Settings/DbMaskingSection.test.tsx client/src/components/Settings/DbRateLimitSection.test.tsx`
- `npm run test -w client -- src/components/Settings/DbFirewallSection.test.tsx src/components/Settings/DbMaskingSection.test.tsx src/components/Settings/DbRateLimitSection.test.tsx`
- `npm run typecheck -w client`
- `make dev client`
- Selenium/WebDriver smoke on `https://localhost:3000` covering `Settings -> Governance`, searchable preset selection, and create/delete verification for firewall, masking, and rate-limit rows
- `./build/go/arsenale-cli --server https://localhost:3000 health`
- `./build/go/arsenale-cli --server https://localhost:3000 whoami`
- `npm run verify` still fails on the pre-existing repository-wide lint backlog unrelated to this change set
