### PR TITLE
[codex] Fix bundled storage secret handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Password self-signup now generates a user ID and sets `updatedAt`, resolving the `null value in column "id" of relation "User"` registration failure.
 - OAuth and LDAP auto-provisioning paths now set `updatedAt` consistently when creating users.
 - Client nginx startup no longer fails when `ip_geolocation` disables the `map-assets` service.
+- Production TLS private keys are no longer made world-readable for rootless Podman installs.
+- Bundled production shared-file storage no longer persists the S3 secret in the generated env file or falls back to development credentials.
 
 ### Removed
 - Legacy RDGW service, CLI command, settings UI, API routes, and deployment wiring.

--- a/deployment/ansible/README.md
+++ b/deployment/ansible/README.md
@@ -251,7 +251,7 @@ Production-specific behaviors:
 - Secrets are verified to be mounted via Podman secrets, not environment variables.
 - Images can be built from source or pulled from a registry.
 - When `arsenale_public_url` starts with `https://`, the production Podman client mounts the generated client certificate and an installer-managed HTTPS nginx template so the exposed web port speaks TLS directly.
-- RDP shared drives and SSH staged upload/download flows require S3-compatible object storage. Production Podman profiles that include the bundled `shared-files-s3` service use installer-managed MinIO defaults; otherwise set `arsenale_shared_files_s3_bucket` and related `arsenale_shared_files_s3_*` vars, plus `vault_shared_files_s3_secret_access_key` when static credentials are needed.
+- RDP shared drives and SSH staged upload/download flows require S3-compatible object storage. Production Podman profiles that include the bundled `shared-files-s3` service use installer-managed MinIO endpoint and bucket defaults, but must set `vault_shared_files_s3_secret_access_key`; otherwise set `arsenale_shared_files_s3_bucket` and related `arsenale_shared_files_s3_*` vars, plus `vault_shared_files_s3_secret_access_key` when static credentials are needed.
 
 ---
 

--- a/deployment/ansible/roles/certificates/tasks/main.yml
+++ b/deployment/ansible/roles/certificates/tasks/main.yml
@@ -19,16 +19,16 @@
 
 - name: Set runtime private key mode
   set_fact:
-    _runtime_key_mode: "0644"
-    _guacd_runtime_key_mode: "0644"
+    _runtime_key_mode: "0640"
+    _guacd_runtime_key_mode: "0640"
     _spiffe_trust_domain: "{{ arsenale_spiffe_trust_domain | default('arsenale.local') }}"
     _dev_tunnel_fixtures_enabled: "{{ arsenale_dev_tunnel_fixtures_enabled | default(_is_dev | default(false) | bool) }}"
 
-- name: Ensure certificate root is traversable by rootless containers
+- name: Ensure certificate root is private to the runtime owner
   file:
     path: "{{ arsenale_cert_dir }}"
     state: directory
-    mode: "0755"
+    mode: "0750"
 
 - name: Derive development client extra IPv4 SANs
   set_fact:
@@ -218,14 +218,14 @@
   file:
     path: "{{ arsenale_cert_dir }}/{{ item.name }}"
     state: directory
-    mode: "0755"
+    mode: "0750"
   loop: "{{ _services_need_certs }}"
   when: _services_need_certs | length > 0
 
-- name: Ensure existing cert directories are traversable (rootless Podman UID mapping)
+- name: Ensure existing cert directories are private to the runtime owner
   file:
     path: "{{ arsenale_cert_dir }}/{{ item.name }}"
-    mode: "0755"
+    mode: "0750"
   loop: "{{ cert_services }}"
   failed_when: false
 

--- a/deployment/ansible/roles/deploy/templates/compose.yml.j2
+++ b/deployment/ansible/roles/deploy/templates/compose.yml.j2
@@ -145,6 +145,8 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    group_add:
+      - keep-groups
     healthcheck:
       test: ["CMD-SHELL", "netstat -tln | grep -q ':4822 ' || exit 1"]
       interval: 10s
@@ -182,6 +184,8 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    group_add:
+      - keep-groups
     healthcheck:
       test: ["CMD-SHELL", "curl --silent --show-error --fail --insecure https://127.0.0.1:3003/health >/dev/null || exit 1"]
       interval: 10s
