### PR TITLE
[codex] Fix client startup without map-assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Password self-signup now generates a user ID and sets `updatedAt`, resolving the `null value in column "id" of relation "User"` registration failure.
 - OAuth and LDAP auto-provisioning paths now set `updatedAt` consistently when creating users.
+- Client nginx startup no longer fails when `ip_geolocation` disables the `map-assets` service.
 
 ### Removed
 - Legacy RDGW service, CLI command, settings UI, API routes, and deployment wiring.

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -62,7 +62,8 @@ server {
 
     location /map-assets {
         rewrite ^/map-assets/?(.*)$ /$1 break;
-        proxy_pass http://${MAP_ASSETS_UPSTREAM_HOST}:8096;
+        set $map_assets_upstream http://${MAP_ASSETS_UPSTREAM_HOST}:8096;
+        proxy_pass $map_assets_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/client/nginx.dev.conf
+++ b/client/nginx.dev.conf
@@ -66,7 +66,8 @@ server {
 
     location /map-assets {
         rewrite ^/map-assets/?(.*)$ /$1 break;
-        proxy_pass http://${MAP_ASSETS_UPSTREAM_HOST}:8096;
+        set $map_assets_upstream http://${MAP_ASSETS_UPSTREAM_HOST}:8096;
+        proxy_pass $map_assets_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/deployment/ansible/roles/deploy/templates/client/nginx.https.conf.j2
+++ b/deployment/ansible/roles/deploy/templates/client/nginx.https.conf.j2
@@ -65,7 +65,8 @@ server {
 
     location /map-assets {
         rewrite ^/map-assets/?(.*)$ /$1 break;
-        proxy_pass http://${MAP_ASSETS_UPSTREAM_HOST}:8096;
+        set $map_assets_upstream http://${MAP_ASSETS_UPSTREAM_HOST}:8096;
+        proxy_pass $map_assets_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/deployment/ansible/tests/test_client_nginx_config.py
+++ b/deployment/ansible/tests/test_client_nginx_config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class ClientNginxConfigTest(unittest.TestCase):
+    def test_map_assets_upstream_is_resolved_lazily(self) -> None:
+        config_paths = [
+            ROOT / "client" / "nginx.conf",
+            ROOT / "client" / "nginx.dev.conf",
+            ROOT / "deployment" / "ansible" / "roles" / "deploy" / "templates" / "client" / "nginx.https.conf.j2",
+        ]
+
+        for config_path in config_paths:
+            with self.subTest(config=str(config_path.relative_to(ROOT))):
+                config = config_path.read_text(encoding="utf-8")
+                self.assertIn("set $map_assets_upstream http://${MAP_ASSETS_UPSTREAM_HOST}:8096;", config)
+                self.assertIn("proxy_pass $map_assets_upstream;", config)
+                self.assertNotIn("proxy_pass http://${MAP_ASSETS_UPSTREAM_HOST}:8096;", config)


### PR DESCRIPTION
## Summary
- Lazily resolve the `map-assets` nginx upstream in production, development, and installer TLS client configs.
- Add a regression test for the nginx map-assets proxy configuration.
- Update the 1.8.2 changelog.

## Validation
- `python3 -m unittest deployment.ansible.tests.test_client_nginx_config`
- `python3 -m unittest discover deployment/ansible/tests`