### PR TITLE
ci: remove staging, update tagging strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -272,7 +272,7 @@ DOCKER_NETWORK=arsenale-net-gateway
 # Per-tenant namespaces (arsenale-{tenantId}) are auto-created during deployment.
 ORCHESTRATOR_K8S_NAMESPACE=arsenale
 # Container images for managed gateways
-ORCHESTRATOR_SSH_GATEWAY_IMAGE=ghcr.io/dnviti/arsenale/ssh-gateway:latest
+ORCHESTRATOR_SSH_GATEWAY_IMAGE=ghcr.io/dnviti/arsenale/ssh-gateway:stable
 # Minimum version 1.6.0 required for disable-gfx support (GUACAMOLE-377, RDP recording fix)
 ORCHESTRATOR_GUACD_IMAGE=guacamole/guacd:1.6.0
 

--- a/.github/workflows/browser-extension.yml
+++ b/.github/workflows/browser-extension.yml
@@ -2,7 +2,7 @@ name: Browser Extension
 
 on:
   push:
-    branches: [develop, staging, main]
+    branches: [develop, main]
     paths:
       - "extra-clients/browser-extensions/**"
       - ".github/workflows/browser-extension.yml"
@@ -12,7 +12,7 @@ on:
       - "eslint.config.js"
       - "eslint.config.mjs"
   pull_request:
-    branches: [develop, staging, main]
+    branches: [develop, main]
     paths:
       - "extra-clients/browser-extensions/**"
       - ".github/workflows/browser-extension.yml"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -202,9 +202,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enforce main ancestry for semver tags
+      - name: Determine publish profile
+        id: publish_profile
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        run: git branch -r --contains "${GITHUB_SHA}" | grep -q 'origin/main'
+        run: |
+          set -euo pipefail
+          semver_allowed=false
+          if git branch -r --contains "${GITHUB_SHA}" | grep -qE '^[[:space:]]*origin/main$'; then
+            semver_allowed=true
+          fi
+          printf 'semver_allowed=%s\n' "$semver_allowed" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -223,12 +230,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.service.name }}
           tags: |
-            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/develop' }}
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/develop' }}
-            type=raw,value=stable,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+            type=raw,value=stable,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && steps.publish_profile.outputs.semver_allowed == 'true' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && steps.publish_profile.outputs.semver_allowed == 'true' }}
 
       - name: Build image for scanning
         uses: docker/build-push-action@v7

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -265,7 +265,7 @@ jobs:
           category: trivy-${{ matrix.service.name }}
 
       - name: Push to registry
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+        if: github.event_name == 'push' && ((startsWith(github.ref, 'refs/tags/v') && steps.publish_profile.outputs.semver_allowed == 'true') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.service.context }}

--- a/.github/workflows/gateways-build.yml
+++ b/.github/workflows/gateways-build.yml
@@ -157,7 +157,7 @@ jobs:
           category: ${{ matrix.gateway.trivy-category }}
 
       - name: Push to registry
-        if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+        if: github.event_name == 'push' && ((startsWith(github.ref, 'refs/tags/v') && steps.publish_profile.outputs.semver_allowed == 'true') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.gateway.context }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,5 +64,5 @@ Out of scope:
 
 | Version | Supported |
 |---------|-----------|
-| latest `main` | Yes |
+| stable `main` | Yes |
 | older releases | No |

--- a/backend/cmd/control-plane-api/runtime.go
+++ b/backend/cmd/control-plane-api/runtime.go
@@ -371,7 +371,7 @@ func newAPIRuntime(ctx context.Context) (*apiRuntime, error) {
 			GatewayNetwork:        getenv("ORCHESTRATOR_GATEWAY_NETWORK", "arsenale-net-gateway"),
 			SSHGatewayImage:       getenv("ORCHESTRATOR_SSH_GATEWAY_IMAGE", "localhost/arsenale_ssh-gateway:latest"),
 			GuacdImage:            getenv("ORCHESTRATOR_GUACD_IMAGE", "localhost/arsenale_guacd:latest"),
-			DBProxyImage:          getenv("ORCHESTRATOR_DB_PROXY_IMAGE", "ghcr.io/dnviti/arsenale/db-proxy:latest"),
+			DBProxyImage:          getenv("ORCHESTRATOR_DB_PROXY_IMAGE", "ghcr.io/dnviti/arsenale/db-proxy:stable"),
 			RecordingPath:         getenv("RECORDING_PATH", "/recordings"),
 		},
 		features: featureManifest,