@@ -524,9 +528,11 @@ services:
     image: {{ arsenale_dev_shared_files_s3_image | default('quay.io/minio/minio:latest') }}
     container_name: arsenale-shared-files-s3
     command: ["server", "/data", "--console-address", ":9001"]
+    secrets:
+      - shared_files_s3_secret_access_key
     environment:
       MINIO_ROOT_USER: "${SHARED_FILES_S3_ACCESS_KEY_ID:-arsenale}"
-      MINIO_ROOT_PASSWORD: "${SHARED_FILES_S3_SECRET_ACCESS_KEY:-arsenale-dev-shared-files}"
+      MINIO_ROOT_PASSWORD_FILE: /run/secrets/shared_files_s3_secret_access_key
       MINIO_REGION_NAME: "${SHARED_FILES_S3_REGION:-us-east-1}"
     volumes:
       - shared_files_s3_data:/data
@@ -1407,6 +1413,8 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    group_add:
+      - keep-groups
     ports:
       - "{{ _client_bind_host }}:{{ arsenale_client_port }}:8080"
     environment:
@@ -1462,6 +1470,8 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    group_add:
+      - keep-groups
     environment:
       SPIFFE_TRUST_DOMAIN: "{{ arsenale_spiffe_trust_domain | default('arsenale.local') }}"
       GATEWAY_API_TLS_CERT: /certs/server-cert.pem
@@ -1502,6 +1512,8 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    group_add:
+      - keep-groups
     environment:
       SPIFFE_TRUST_DOMAIN: "{{ arsenale_spiffe_trust_domain | default('arsenale.local') }}"
       TUNNEL_SERVER_URL: "ws://tunnel-broker:8092/api/tunnel/connect"
@@ -1554,6 +1566,8 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    group_add:
+      - keep-groups
     environment:
       GUACD_SSL: "true"
       GUACD_SSL_CERT: /certs/server-cert.pem
@@ -1604,6 +1618,8 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    group_add:
+      - keep-groups
     environment:
       DB_LISTEN_PORT: "5432"
       TUNNEL_SERVER_URL: "ws://tunnel-broker:8092/api/tunnel/connect"

