### PR TITLE
[codex] Fix compose shared-files gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Client nginx startup no longer fails when `ip_geolocation` disables the `map-assets` service.
 - Production TLS private keys are no longer made world-readable for rootless Podman installs.
 - Bundled production shared-file storage no longer persists the S3 secret in the generated env file or falls back to development credentials.
+- Production compose rendering no longer lets the optional `shared-files-s3` gate override core service definitions.
 
 ### Removed
 - Legacy RDGW service, CLI command, settings UI, API routes, and deployment wiring.

--- a/deployment/ansible/roles/deploy/templates/compose.yml.j2
+++ b/deployment/ansible/roles/deploy/templates/compose.yml.j2
@@ -545,9 +545,11 @@ services:
     restart: always
     networks:
       - net-cache
+{% endif %}
 
+{% if _is_dev | default(false) | bool %}
   # ---------------------------------------------------------------------------
-  # Go backend foundation services — active public runtime
+  # Go backend foundation services — active development runtime
   # ---------------------------------------------------------------------------
   control-plane-api:
 {{ compose_service_source('control-plane-api', 'backend/Dockerfile', build_args={'SERVICE': 'control-plane-api'}) | indent(4, true) }}

--- a/deployment/ansible/tests/test_standalone_installer.py
+++ b/deployment/ansible/tests/test_standalone_installer.py
@@ -313,6 +313,11 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         self.assertEqual(services["shared-files-s3"]["secrets"], ["shared_files_s3_secret_access_key"])
         self.assertEqual(env["MINIO_ROOT_PASSWORD_FILE"], "/run/secrets/shared_files_s3_secret_access_key")
         self.assertNotIn("MINIO_ROOT_PASSWORD", env)
+        self.assertEqual(
+            services["control-plane-api"]["environment"]["ARSENALE_INSTALL_MODE"],
+            "${ARSENALE_INSTALL_MODE:-production}",
+        )
+        self.assertNotIn("control-plane-controller", services)
 
     def test_production_compose_does_not_require_dev_demo_database_vars(self) -> None:
         dev_demo_keys = [
@@ -347,7 +352,7 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
         compose = _render_compose(installer_services=["shared-files-s3"], _omit_keys=dev_demo_keys)
         env = compose["services"]["control-plane-api"]["environment"]
 
-        self.assertEqual(env["DEV_SAMPLE_POSTGRES_HOST"], "")
+        self.assertNotIn("DEV_SAMPLE_POSTGRES_HOST", env)
         self.assertNotIn("dev-demo-postgres", compose["services"])
 
     def test_development_compose_keeps_local_builds(self) -> None:


### PR DESCRIPTION
## Summary
- Close the optional `shared-files-s3` Jinja block before the core development runtime services.
- Keep production bundled storage renders on the production control-plane service definition.
- Update the 1.8.2 changelog.

## Validation
- `python3 -m unittest deployment.ansible.tests.test_standalone_installer deployment.ansible.tests.test_client_nginx_config`
- `python3 -m unittest discover deployment/ansible/tests`