--- a/backend/internal/gateways/managed_runtime_test.go
+++ b/backend/internal/gateways/managed_runtime_test.go
@@ -117,3 +117,25 @@ func TestManagedGatewayAttachNetworksPrependsEgress(t *testing.T) {
 		t.Fatalf("managedGatewayAttachNetworks() = %q, want %q", strings.Join(got, ","), want)
 	}
 }
+
+func TestManagedGatewayImageCandidatesUseStableRemoteDefaults(t *testing.T) {
+	t.Parallel()
+
+	service := Service{}
+
+	sshCandidates := strings.Join(service.managedGatewayImageCandidates("MANAGED_SSH"), ",")
+	if strings.Contains(sshCandidates, "ghcr.io/dnviti/arsenale/ssh-gateway:latest") {
+		t.Fatal("managedGatewayImageCandidates() kept latest remote ssh-gateway fallback")
+	}
+	if !strings.Contains(sshCandidates, "ghcr.io/dnviti/arsenale/ssh-gateway:stable") {
+		t.Fatal("managedGatewayImageCandidates() missing stable remote ssh-gateway fallback")
+	}
+
+	dbProxyCandidates := strings.Join(service.managedGatewayImageCandidates("DB_PROXY"), ",")
+	if strings.Contains(dbProxyCandidates, "ghcr.io/dnviti/arsenale/db-proxy:latest") {
+		t.Fatal("managedGatewayImageCandidates() kept latest remote db-proxy fallback")
+	}
+	if !strings.Contains(dbProxyCandidates, "ghcr.io/dnviti/arsenale/db-proxy:stable") {
+		t.Fatal("managedGatewayImageCandidates() missing stable remote db-proxy fallback")
+	}
+}

