### PR TITLE
Fix 1.8.4 tunnel revoke dialog state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generated GUACD and CLI tunnel bundles, plus backend tunnel proxy routes, now target the embedded gateway listener port instead of a configured external host port.
 - Generated GUACD install bundles now default to TLS and create local guacd certificate material for the remote container.
 - Generated GUACD compose bundles now declare only named persistence volumes at top level while keeping certificate bind mounts scoped to the service.
+- Revoking a tunnel token from the post-create gateway dialog now clears the local enabled state immediately.
 
 ## [1.8.3] - 2026-05-14
 

--- a/client/src/components/gateway/GatewayDialog.test.tsx
+++ b/client/src/components/gateway/GatewayDialog.test.tsx
@@ -69,6 +69,7 @@ describe('GatewayDialog', () => {
       gateways: [],
       createGateway: vi.fn().mockResolvedValue(baseGateway),
       generateTunnelToken: vi.fn().mockResolvedValue(tunnelBundle),
+      revokeTunnelToken: vi.fn().mockResolvedValue(undefined),
     });
     useUiPreferencesStore.setState({
       tunnelSectionOpen: true,
@@ -138,6 +139,30 @@ describe('GatewayDialog', () => {
     expect(screen.getByDisplayValue(/TUNNEL_TOKEN="tok-secret"/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue(/docker compose --env-file tunnel.env up -d/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue(/-----BEGIN PRIVATE KEY-----/i)).toBeInTheDocument();
+  });
+
+  it('clears post-create tunnel state after revoking the token', async () => {
+    const user = userEvent.setup();
+    const createGateway = vi.fn().mockResolvedValue(baseGateway);
+    const generateTunnelToken = vi.fn().mockResolvedValue(tunnelBundle);
+    const revokeTunnelToken = vi.fn().mockResolvedValue(undefined);
+    useGatewayStore.setState({ createGateway, generateTunnelToken, revokeTunnelToken });
+
+    render(<GatewayDialog open onClose={vi.fn()} gateway={null} />);
+
+    await user.type(screen.getByLabelText('Name'), 'Remote GUACD');
+    await user.type(screen.getByLabelText('Host'), 'remote-guacd.local');
+    await user.type(screen.getByLabelText('Port'), '4822');
+    await user.click(screen.getByRole('button', { name: 'Enable Zero-Trust Tunnel' }));
+    await user.click(screen.getByRole('button', { name: 'Create and Enable Tunnel' }));
+
+    expect(await screen.findByText(/Copy these values now/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Revoke Token' }));
+    await user.click(screen.getByRole('button', { name: 'Yes, Revoke' }));
+
+    await waitFor(() => expect(revokeTunnelToken).toHaveBeenCalledWith('gateway-1'));
+    expect(screen.getByRole('button', { name: 'Enable Zero-Trust Tunnel' })).toBeInTheDocument();
+    expect(screen.queryByText(/Tunnel is enabled/i)).not.toBeInTheDocument();
   });
 
   it('keeps the created gateway open when tunnel activation fails after create', async () => {

--- a/client/src/components/gateway/GatewayDialog.test.tsx
+++ b/client/src/components/gateway/GatewayDialog.test.tsx
@@ -160,8 +160,8 @@ describe('GatewayDialog', () => {
     await user.click(screen.getByRole('button', { name: 'Revoke Token' }));
     await user.click(screen.getByRole('button', { name: 'Yes, Revoke' }));
 
-    await waitFor(() => expect(revokeTunnelToken).toHaveBeenCalledWith('gateway-1'));
-    expect(screen.getByRole('button', { name: 'Enable Zero-Trust Tunnel' })).toBeInTheDocument();
+    expect(revokeTunnelToken).toHaveBeenCalledWith('gateway-1');
+    expect(await screen.findByRole('button', { name: 'Enable Zero-Trust Tunnel' })).toBeInTheDocument();
     expect(screen.queryByText(/Tunnel is enabled/i)).not.toBeInTheDocument();
   });
 

--- a/client/src/components/gateway/GatewayDialog.tsx
+++ b/client/src/components/gateway/GatewayDialog.tsx
@@ -236,6 +236,10 @@ export default function GatewayDialog({ open, onClose, gateway }: GatewayDialogP
     if (ok && (isEditMode || !enableTunnelOnCreate)) handleClose();
   };
 
+  const updateCreatedGatewayTunnelState = useCallback((id: string, updates: Partial<GatewayData>) => {
+    setCreatedGateway((current) => (current?.id === id ? { ...current, ...updates } : current));
+  }, []);
+
   const handleEnableTunnel = async () => {
     if (!activeGateway) {
       setTunnelError('');
@@ -247,14 +251,11 @@ export default function GatewayDialog({ open, onClose, gateway }: GatewayDialogP
     const ok = await runTunnelAction(async () => {
       const result = await generateTunnelTokenAction(activeGateway.id);
       setTunnelBundle(result);
-      if (createdGateway?.id === activeGateway.id) {
-        setCreatedGateway({
-          ...createdGateway,
-          tunnelEnabled: result.tunnelEnabled,
-          tunnelConnected: result.tunnelConnected,
-          tunnelClientCertExp: result.tunnelClientCertExp ?? createdGateway.tunnelClientCertExp,
-        });
-      }
+      updateCreatedGatewayTunnelState(activeGateway.id, {
+        tunnelEnabled: result.tunnelEnabled,
+        tunnelConnected: result.tunnelConnected,
+        tunnelClientCertExp: result.tunnelClientCertExp ?? activeGateway.tunnelClientCertExp,
+      });
     }, 'Failed to enable tunnel');
     setTunnelDeploying(false);
     if (!ok) setTunnelError('Failed to generate tunnel token');
@@ -266,6 +267,11 @@ export default function GatewayDialog({ open, onClose, gateway }: GatewayDialogP
     const ok = await runTunnelAction(async () => {
       const result = await generateTunnelTokenAction(activeGateway.id);
       setTunnelBundle(result);
+      updateCreatedGatewayTunnelState(activeGateway.id, {
+        tunnelEnabled: result.tunnelEnabled,
+        tunnelConnected: result.tunnelConnected,
+        tunnelClientCertExp: result.tunnelClientCertExp ?? activeGateway.tunnelClientCertExp,
+      });
     }, 'Failed to rotate tunnel token');
     if (!ok) setTunnelError('Failed to rotate tunnel token');
   };
@@ -276,6 +282,13 @@ export default function GatewayDialog({ open, onClose, gateway }: GatewayDialogP
     const ok = await runTunnelAction(async () => {
       await revokeTunnelTokenAction(activeGateway.id);
       setTunnelBundle(null);
+      setTunnelMetrics(null);
+      updateCreatedGatewayTunnelState(activeGateway.id, {
+        tunnelEnabled: false,
+        tunnelConnected: false,
+        tunnelConnectedAt: null,
+        tunnelClientCertExp: null,
+      });
     }, 'Failed to revoke tunnel token');
     if (!ok) setTunnelError('Failed to revoke tunnel token');
   };


### PR DESCRIPTION
## Summary
- keep post-create gateway tunnel state in sync after enable, rotate, and revoke actions
- show the enable flow immediately after revoking a just-created gateway tunnel token
- update 1.8.4 changelog

## Verification
- npm run test -w client -- GatewayDialog.test.tsx
- npm run typecheck -w client
- npm run verify
- go test ./tools/arsenale-cli/...
- go build -o ./build/go/arsenale-cli ./tools/arsenale-cli
- ./build/go/arsenale-cli version