--- a/deployment/ansible/roles/deploy/templates/env.j2
+++ b/deployment/ansible/roles/deploy/templates/env.j2
@@ -40,7 +40,6 @@ SHARED_FILES_S3_BUCKET={{ (arsenale_dev_shared_files_s3_bucket if _local_shared_
 SHARED_FILES_S3_REGION={{ (arsenale_dev_shared_files_s3_region if _local_shared_files_s3_enabled else arsenale_shared_files_s3_region) | default('us-east-1') }}
 SHARED_FILES_S3_ENDPOINT={{ (arsenale_dev_shared_files_s3_endpoint if _local_shared_files_s3_enabled else arsenale_shared_files_s3_endpoint) | default('') }}
 SHARED_FILES_S3_ACCESS_KEY_ID={{ (arsenale_dev_shared_files_s3_access_key_id if _local_shared_files_s3_enabled else arsenale_shared_files_s3_access_key_id) | default('') }}
-SHARED_FILES_S3_SECRET_ACCESS_KEY={{ (arsenale_dev_shared_files_s3_secret_access_key if _local_shared_files_s3_enabled else '') }}
 SHARED_FILES_S3_PREFIX={{ (arsenale_dev_shared_files_s3_prefix if _local_shared_files_s3_enabled else arsenale_shared_files_s3_prefix) | default('') }}
 SHARED_FILES_S3_FORCE_PATH_STYLE={{ ('true' if ((arsenale_dev_shared_files_s3_force_path_style if _local_shared_files_s3_enabled else arsenale_shared_files_s3_force_path_style) | default(false) | bool) else 'false') }}
 SHARED_FILES_S3_AUTO_CREATE_BUCKET={{ ('true' if ((arsenale_dev_shared_files_s3_auto_create_bucket if _local_shared_files_s3_enabled else arsenale_shared_files_s3_auto_create_bucket) | default(false) | bool) else 'false') }}

--- a/deployment/ansible/roles/podman_secrets/tasks/main.yml
+++ b/deployment/ansible/roles/podman_secrets/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Require shared-files S3 secret for bundled production storage
+  fail:
+    msg: "Set vault_shared_files_s3_secret_access_key when enabling bundled shared-files-s3 outside development."
+  when:
+    - not (_is_dev | default(false) | bool)
+    - "'shared-files-s3' in (installer_services | default([]))"
+    - (vault_shared_files_s3_secret_access_key | default('') | length) == 0
+
 - name: Define secret mappings
   set_fact:
     podman_secrets:
@@ -9,7 +17,7 @@
       - { name: database_url, value: "{{ vault_database_url }}" }
       - { name: postgres_password, value: "{{ vault_postgres_password }}" }
       - { name: guacenc_auth_token, value: "{{ vault_guacenc_auth_token }}" }
-      - { name: shared_files_s3_secret_access_key, value: "{{ (arsenale_dev_shared_files_s3_secret_access_key if (((_is_dev | default(false) | bool) or ('shared-files-s3' in (installer_services | default([])))) and ((vault_shared_files_s3_secret_access_key | default('')) | length == 0)) else vault_shared_files_s3_secret_access_key) }}" }
+      - { name: shared_files_s3_secret_access_key, value: "{{ (arsenale_dev_shared_files_s3_secret_access_key if ((_is_dev | default(false) | bool) and ((vault_shared_files_s3_secret_access_key | default('')) | length == 0)) else (vault_shared_files_s3_secret_access_key | default(''))) }}" }
       # Optional secrets (only create if non-empty)
       - { name: runtime_egress_principal_signing_key, value: "{{ vault_runtime_egress_principal_signing_key | default('') }}" }
       - { name: smtp_pass, value: "{{ vault_smtp_pass }}" }

--- a/deployment/ansible/tests/test_standalone_installer.py
+++ b/deployment/ansible/tests/test_standalone_installer.py
@@ -16,6 +16,7 @@ BROWSER_EXTENSION_WORKFLOW = ROOT / ".github" / "workflows" / "browser-extension
 INSTALL_PLAYBOOK = ROOT / "deployment" / "ansible" / "playbooks" / "install.yml"
 INSTALL_APPLY_TASKS = ROOT / "deployment" / "ansible" / "playbooks" / "tasks" / "install_apply.yml"
 CERTIFICATE_TASKS = ROOT / "deployment" / "ansible" / "roles" / "certificates" / "tasks" / "main.yml"
+PODMAN_SECRETS_TASKS = ROOT / "deployment" / "ansible" / "roles" / "podman_secrets" / "tasks" / "main.yml"
 DEPLOY_APPLY_TASKS = ROOT / "deployment" / "ansible" / "roles" / "deploy" / "tasks" / "apply.yml"
 DEPLOY_PLAYBOOK = ROOT / "deployment" / "ansible" / "playbooks" / "deploy.yml"
 DEV_REFRESH_PLAYBOOK = ROOT / "deployment" / "ansible" / "playbooks" / "dev_refresh.yml"
@@ -271,6 +272,8 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         self.assertIn("net-egress", services["guacd"]["networks"])
         self.assertIn("net-egress", services["ssh-gateway"]["networks"])
         self.assertIn("net-egress", services["query-runner"]["networks"])
+        for service_name in ["client", "guacd", "guacenc", "ssh-gateway"]:
+            self.assertEqual(services[service_name]["group_add"], ["keep-groups"])
 
     def test_production_compose_honors_pinned_release_image_tag(self) -> None:
         compose = _render_compose(arsenale_image_tag="1.8.0")
@@ -302,10 +305,14 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
     def test_production_compose_can_render_bundled_shared_file_storage(self) -> None:
         compose = _render_compose(installer_services=["shared-files-s3"])
         services = compose["services"]
+        env = services["shared-files-s3"]["environment"]
 
         self.assertIn("shared-files-s3", services)
         self.assertEqual(services["shared-files-s3"]["image"], "quay.io/minio/minio:latest")
         self.assertEqual(services["shared-files-s3"]["volumes"], ["shared_files_s3_data:/data"])
+        self.assertEqual(services["shared-files-s3"]["secrets"], ["shared_files_s3_secret_access_key"])
+        self.assertEqual(env["MINIO_ROOT_PASSWORD_FILE"], "/run/secrets/shared_files_s3_secret_access_key")
+        self.assertNotIn("MINIO_ROOT_PASSWORD", env)
 
     def test_production_compose_does_not_require_dev_demo_database_vars(self) -> None:
         dev_demo_keys = [
@@ -384,6 +391,8 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         self.assertIn("shared-files-s3", services)
         self.assertEqual(services["shared-files-s3"]["image"], "quay.io/minio/minio:latest")
         self.assertEqual(services["shared-files-s3"]["volumes"], ["shared_files_s3_data:/data"])
+        self.assertEqual(services["shared-files-s3"]["secrets"], ["shared_files_s3_secret_access_key"])
+        self.assertNotIn("MINIO_ROOT_PASSWORD", services["shared-files-s3"]["environment"])
         self.assertEqual(
             services["shared-files-s3"]["healthcheck"]["test"],
             ["CMD-SHELL", "curl --silent --fail http://127.0.0.1:9000/minio/health/live >/dev/null || exit 1"],
@@ -398,6 +407,8 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         self.assertIn("net-egress", services["guacd"]["networks"])
         self.assertIn("net-egress", services["ssh-gateway"]["networks"])
         self.assertIn("net-egress", services["query-runner"]["networks"])
+        for service_name in ["client", "guacd", "guacenc", "ssh-gateway", "dev-tunnel-ssh-gateway", "dev-tunnel-guacd", "dev-tunnel-db-proxy"]:
+            self.assertEqual(services[service_name]["group_add"], ["keep-groups"])
 
     def test_development_compose_can_disable_dev_fixtures(self) -> None:
         compose = _render_compose(
@@ -432,6 +443,9 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
             "true",
         )
 
+    def test_env_file_does_not_render_shared_files_secret(self) -> None:
+        self.assertNotIn("SHARED_FILES_S3_SECRET_ACCESS_KEY", _render_env(installer_services=["shared-files-s3"]))
+
 
 class StandaloneInstallerConfigTest(unittest.TestCase):
     def test_non_dev_playbooks_default_to_prebuilt_images(self) -> None:
@@ -449,13 +463,23 @@ class StandaloneInstallerConfigTest(unittest.TestCase):
 
         self.assertIn("'ip_geolocation': ('ip_geolocation' in installer_capability_selection)", capabilities_section)
 
-    def test_runtime_service_private_keys_are_container_readable(self) -> None:
+    def test_runtime_service_private_keys_stay_group_scoped(self) -> None:
         cert_text = CERTIFICATE_TASKS.read_text(encoding="utf-8")
 
-        self.assertIn('_runtime_key_mode: "0644"', cert_text)
-        self.assertIn("name: Ensure certificate root is traversable by rootless containers", cert_text)
+        self.assertIn('_runtime_key_mode: "0640"', cert_text)
+        self.assertIn('_guacd_runtime_key_mode: "0640"', cert_text)
+        self.assertIn("name: Ensure certificate root is private to the runtime owner", cert_text)
+        self.assertNotIn('_runtime_key_mode: "0644"', cert_text)
         self.assertIn("_client_certificate_host_is_ipv4", cert_text)
         self.assertIn("regex_search('^\\\\d+\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+$')", cert_text)
+
+    def test_bundled_production_shared_files_secret_requires_vault_value(self) -> None:
+        secret_text = PODMAN_SECRETS_TASKS.read_text(encoding="utf-8")
+
+        self.assertIn("name: Require shared-files S3 secret for bundled production storage", secret_text)
+        self.assertIn("Set vault_shared_files_s3_secret_access_key", secret_text)
+        self.assertIn("arsenale_dev_shared_files_s3_secret_access_key if ((_is_dev", secret_text)
+        self.assertNotIn("or ('shared-files-s3' in (installer_services", secret_text)
 
     def test_full_force_recreate_refreshes_postgres_before_migrations(self) -> None:
         apply_text = DEPLOY_APPLY_TASKS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Keep generated TLS private keys group-scoped instead of world-readable and allow non-root Podman containers to read them through `keep-groups`.
- Remove the shared-files S3 secret from the generated env file.
- Make bundled MinIO read the secret through Podman secrets and require an explicit production vault value.
- Update the 1.8.2 changelog and deployment docs.

## Validation
- `python3 -m unittest deployment.ansible.tests.test_standalone_installer deployment.ansible.tests.test_client_nginx_config`
- `python3 -m unittest discover deployment/ansible/tests`