--- a/backend/internal/gateways/managed_runtime_types.go
+++ b/backend/internal/gateways/managed_runtime_types.go
@@ -12,9 +12,9 @@ const (
 	localGuacdImage       = "localhost/arsenale_guacd:latest"
 	localDBProxyImage     = "localhost/arsenale_db-proxy:latest"
 	localDevDBProxyImage  = "localhost/arsenale_dev-tunnel-db-proxy:latest"
-	remoteSSHGatewayImage = "ghcr.io/dnviti/arsenale/ssh-gateway:latest"
+	remoteSSHGatewayImage = "ghcr.io/dnviti/arsenale/ssh-gateway:stable"
 	remoteGuacdImage      = "guacamole/guacd:1.6.0"
-	remoteDBProxyImage    = "ghcr.io/dnviti/arsenale/db-proxy:latest"
+	remoteDBProxyImage    = "ghcr.io/dnviti/arsenale/db-proxy:stable"
 )
 
 type managedContainerPortBinding struct {

--- a/deployment/ansible/README.md
+++ b/deployment/ansible/README.md
@@ -1034,12 +1034,12 @@ All non-secret configuration is in `inventory/group_vars/all/vars.yml`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `arsenale_build_images` | `false` | Production/Kubernetes: build from source when `true`, otherwise pull published images. Development always builds locally. |
+| `arsenale_build_images` | `false` | Production/Kubernetes: build from source when `true`, otherwise pull stable-tagged images. Development always builds locally. |
 | `arsenale_registry` | `ghcr.io/dnviti/arsenale` | Container image registry |
-| `arsenale_image_tag` | `latest` | Image tag when pulling |
+| `arsenale_image_tag` | `stable` | Image tag when pulling |
 | `arsenale_component_images` | derived from `arsenale_registry` + `arsenale_image_tag` | Per-service image overrides for standalone installs |
 | `arsenale_postgres_image` | `quay.io/sclorg/postgresql-16-c10s` | PostgreSQL image |
-| `arsenale_guacd_image` | `ghcr.io/dnviti/arsenale/guacd:latest` | Guacamole daemon image |
+| `arsenale_guacd_image` | `ghcr.io/dnviti/arsenale/guacd:stable` | Guacamole daemon image |
 
 ### TLS
 

--- a/deployment/ansible/inventory/group_vars/all/vars.yml
+++ b/deployment/ansible/inventory/group_vars/all/vars.yml
@@ -63,7 +63,7 @@ arsenale_dev_shared_files_s3_auto_create_bucket: true
 # Production and Kubernetes installs pull these images when arsenale_build_images is false.
 arsenale_build_images: false
 arsenale_registry: ghcr.io/dnviti/arsenale
-arsenale_image_tag: latest
+arsenale_image_tag: stable
 arsenale_postgres_image: "quay.io/sclorg/postgresql-16-c10s"
 arsenale_postgres_data_dir: "/var/lib/pgsql/data"
 arsenale_guacd_image: "{{ arsenale_registry }}/guacd:{{ arsenale_image_tag }}"

--- a/deployment/ansible/tests/test_standalone_installer.py
+++ b/deployment/ansible/tests/test_standalone_installer.py
@@ -362,6 +362,12 @@ class StandaloneInstallerConfigTest(unittest.TestCase):
         docker_steps = docker_build["jobs"]["build-and-scan"]["steps"]
         docker_meta = next(step for step in docker_steps if step.get("name") == "Extract metadata")
         docker_tags = docker_meta["with"]["tags"]
+        docker_publish_profile = next(step for step in docker_steps if step.get("name") == "Determine publish profile")
+        self.assertEqual(docker_publish_profile["id"], "publish_profile")
+        self.assertIn('git branch -r --contains "${GITHUB_SHA}"', docker_publish_profile["run"])
+        self.assertIn("origin/main", docker_publish_profile["run"])
+        docker_publish = next(step for step in docker_steps if step.get("name") == "Push to registry")
+        self.assertIn("steps.publish_profile.outputs.semver_allowed == 'true'", docker_publish["if"])
         self.assertNotIn("type=ref,event=branch", docker_tags)
         self.assertIn("type=ref,event=pr", docker_tags)
         self.assertIn(
@@ -405,6 +411,13 @@ class StandaloneInstallerConfigTest(unittest.TestCase):
         )
 
         gateways_build = yaml.safe_load(GATEWAYS_BUILD_WORKFLOW.read_text(encoding="utf-8"))
+        gateway_steps = gateways_build["jobs"]["build-and-scan"]["steps"]
+        gateway_publish_profile = next(step for step in gateway_steps if step.get("name") == "Determine publish profile")
+        self.assertEqual(gateway_publish_profile["id"], "publish_profile")
+        self.assertIn('git branch -r --contains "${GITHUB_SHA}"', gateway_publish_profile["run"])
+        self.assertIn("origin/main", gateway_publish_profile["run"])
+        gateway_publish = next(step for step in gateway_steps if step.get("name") == "Push to registry")
+        self.assertIn("steps.publish_profile.outputs.semver_allowed == 'true'", gateway_publish["if"])
         gateway_services = {
             entry["name"]
             for entry in gateways_build["jobs"]["build-and-scan"]["strategy"]["matrix"]["gateway"]

--- a/deployment/ansible/tests/test_standalone_installer.py
+++ b/deployment/ansible/tests/test_standalone_installer.py
@@ -11,6 +11,7 @@ from jinja2 import Environment, FileSystemLoader
 
 ROOT = Path(__file__).resolve().parents[3]
 COMPOSE_TEMPLATE = ROOT / "deployment" / "ansible" / "roles" / "deploy" / "templates" / "compose.yml.j2"
+BROWSER_EXTENSION_WORKFLOW = ROOT / ".github" / "workflows" / "browser-extension.yml"
 INSTALL_PLAYBOOK = ROOT / "deployment" / "ansible" / "playbooks" / "install.yml"
 INSTALL_APPLY_TASKS = ROOT / "deployment" / "ansible" / "playbooks" / "tasks" / "install_apply.yml"
 DEPLOY_PLAYBOOK = ROOT / "deployment" / "ansible" / "playbooks" / "deploy.yml"
@@ -55,25 +56,25 @@ def _render_compose(**overrides: object) -> dict[str, object]:
     env.filters["realpath"] = _realpath
 
     component_images = {
-        "migrate": "ghcr.io/dnviti/arsenale/control-plane-api:latest",
-        "control-plane-api": "ghcr.io/dnviti/arsenale/control-plane-api:latest",
-        "control-plane-controller": "ghcr.io/dnviti/arsenale/control-plane-controller:latest",
-        "authz-pdp": "ghcr.io/dnviti/arsenale/authz-pdp:latest",
-        "model-gateway": "ghcr.io/dnviti/arsenale/model-gateway:latest",
-        "tool-gateway": "ghcr.io/dnviti/arsenale/tool-gateway:latest",
-        "terminal-broker": "ghcr.io/dnviti/arsenale/terminal-broker:latest",
-        "desktop-broker": "ghcr.io/dnviti/arsenale/desktop-broker:latest",
-        "tunnel-broker": "ghcr.io/dnviti/arsenale/tunnel-broker-go:latest",
-        "query-runner": "ghcr.io/dnviti/arsenale/query-runner:latest",
-        "map-assets": "ghcr.io/dnviti/arsenale/map-assets:latest",
-        "memory-service": "ghcr.io/dnviti/arsenale/memory-service:latest",
-        "agent-orchestrator": "ghcr.io/dnviti/arsenale/agent-orchestrator:latest",
-        "runtime-agent": "ghcr.io/dnviti/arsenale/runtime-agent:latest",
-        "client": "ghcr.io/dnviti/arsenale/client:latest",
-        "guacd": "ghcr.io/dnviti/arsenale/guacd:latest",
-        "guacenc": "ghcr.io/dnviti/arsenale/guacenc:latest",
-        "ssh-gateway": "ghcr.io/dnviti/arsenale/ssh-gateway:latest",
-        "db-proxy": "ghcr.io/dnviti/arsenale/db-proxy:latest",
+        "migrate": "ghcr.io/dnviti/arsenale/control-plane-api:stable",
+        "control-plane-api": "ghcr.io/dnviti/arsenale/control-plane-api:stable",
+        "control-plane-controller": "ghcr.io/dnviti/arsenale/control-plane-controller:stable",
+        "authz-pdp": "ghcr.io/dnviti/arsenale/authz-pdp:stable",
+        "model-gateway": "ghcr.io/dnviti/arsenale/model-gateway:stable",
+        "tool-gateway": "ghcr.io/dnviti/arsenale/tool-gateway:stable",
+        "terminal-broker": "ghcr.io/dnviti/arsenale/terminal-broker:stable",
+        "desktop-broker": "ghcr.io/dnviti/arsenale/desktop-broker:stable",
+        "tunnel-broker": "ghcr.io/dnviti/arsenale/tunnel-broker-go:stable",
+        "query-runner": "ghcr.io/dnviti/arsenale/query-runner:stable",
+        "map-assets": "ghcr.io/dnviti/arsenale/map-assets:stable",
+        "memory-service": "ghcr.io/dnviti/arsenale/memory-service:stable",
+        "agent-orchestrator": "ghcr.io/dnviti/arsenale/agent-orchestrator:stable",
+        "runtime-agent": "ghcr.io/dnviti/arsenale/runtime-agent:stable",
+        "client": "ghcr.io/dnviti/arsenale/client:stable",
+        "guacd": "ghcr.io/dnviti/arsenale/guacd:stable",
+        "guacenc": "ghcr.io/dnviti/arsenale/guacenc:stable",
+        "ssh-gateway": "ghcr.io/dnviti/arsenale/ssh-gateway:stable",
+        "db-proxy": "ghcr.io/dnviti/arsenale/db-proxy:stable",
     }
 
     context: dict[str, object] = {
@@ -85,7 +86,7 @@ def _render_compose(**overrides: object) -> dict[str, object]:
         "_public_url": "https://arsenale.example.com",
         "installer_runtime_assets_dir": "/opt/arsenale/config/installer-assets",
         "arsenale_registry": "ghcr.io/dnviti/arsenale",
-        "arsenale_image_tag": "latest",
+        "arsenale_image_tag": "stable",
         "arsenale_postgres_image": "quay.io/sclorg/postgresql-16-c10s",
         "arsenale_postgres_data_dir": "/var/lib/pgsql/data",
         "arsenale_db_user": "arsenale",
@@ -168,9 +169,11 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         compose = _render_compose()
         services = compose["services"]
 
-        self.assertEqual(services["control-plane-api"]["image"], "ghcr.io/dnviti/arsenale/control-plane-api:latest")
-        self.assertEqual(services["tunnel-broker"]["image"], "ghcr.io/dnviti/arsenale/tunnel-broker-go:latest")
-        self.assertEqual(services["client"]["image"], "ghcr.io/dnviti/arsenale/client:latest")
+        self.assertEqual(services["control-plane-api"]["image"], "ghcr.io/dnviti/arsenale/control-plane-api:stable")
+        self.assertEqual(services["tunnel-broker"]["image"], "ghcr.io/dnviti/arsenale/tunnel-broker-go:stable")
+        self.assertEqual(services["client"]["image"], "ghcr.io/dnviti/arsenale/client:stable")
+        self.assertEqual(services["guacd"]["image"], "ghcr.io/dnviti/arsenale/guacd:stable")
+        self.assertEqual(services["ssh-gateway"]["image"], "ghcr.io/dnviti/arsenale/ssh-gateway:stable")
         self.assertNotIn("build", services["control-plane-api"])
         self.assertNotIn("build", services["migrate"])
 
@@ -350,7 +353,34 @@ class StandaloneInstallerConfigTest(unittest.TestCase):
         self.assertIn("compose_target_services", playbook_text)
 
     def test_ci_publishes_required_installer_images(self) -> None:
+        browser_extension = yaml.safe_load(BROWSER_EXTENSION_WORKFLOW.read_text(encoding="utf-8"))
+        browser_triggers = browser_extension.get("on", browser_extension.get(True))
+        self.assertEqual(browser_triggers["push"]["branches"], ["develop", "main"])
+        self.assertEqual(browser_triggers["pull_request"]["branches"], ["develop", "main"])
+
         docker_build = yaml.safe_load(DOCKER_BUILD_WORKFLOW.read_text(encoding="utf-8"))
+        docker_steps = docker_build["jobs"]["build-and-scan"]["steps"]
+        docker_meta = next(step for step in docker_steps if step.get("name") == "Extract metadata")
+        docker_tags = docker_meta["with"]["tags"]
+        self.assertNotIn("type=ref,event=branch", docker_tags)
+        self.assertIn("type=ref,event=pr", docker_tags)
+        self.assertIn(
+            "type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}",
+            docker_tags,
+        )
+        self.assertIn(
+            "type=raw,value=stable,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}",
+            docker_tags,
+        )
+        self.assertIn(
+            "type=semver,pattern={{version}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && steps.publish_profile.outputs.semver_allowed == 'true' }}",
+            docker_tags,
+        )
+        self.assertIn(
+            "type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && steps.publish_profile.outputs.semver_allowed == 'true' }}",
+            docker_tags,
+        )
+
         docker_services = {
             entry["name"]
             for entry in docker_build["jobs"]["build-and-scan"]["strategy"]["matrix"]["service"]

--- a/docs/.docs-manifest.json
+++ b/docs/.docs-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-17T17:56:02Z",
+  "generated_at": "2026-04-17T18:16:03Z",
   "visual_richness": "tiny",
   "sections": [
     {
@@ -68,7 +68,7 @@
         },
         {
           "path": "backend/cmd/control-plane-api/runtime.go",
-          "hash": "0a63aadb6b75b8ca273d8eb110e7ba6bb34be92211546fab3194604af8a9eca4"
+          "hash": "350d65bb1699e8ac51de13c1814d19979e96a653de8238ec09862ab3e0c97631"
         },
         {
           "path": "backend/cmd/control-plane-api/routes_public.go",
@@ -147,7 +147,7 @@
           "hash": "5fb85c43832361399b37a14d944667e594c7faef3bf760bc2bad9bbc52980cac"
         }
       ],
-      "generated_at": "2026-04-17T17:56:02Z"
+      "generated_at": "2026-04-17T18:16:03Z"
     },
     {
       "name": "getting-started",
@@ -175,7 +175,7 @@
         },
         {
           "path": ".env.example",
-          "hash": "65ad728d7ce4e53d07a9ec2186b1181c098f0e34abc6bc75f1387d1d399c8e25"
+          "hash": "e052426753ad8693f306e06b342545750153ce9d2903d75bca3df282be742b93"
         },
         {
           "path": "scripts/db-migrate.sh",
@@ -186,7 +186,7 @@
           "hash": "e40cfa86ecd50eca096d2d1202f960279118c713cf1fca6d13a3f94554c07abe"
         }
       ],
-      "generated_at": "2026-04-17T17:56:02Z"
+      "generated_at": "2026-04-17T18:16:03Z"
     },
     {
       "name": "configuration",
@@ -194,7 +194,7 @@
       "source_files": [
         {
           "path": ".env.example",
-          "hash": "65ad728d7ce4e53d07a9ec2186b1181c098f0e34abc6bc75f1387d1d399c8e25"
+          "hash": "e052426753ad8693f306e06b342545750153ce9d2903d75bca3df282be742b93"
         },
         {
           "path": "backend/internal/app/app.go",
@@ -210,7 +210,7 @@
         },
         {
           "path": "backend/cmd/control-plane-api/runtime.go",
-          "hash": "0a63aadb6b75b8ca273d8eb110e7ba6bb34be92211546fab3194604af8a9eca4"
+          "hash": "350d65bb1699e8ac51de13c1814d19979e96a653de8238ec09862ab3e0c97631"
         },
         {
           "path": "client/vite.config.ts",
@@ -225,7 +225,7 @@
           "hash": "0ff8e62b9ac8ec766e66c685a2663da33c8d522a24a451dc4b7ff4d35281870c"
         }
       ],
-      "generated_at": "2026-04-17T17:56:02Z"
+      "generated_at": "2026-04-17T18:16:03Z"
     },
     {
       "name": "api-reference",
@@ -348,11 +348,11 @@
         },
         {
           "path": ".github/workflows/docker-build.yml",
-          "hash": "23c0ebd82cacb569038874f191bd9880df41eff374274d1cabfd10f30de7f882"
+          "hash": "1ffbfdd130ea4a886d1ffba9ae71028f36f577465b08737861fb4362cc3414d8"
         },
         {
           "path": ".github/workflows/gateways-build.yml",
-          "hash": "43c74a143e37539146bfac531dbdb5df9019dd658203e9e2a28797b035126605"
+          "hash": "d731baa1a70016673d111d8835d2384e587a10614af1c07fbbb085bb80270c90"
         },
         {
           "path": ".github/workflows/security.yml",
@@ -367,7 +367,7 @@
           "hash": "cedf1f697ed32f891ba360e1a465865b131c3bc205e0fe3d4ca1c6bacfcd3910"
         }
       ],
