### PR TITLE
fix(release): canonical tunnel broker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -169,7 +169,7 @@ jobs:
             context: .
             build_args: |
               SERVICE=desktop-broker
-          - name: tunnel-broker-go
+          - name: tunnel-broker
             dockerfile: ./backend/Dockerfile
             context: .
             build_args: |

--- a/backend/internal/tunnelbroker/broker_types.go
+++ b/backend/internal/tunnelbroker/broker_types.go
@@ -109,7 +109,7 @@ func NewBroker(config BrokerConfig) *Broker {
 	if strings.TrimSpace(config.ProxyAdvertiseHost) == "" {
 		config.ProxyAdvertiseHost = strings.TrimSpace(os.Getenv("HOSTNAME"))
 		if config.ProxyAdvertiseHost == "" {
-			config.ProxyAdvertiseHost = "tunnel-broker-go"
+			config.ProxyAdvertiseHost = "tunnel-broker"
 		}
 	}
 

--- a/backend/internal/tunnelbroker/broker_types_test.go
+++ b/backend/internal/tunnelbroker/broker_types_test.go
@@ -1,0 +1,13 @@
+package tunnelbroker
+
+import "testing"
+
+func TestNewBrokerDefaultsProxyAdvertiseHostToCanonicalServiceName(t *testing.T) {
+	t.Setenv("HOSTNAME", "")
+
+	broker := NewBroker(BrokerConfig{})
+
+	if broker.config.ProxyAdvertiseHost != "tunnel-broker" {
+		t.Fatalf("ProxyAdvertiseHost = %q, want tunnel-broker", broker.config.ProxyAdvertiseHost)
+	}
+}

--- a/deployment/ansible/README.md
+++ b/deployment/ansible/README.md
@@ -1034,9 +1034,9 @@ All non-secret configuration is in `inventory/group_vars/all/vars.yml`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `arsenale_build_images` | `false` | Production/Kubernetes: build from source when `true`, otherwise pull stable-tagged images. Development always builds locally. |
+| `arsenale_build_images` | `false` | Production/Kubernetes: build from source when `true`, otherwise pull images tagged by `arsenale_image_tag`. Development always builds locally. |
 | `arsenale_registry` | `ghcr.io/dnviti/arsenale` | Container image registry |
-| `arsenale_image_tag` | `stable` | Image tag when pulling |
+| `arsenale_image_tag` | `stable` | Image tag when pulling; set to a release tag such as `1.8.0` for pinned installs |
 | `arsenale_component_images` | derived from `arsenale_registry` + `arsenale_image_tag` | Per-service image overrides for standalone installs |
 | `arsenale_postgres_image` | `quay.io/sclorg/postgresql-16-c10s` | PostgreSQL image |
 | `arsenale_guacd_image` | `ghcr.io/dnviti/arsenale/guacd:stable` | Guacamole daemon image |

--- a/deployment/ansible/inventory/group_vars/all/vars.yml
+++ b/deployment/ansible/inventory/group_vars/all/vars.yml
@@ -76,7 +76,7 @@ arsenale_component_images:
   tool-gateway: "{{ arsenale_registry }}/tool-gateway:{{ arsenale_image_tag }}"
   terminal-broker: "{{ arsenale_registry }}/terminal-broker:{{ arsenale_image_tag }}"
   desktop-broker: "{{ arsenale_registry }}/desktop-broker:{{ arsenale_image_tag }}"
-  tunnel-broker: "{{ arsenale_registry }}/tunnel-broker-go:{{ arsenale_image_tag }}"
+  tunnel-broker: "{{ arsenale_registry }}/tunnel-broker:{{ arsenale_image_tag }}"
   query-runner: "{{ arsenale_registry }}/query-runner:{{ arsenale_image_tag }}"
   map-assets: "{{ arsenale_registry }}/map-assets:{{ arsenale_image_tag }}"
   memory-service: "{{ arsenale_registry }}/memory-service:{{ arsenale_image_tag }}"

--- a/deployment/ansible/tests/test_standalone_installer.py
+++ b/deployment/ansible/tests/test_standalone_installer.py
@@ -55,26 +55,28 @@ def _render_compose(**overrides: object) -> dict[str, object]:
     env.filters["basename"] = _basename
     env.filters["realpath"] = _realpath
 
+    image_tag = str(overrides.get("arsenale_image_tag", "stable"))
+    registry = str(overrides.get("arsenale_registry", "ghcr.io/dnviti/arsenale"))
     component_images = {
-        "migrate": "ghcr.io/dnviti/arsenale/control-plane-api:stable",
-        "control-plane-api": "ghcr.io/dnviti/arsenale/control-plane-api:stable",
-        "control-plane-controller": "ghcr.io/dnviti/arsenale/control-plane-controller:stable",
-        "authz-pdp": "ghcr.io/dnviti/arsenale/authz-pdp:stable",
-        "model-gateway": "ghcr.io/dnviti/arsenale/model-gateway:stable",
-        "tool-gateway": "ghcr.io/dnviti/arsenale/tool-gateway:stable",
-        "terminal-broker": "ghcr.io/dnviti/arsenale/terminal-broker:stable",
-        "desktop-broker": "ghcr.io/dnviti/arsenale/desktop-broker:stable",
-        "tunnel-broker": "ghcr.io/dnviti/arsenale/tunnel-broker-go:stable",
-        "query-runner": "ghcr.io/dnviti/arsenale/query-runner:stable",
-        "map-assets": "ghcr.io/dnviti/arsenale/map-assets:stable",
-        "memory-service": "ghcr.io/dnviti/arsenale/memory-service:stable",
-        "agent-orchestrator": "ghcr.io/dnviti/arsenale/agent-orchestrator:stable",
-        "runtime-agent": "ghcr.io/dnviti/arsenale/runtime-agent:stable",
-        "client": "ghcr.io/dnviti/arsenale/client:stable",
-        "guacd": "ghcr.io/dnviti/arsenale/guacd:stable",
-        "guacenc": "ghcr.io/dnviti/arsenale/guacenc:stable",
-        "ssh-gateway": "ghcr.io/dnviti/arsenale/ssh-gateway:stable",
-        "db-proxy": "ghcr.io/dnviti/arsenale/db-proxy:stable",
+        "migrate": f"{registry}/control-plane-api:{image_tag}",
+        "control-plane-api": f"{registry}/control-plane-api:{image_tag}",
+        "control-plane-controller": f"{registry}/control-plane-controller:{image_tag}",
+        "authz-pdp": f"{registry}/authz-pdp:{image_tag}",
+        "model-gateway": f"{registry}/model-gateway:{image_tag}",
+        "tool-gateway": f"{registry}/tool-gateway:{image_tag}",
+        "terminal-broker": f"{registry}/terminal-broker:{image_tag}",
+        "desktop-broker": f"{registry}/desktop-broker:{image_tag}",
+        "tunnel-broker": f"{registry}/tunnel-broker:{image_tag}",
+        "query-runner": f"{registry}/query-runner:{image_tag}",
+        "map-assets": f"{registry}/map-assets:{image_tag}",
+        "memory-service": f"{registry}/memory-service:{image_tag}",
+        "agent-orchestrator": f"{registry}/agent-orchestrator:{image_tag}",
+        "runtime-agent": f"{registry}/runtime-agent:{image_tag}",
+        "client": f"{registry}/client:{image_tag}",
+        "guacd": f"{registry}/guacd:{image_tag}",
+        "guacenc": f"{registry}/guacenc:{image_tag}",
+        "ssh-gateway": f"{registry}/ssh-gateway:{image_tag}",
+        "db-proxy": f"{registry}/db-proxy:{image_tag}",
     }
 
     context: dict[str, object] = {
@@ -85,8 +87,8 @@ def _render_compose(**overrides: object) -> dict[str, object]:
         "_client_bind_host": "0.0.0.0",
         "_public_url": "https://arsenale.example.com",
         "installer_runtime_assets_dir": "/opt/arsenale/config/installer-assets",
-        "arsenale_registry": "ghcr.io/dnviti/arsenale",
-        "arsenale_image_tag": "stable",
+        "arsenale_registry": registry,
+        "arsenale_image_tag": image_tag,
         "arsenale_postgres_image": "quay.io/sclorg/postgresql-16-c10s",
         "arsenale_postgres_data_dir": "/var/lib/pgsql/data",
         "arsenale_db_user": "arsenale",
@@ -170,7 +172,7 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         services = compose["services"]
 
         self.assertEqual(services["control-plane-api"]["image"], "ghcr.io/dnviti/arsenale/control-plane-api:stable")
-        self.assertEqual(services["tunnel-broker"]["image"], "ghcr.io/dnviti/arsenale/tunnel-broker-go:stable")
+        self.assertEqual(services["tunnel-broker"]["image"], "ghcr.io/dnviti/arsenale/tunnel-broker:stable")
         self.assertEqual(services["client"]["image"], "ghcr.io/dnviti/arsenale/client:stable")
         self.assertEqual(services["guacd"]["image"], "ghcr.io/dnviti/arsenale/guacd:stable")
         self.assertEqual(services["ssh-gateway"]["image"], "ghcr.io/dnviti/arsenale/ssh-gateway:stable")
@@ -190,6 +192,15 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         self.assertIn("net-egress", services["guacd"]["networks"])
         self.assertIn("net-egress", services["ssh-gateway"]["networks"])
         self.assertIn("net-egress", services["query-runner"]["networks"])
+
+    def test_production_compose_honors_pinned_release_image_tag(self) -> None:
+        compose = _render_compose(arsenale_image_tag="1.8.0")
+        services = compose["services"]
+
+        self.assertEqual(services["control-plane-api"]["image"], "ghcr.io/dnviti/arsenale/control-plane-api:1.8.0")
+        self.assertEqual(services["tunnel-broker"]["image"], "ghcr.io/dnviti/arsenale/tunnel-broker:1.8.0")
+        self.assertEqual(services["client"]["image"], "ghcr.io/dnviti/arsenale/client:1.8.0")
+        self.assertEqual(services["guacd"]["image"], "ghcr.io/dnviti/arsenale/guacd:1.8.0")
 
     def test_development_compose_keeps_local_builds(self) -> None:
         compose = _render_compose(
@@ -402,7 +413,7 @@ class StandaloneInstallerConfigTest(unittest.TestCase):
                 "memory-service",
                 "terminal-broker",
                 "desktop-broker",
-                "tunnel-broker-go",
+                "tunnel-broker",
                 "query-runner",
                 "map-assets",
                 "runtime-agent",

--- a/docs/.docs-manifest.json
+++ b/docs/.docs-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-30T23:59:29Z",
+  "generated_at": "2026-05-01T09:31:00Z",
   "visual_richness": "tiny",
   "sections": [
     {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -270,6 +270,7 @@ Notable facts from the workflow definitions:
 - gateway verification runs `go vet` and `go test -race` for the Go modules under `gateways/`,
 - docker-build publishes `:latest` from `develop`, `:stable` from `main`, and semver tags only for version tags whose commits are on `origin/main` ancestry,
 - gateways-build follows the same channel split for `develop`, `main`, and main-ancestry semver tags,
+- the canonical runtime broker image package is `ghcr.io/dnviti/arsenale/tunnel-broker`; refactor-era broker package names are not used by deployment,
 - release artifacts currently center on the CLI, not full application bundles.
 
 ## 📦 Compose Project Helper


### PR DESCRIPTION
## Summary
- publish the tunnel broker backend image as ghcr.io/dnviti/arsenale/tunnel-broker instead of tunnel-broker-go
- update installer defaults and docs to use the canonical image name
- add regression coverage for pinned production image tags and tunnel broker advertise host defaults

## Verification
- python3 -m unittest deployment.ansible.tests.test_standalone_installer
- go test ./backend/internal/tunnelbroker
- npm run verify