### PR TITLE
Finalize 1.8.4 tunnel compose test fix

### DIFF
--- a/client/src/components/gateway/GatewayDialog.test.tsx
+++ b/client/src/components/gateway/GatewayDialog.test.tsx
@@ -137,7 +137,7 @@ describe('GatewayDialog', () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(await screen.findByText(/Copy these values now/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue(/TUNNEL_TOKEN="tok-secret"/i)).toBeInTheDocument();
-    expect(screen.getByDisplayValue(/docker compose --env-file tunnel.env up -d/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/\$compose_cmd --env-file tunnel.env up -d/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue(/-----BEGIN PRIVATE KEY-----/i)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- Updates the gateway dialog test to expect the runtime-selected compose command introduced by the tunnel key permission fix.

## Verification
- npm run test -w client -- GatewayDialog.test.tsx gatewayTunnelInstall.test.ts
- npm run typecheck -w client