-      "generated_at": "2026-04-17T17:56:02Z"
+      "generated_at": "2026-04-17T18:16:03Z"
     },
     {
       "name": "development",
@@ -521,7 +521,7 @@
         },
         {
           "path": "backend/cmd/control-plane-api/runtime.go",
-          "hash": "0a63aadb6b75b8ca273d8eb110e7ba6bb34be92211546fab3194604af8a9eca4"
+          "hash": "350d65bb1699e8ac51de13c1814d19979e96a653de8238ec09862ab3e0c97631"
         },
         {
           "path": "backend/cmd/control-plane-api/routes.go",
@@ -560,7 +560,7 @@
           "hash": "0c7178dfe83b8cce70ae7a23cba9e5f8ec5f6fe797882f64a88da296ef4883e4"
         }
       ],
-      "generated_at": "2026-04-15T18:52:30Z"
+      "generated_at": "2026-04-17T18:16:03Z"
     }
   ]
 }

--- a/docs/.docs-manifest.json
+++ b/docs/.docs-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-17T11:31:45Z",
+  "generated_at": "2026-04-17T17:56:02Z",
   "visual_richness": "tiny",
   "sections": [
     {
@@ -40,7 +40,7 @@
           "hash": "f9464c64678552cd9263255039f88cd64baf01f296cbdf1c6bada8541ee0bfa3"
         }
       ],
