### PR TITLE
Fix SSH proxy session-control blockers

### DIFF
--- a/backend/internal/sshproxyapi/channel.go
+++ b/backend/internal/sshproxyapi/channel.go
@@ -15,22 +15,22 @@ const (
 	proxyStreamOutput
 )
 
-func handleProxyChannel(ctx context.Context, newChannel ssh.NewChannel, target *ssh.Client, control *proxySessionControl) {
+func handleProxyChannel(ctx context.Context, newChannel ssh.NewChannel, target *ssh.Client, control *proxySessionControl) bool {
 	if newChannel.ChannelType() != "session" {
 		_ = newChannel.Reject(ssh.UnknownChannelType, "only session channels are supported")
-		return
+		return false
 	}
 
 	channel, requests, err := newChannel.Accept()
 	if err != nil {
-		return
+		return true
 	}
 	defer channel.Close()
 
 	targetSession, err := target.NewSession()
 	if err != nil {
 		_ = channel.Close()
-		return
+		return true
 	}
 	defer targetSession.Close()
 	unregisterActive := control.registerActiveSSH(channel, targetSession)
@@ -38,15 +38,15 @@ func handleProxyChannel(ctx context.Context, newChannel ssh.NewChannel, target *
 
 	stdin, err := targetSession.StdinPipe()
 	if err != nil {
-		return
+		return true
 	}
 	stdout, err := targetSession.StdoutPipe()
 	if err != nil {
-		return
+		return true
 	}
 	stderr, err := targetSession.StderrPipe()
 	if err != nil {
-		return
+		return true
 	}
 
 	go func() {
@@ -90,13 +90,13 @@ func handleProxyChannel(ctx context.Context, newChannel ssh.NewChannel, target *
 				_ = req.Reply(ok, nil)
 			}
 		case "shell":
-			if startedFlag {
+			if proxyStartBlocked(startedFlag, control) {
 				_ = req.Reply(false, nil)
 				continue
 			}
 			startAndWait(targetSession.Shell, req)
 		case "exec":
-			if startedFlag {
+			if proxyStartBlocked(startedFlag, control) {
 				_ = req.Reply(false, nil)
 				continue
 			}
@@ -119,6 +119,11 @@ func handleProxyChannel(ctx context.Context, newChannel ssh.NewChannel, target *
 			}
 		}
 	}
+	return true
+}
+
+func proxyStartBlocked(started bool, control *proxySessionControl) bool {
+	return started || (control != nil && control.isPaused())
 }
 
 func copyProxyStream(ctx context.Context, dst io.Writer, src io.Reader, control *proxySessionControl, kind proxyStreamKind) {

--- a/backend/internal/sshproxyapi/channel_test.go
+++ b/backend/internal/sshproxyapi/channel_test.go
@@ -1,0 +1,65 @@
+package sshproxyapi
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type fakeNewChannel struct {
+	channelType   string
+	rejectReason  ssh.RejectionReason
+	rejectMessage string
+	rejected      bool
+}
+
+func (f *fakeNewChannel) Accept() (ssh.Channel, <-chan *ssh.Request, error) {
+	return nil, nil, nil
+}
+
+func (f *fakeNewChannel) Reject(reason ssh.RejectionReason, message string) error {
+	f.rejected = true
+	f.rejectReason = reason
+	f.rejectMessage = message
+	return nil
+}
+
+func (f *fakeNewChannel) ChannelType() string {
+	return f.channelType
+}
+
+func (f *fakeNewChannel) ExtraData() []byte {
+	return nil
+}
+
+func TestHandleProxyChannelDoesNotFinishTransportForUnsupportedChannel(t *testing.T) {
+	t.Parallel()
+
+	channel := &fakeNewChannel{channelType: "direct-tcpip"}
+	handled := handleProxyChannel(context.Background(), channel, nil, nil)
+
+	if handled {
+		t.Fatal("unsupported channel marked the proxy session as handled")
+	}
+	if !channel.rejected {
+		t.Fatal("unsupported channel was not rejected")
+	}
+	if channel.rejectReason != ssh.UnknownChannelType {
+		t.Fatalf("reject reason = %v; want %v", channel.rejectReason, ssh.UnknownChannelType)
+	}
+}
+
+func TestProxyStartBlockedWhilePaused(t *testing.T) {
+	t.Parallel()
+
+	control := newProxySessionControl(context.Background(), "sess-1", nil, nil)
+	control.setPaused(true)
+
+	if !proxyStartBlocked(false, control) {
+		t.Fatal("start request was allowed while the proxy session was paused")
+	}
+	if !proxyStartBlocked(true, nil) {
+		t.Fatal("second start request was allowed")
+	}
+}

--- a/backend/internal/sshproxyapi/listener.go
+++ b/backend/internal/sshproxyapi/listener.go
@@ -163,8 +163,9 @@ func (s Service) handleProxyConnection(parentCtx context.Context, conn net.Conn,
 			wg.Add(1)
 			go func(ch ssh.NewChannel) {
 				defer wg.Done()
-				handleProxyChannel(control.ctx, ch, targetClient.client, control)
-				notifyChannelDone.Do(func() { close(channelDone) })
+				if handleProxyChannel(control.ctx, ch, targetClient.client, control) {
+					notifyChannelDone.Do(func() { close(channelDone) })
+				}
 			}(newChannel)
 		}
 	}()

--- a/backend/internal/sshproxyapi/session_runtime.go
+++ b/backend/internal/sshproxyapi/session_runtime.go
@@ -281,8 +281,15 @@ func (s Service) watchProxySessionState(control *proxySessionControl) {
 		case <-control.done():
 			return
 		case <-ticker.C:
-			state, err := s.loadProxySessionState(context.Background(), control.sessionID)
+			queryCtx, cancel := context.WithTimeout(control.ctx, 3*time.Second)
+			state, err := s.loadProxySessionState(queryCtx, control.sessionID)
+			cancel()
 			if err != nil {
+				select {
+				case <-control.done():
+					return
+				default:
+				}
 				slog.Default().Warn("load SSH proxy session state failed", "session_id", control.sessionID, "error", err)
 				continue
 			}

--- a/backend/internal/sshproxyapi/target_client.go
+++ b/backend/internal/sshproxyapi/target_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -130,6 +131,7 @@ func sshHostKeyCallbackForPaths(configured string, defaultPaths []string) (ssh.H
 		if configured != "" {
 			return nil, errors.New("configured SSH proxy known_hosts file does not exist")
 		}
+		slog.Default().Warn("SSH proxy target host key verification disabled because no known_hosts files exist", "default_paths", defaultPaths)
 		return ssh.InsecureIgnoreHostKey(), nil
 	}
 	callback, err := knownhosts.New(paths...)


### PR DESCRIPTION
## Summary
- keep the native SSH proxy transport alive after rejected non-session channels
- reject shell/exec starts while an SSH proxy session is paused
- make session-state polling cancellable through the live session context
- warn when SSH proxy target host-key verification falls back because no known_hosts files exist

## Verification
- go test ./backend/internal/sshproxyapi ./backend/cmd/control-plane-api