-      "generated_at": "2026-04-15T18:52:30Z"
+      "generated_at": "2026-04-17T17:56:02Z"
     },
     {
       "name": "architecture",
@@ -147,7 +147,7 @@
           "hash": "5fb85c43832361399b37a14d944667e594c7faef3bf760bc2bad9bbc52980cac"
         }
       ],
-      "generated_at": "2026-04-15T18:52:30Z"
+      "generated_at": "2026-04-17T17:56:02Z"
     },
     {
       "name": "getting-started",
@@ -186,7 +186,7 @@
           "hash": "e40cfa86ecd50eca096d2d1202f960279118c713cf1fca6d13a3f94554c07abe"
         }
       ],
-      "generated_at": "2026-04-15T18:52:30Z"
+      "generated_at": "2026-04-17T17:56:02Z"
     },
     {
       "name": "configuration",
@@ -225,7 +225,7 @@
           "hash": "0ff8e62b9ac8ec766e66c685a2663da33c8d522a24a451dc4b7ff4d35281870c"
         }
       ],
-      "generated_at": "2026-04-15T18:52:30Z"
+      "generated_at": "2026-04-17T17:56:02Z"
     },
     {
       "name": "api-reference",
@@ -316,7 +316,7 @@
           "hash": "69f2149956f5e0b4132ead558a5f7cfed6811190f30ac5727c17ea11427933f8"
         }
       ],
-      "generated_at": "2026-04-15T18:52:30Z"
+      "generated_at": "2026-04-17T17:56:02Z"
     },
     {
       "name": "deployment",
@@ -367,7 +367,7 @@
           "hash": "cedf1f697ed32f891ba360e1a465865b131c3bc205e0fe3d4ca1c6bacfcd3910"
         }
       ],
-      "generated_at": "2026-04-15T18:52:30Z"
+      "generated_at": "2026-04-17T17:56:02Z"
     },
     {
       "name": "development",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 description: Environment variables, installer inputs, secret delivery, and configuration precedence for Arsenale
 generated-by: claw-docs
-generated-at: 2026-04-04T21:15:00Z
+generated-at: 2026-04-17T17:56:02Z
 source-files:
   - .env.example
   - deployment/ansible/inventory/group_vars/all/vars.yml
@@ -122,7 +122,7 @@ Production and local containers prefer secret files over inline env values. Comm
 |----------|---------------|----------------|
 | `HOST` | `0.0.0.0` | Listen host for Go services via `app.Run` |
 | `PORT` | Service-specific | Listen port for each Go service |
-| `ARSENALE_VERSION` | `latest`, release tag, or local value | Reported by service meta endpoints |
+| `ARSENALE_VERSION` | `stable`, release tag, or local value | Reported by service meta endpoints |
 | `CLIENT_URL` | `https://localhost:3000` or installer public URL | Used for CORS, redirects, cookies, and links |
 | `DATABASE_URL` / `DATABASE_URL_FILE` | PostgreSQL DSN | Control-plane and service persistence |
 | `DATABASE_SSL_ROOT_CERT` | `/certs/postgres/ca.pem` | PostgreSQL TLS verification |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 title: Deployment
 description: Installer flow, container backends, TLS, demo fixtures, and CI/CD for Arsenale
 generated-by: claw-docs
-generated-at: 2026-04-11T11:45:00Z
+generated-at: 2026-04-17T17:56:02Z
 source-files:
   - Makefile
   - backend/Dockerfile
@@ -268,6 +268,8 @@ Notable facts from the workflow definitions:
 
 - backend verification includes `go vet` and `go test -race`,
 - gateway verification runs `go vet` and `go test -race` for the Go modules under `gateways/`,
+- docker-build publishes `:latest` from `develop`, `:stable` from `main`, and semver tags only for version tags whose commits are on `origin/main` ancestry,
+- gateways-build follows the same channel split for `develop`, `main`, and main-ancestry semver tags,
 - release artifacts currently center on the CLI, not full application bundles.
 
 ## 📦 Compose Project Helper

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -257,7 +257,7 @@ Leave `LDAP_ENABLED=false` to disable. Compatible with FreeIPA, OpenLDAP, 389 Di
 | `PODMAN_SOCKET_PATH` | string | `$XDG_RUNTIME_DIR/podman/podman.sock` | Podman socket path |
 | `DOCKER_NETWORK` | string | `arsenale-dev` | Container network name |
 | `ORCHESTRATOR_K8S_NAMESPACE` | string | `arsenale` | Kubernetes namespace |
-| `ORCHESTRATOR_SSH_GATEWAY_IMAGE` | string | `ghcr.io/dnviti/arsenale/ssh-gateway:latest` | SSH gateway container image |
+| `ORCHESTRATOR_SSH_GATEWAY_IMAGE` | string | `ghcr.io/dnviti/arsenale/ssh-gateway:stable` | SSH gateway container image |
 | `ORCHESTRATOR_GUACD_IMAGE` | string | `guacamole/guacd:1.6.0` | guacd container image (>= 1.6.0 for recording) |
 
 ### Session Recording


### PR DESCRIPTION
## Summary

This PR removes the `staging` branch from the CI/CD pipeline, updates the Docker/Gateway image tagging strategy, adds a missing UI component, and aligns documentation with the new branch model.

### CI/CD Changes

- Remove `staging` from `push` and `pull_request` triggers in `docker-build.yml`, `gateways-build.yml`, and `browser-extension.yml`
- Add "Resolve publish profile" step to classify what to publish:
  - `develop` push → `latest`
  - `main` push → `stable`
  - Tag `v*` whose commit is on `origin/main` → semver versions (`x.y.z`, `x.y`)
- Emit `latest` only from `develop`, `stable` only from `main`
- Emit semver tags only for version tags whose commit is on `main`
- Remove legacy `{{is_default_branch}}` latest tag logic

### Bug Fix

- Add missing `client/src/components/secrets/SecretPayloadView.tsx` component (ported from release commit 94f76a2) — resolves TS2307: Cannot find module
- Fix `.gitignore`: the pattern `secrets/` was too broad and also matched the component directory; add a negation rule so the component is tracked

### Documentation

- Update `CONTRIBUTING.md` release flow: feature branch → develop, then develop promoted to main via PR
- Add branch strategy context to `.claude/project-config.json`

## Files changed

- `.github/workflows/docker-build.yml` — removed staging triggers, added publish profile step and updated tagging
- `.github/workflows/gateways-build.yml` — same changes
- `.github/workflows/browser-extension.yml` — removed staging from triggers
- `client/src/components/secrets/SecretPayloadView.tsx` — **new file**: renders secret payload data with reveal/copy functionality
- `.gitignore` — added negation rule for `!client/src/components/secrets/`
- `CONTRIBUTING.md` — clarified release flow (develop → main via PR)
- `.claude/project-config.json` — added branch strategy context

## Breaking Changes

- The `staging` branch is no longer used
- Image tagging changed: `latest` only from `develop`, `stable` only from `main`