### PR TITLE
Fix tunnel gateway secret mounts for all runtimes

### DIFF
--- a/client/src/components/gateway/GatewayDialog.test.tsx
+++ b/client/src/components/gateway/GatewayDialog.test.tsx
@@ -137,7 +137,7 @@ describe('GatewayDialog', () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(await screen.findByText(/Copy these values now/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue(/TUNNEL_TOKEN="tok-secret"/i)).toBeInTheDocument();
-    expect(screen.getByDisplayValue(/docker compose --env-file tunnel.env up -d/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/\$compose_cmd --env-file tunnel.env up -d/i)).toBeInTheDocument();
     expect(screen.getByDisplayValue(/-----BEGIN PRIVATE KEY-----/i)).toBeInTheDocument();
   });
 

--- a/client/src/components/gateway/gatewayTunnelInstall.test.ts
+++ b/client/src/components/gateway/gatewayTunnelInstall.test.ts
@@ -49,6 +49,7 @@ describe('buildTunnelInstallBundle', () => {
     expect(bundle.installCommands).not.toContain('chmod 644 ./certs/tunnel-client-*.pem');
     expect(bundle.installCommands).toContain('compose_cmd="docker compose"');
     expect(bundle.installCommands).toContain('compose_cmd="podman-compose"');
+    expect(bundle.installCommands).toContain('podman unshare chown 0:0 "$path" 2>/dev/null || true');
     expect(bundle.installCommands).toContain('podman unshare chown 1000:1000 ./certs/tunnel-client-key.pem');
     expect(bundle.installCommands).toContain('$compose_cmd --env-file tunnel.env up -d');
     expect(bundle.installCommands).toContain('-----BEGIN CERTIFICATE-----');
@@ -105,5 +106,21 @@ describe('buildTunnelInstallBundle', () => {
     expect(topLevelVolumes).not.toContain('./certs/guacd-server-key.pem');
     expect(bundle.installCommands).toContain('openssl req -x509');
     expect(bundle.installCommands).toContain('chmod 600 ./certs/guacd-server-key.pem');
+    expect(bundle.installCommands).toContain('podman unshare chown 100:101 ./certs/tunnel-client-key.pem');
+    expect(bundle.installCommands).toContain('podman unshare chown 100:101 ./certs/guacd-server-key.pem');
+    expect(bundle.installCommands).not.toContain('podman unshare chown 1000:1000 ./certs/tunnel-client-key.pem');
+  });
+
+  it('uses the DB proxy runtime user for database tunnel bundles', () => {
+    const bundle = buildTunnelInstallBundle({
+      gateway: { ...gateway, type: 'DB_PROXY', port: 15432 },
+      tokenBundle: { ...tokenBundle, gatewayType: 'DB_PROXY', tunnelLocalPort: 15432 },
+      serverUrl: 'https://arsenale.example.com',
+    });
+
+    expect(bundle.serviceName).toBe('db-proxy');
+    expect(bundle.gatewayImage).toBe('ghcr.io/dnviti/arsenale/db-proxy:stable');
+    expect(bundle.envContent).toContain('DB_LISTEN_PORT="15432"');
+    expect(bundle.installCommands).toContain('podman unshare chown 100:101 ./certs/tunnel-client-key.pem');
   });
 });

--- a/client/src/components/gateway/gatewayTunnelInstall.test.ts
+++ b/client/src/components/gateway/gatewayTunnelInstall.test.ts
@@ -32,6 +32,7 @@ describe('buildTunnelInstallBundle', () => {
 
     expect(bundle.gatewayImage).toBe('ghcr.io/dnviti/arsenale/ssh-gateway:stable');
     expect(bundle.dockerCompose).toContain('image: ghcr.io/dnviti/arsenale/ssh-gateway:stable');
+    expect(bundle.dockerCompose).toContain('user: "0:0"');
     expect(bundle.envContent).toContain('TUNNEL_SERVER_URL="https://arsenale.example.com"');
     expect(bundle.envContent).toContain('TUNNEL_TOKEN="tok-secret"');
     expect(bundle.envContent).toContain('TUNNEL_GATEWAY_ID="gateway-1"');
@@ -95,6 +96,7 @@ describe('buildTunnelInstallBundle', () => {
     expect(bundle.envContent).toContain('TUNNEL_LOCAL_PORT="14822"');
     expect(bundle.envContent).toContain('GUACD_PORT="14822"');
     expect(bundle.dockerCompose).toContain('image: ghcr.io/dnviti/arsenale/guacd:stable');
+    expect(bundle.dockerCompose).toContain('user: "0:0"');
     expect(bundle.dockerCompose).not.toContain('GUACD_PORT: "${GUACD_PORT:-14822}"');
     expect(bundle.dockerCompose).toContain('GUACD_SSL: "true"');
     expect(bundle.dockerCompose).toContain('./certs/guacd-server-cert.pem:/certs/guacd-server-cert.pem:ro');
@@ -120,6 +122,7 @@ describe('buildTunnelInstallBundle', () => {
 
     expect(bundle.serviceName).toBe('db-proxy');
     expect(bundle.gatewayImage).toBe('ghcr.io/dnviti/arsenale/db-proxy:stable');
+    expect(bundle.dockerCompose).toContain('user: "0:0"');
     expect(bundle.envContent).toContain('DB_LISTEN_PORT="15432"');
     expect(bundle.installCommands).toContain('podman unshare chown 100:101 ./certs/tunnel-client-key.pem');
   });

--- a/client/src/components/gateway/gatewayTunnelInstall.ts
+++ b/client/src/components/gateway/gatewayTunnelInstall.ts
@@ -19,8 +19,12 @@ interface GatewayRuntimeInstall {
   image: string;
   defaultLocalPort: number;
   listenerEnvKey: string;
+  containerUid: number;
+  containerGid: number;
   setupCommands: string[];
   extraEnvironment: string[];
+  publicMountPaths: string[];
+  privateMountPaths: string[];
   volumes: string[];
 }
 
@@ -58,7 +62,7 @@ export function buildTunnelInstallBundle({
     tokenBundle,
     envContent,
     dockerCompose,
-    runtime.setupCommands,
+    runtime,
     gatewayInstallDirectory(gatewayID, runtime.serviceName),
   );
 
@@ -79,8 +83,12 @@ function gatewayRuntimeInstall(type: GatewayData['type']): GatewayRuntimeInstall
         image: 'ghcr.io/dnviti/arsenale/ssh-gateway:stable',
         defaultLocalPort: 2222,
         listenerEnvKey: 'SSH_PORT',
+        containerUid: 1000,
+        containerGid: 1000,
         setupCommands: [],
         extraEnvironment: [],
+        publicMountPaths: [],
+        privateMountPaths: [],
         volumes: [],
       };
     case 'DB_PROXY':
@@ -89,8 +97,12 @@ function gatewayRuntimeInstall(type: GatewayData['type']): GatewayRuntimeInstall
         image: 'ghcr.io/dnviti/arsenale/db-proxy:stable',
         defaultLocalPort: 5432,
         listenerEnvKey: 'DB_LISTEN_PORT',
+        containerUid: 100,
+        containerGid: 101,
         setupCommands: [],
         extraEnvironment: [],
+        publicMountPaths: [],
+        privateMountPaths: [],
         volumes: [],
       };
     case 'SSH_BASTION':
@@ -99,8 +111,12 @@ function gatewayRuntimeInstall(type: GatewayData['type']): GatewayRuntimeInstall
         image: 'ghcr.io/dnviti/arsenale/ssh-gateway:stable',
         defaultLocalPort: 2222,
         listenerEnvKey: 'SSH_PORT',
+        containerUid: 1000,
+        containerGid: 1000,
         setupCommands: [],
         extraEnvironment: [],
+        publicMountPaths: [],
+        privateMountPaths: [],
         volumes: [],
       };
     case 'GUACD':
@@ -110,6 +126,8 @@ function gatewayRuntimeInstall(type: GatewayData['type']): GatewayRuntimeInstall
         image: 'ghcr.io/dnviti/arsenale/guacd:stable',
         defaultLocalPort: 4822,
         listenerEnvKey: 'GUACD_PORT',
+        containerUid: 100,
+        containerGid: 101,
         setupCommands: [
           `if [ ! -f ${guacdCertPath} ] || [ ! -f ${guacdKeyPath} ]; then`,
           '  command -v openssl >/dev/null || { echo "openssl is required to generate GUACD TLS certificates" >&2; exit 1; }',
@@ -119,6 +137,8 @@ function gatewayRuntimeInstall(type: GatewayData['type']): GatewayRuntimeInstall
           `chmod 600 ${guacdKeyPath}`,
         ],
         extraEnvironment: ['GUACD_SSL: "true"', `GUACD_SSL_CERT: ${containerGuacdCertPath}`, `GUACD_SSL_KEY: ${containerGuacdKeyPath}`],
+        publicMountPaths: [guacdCertPath],
+        privateMountPaths: [guacdKeyPath],
         volumes: [
           'guacd-drive:/guacd-drive',
           'guacd-recordings:/recordings',
@@ -177,16 +197,19 @@ function buildInstallCommands(
   tokenBundle: TunnelTokenResponse,
   envContent: string,
   dockerCompose: string,
-  setupCommands: string[],
+  runtime: GatewayRuntimeInstall,
   installDirectory: string,
 ): string {
   const quotedInstallDirectory = shellQuote(installDirectory);
   const quotedCertsDirectory = shellQuote(`${installDirectory}/certs`);
+  const publicMountPaths = [certPath, ...runtime.publicMountPaths];
+  const privateMountPaths = [keyPath, ...runtime.privateMountPaths];
   return [
     'umask 077',
     `mkdir -p ${quotedCertsDirectory}`,
     `cd ${quotedInstallDirectory}`,
-    ...setupCommands,
+    ...restorePodmanRootlessOwnershipCommands([...publicMountPaths, ...privateMountPaths]),
+    ...runtime.setupCommands,
     `cat > ${certPath} <<'EOF'`,
     stringsTrimWithNewline(tokenBundle.tunnelClientCert),
     'EOF',
@@ -203,10 +226,7 @@ function buildInstallCommands(
     '  echo "docker compose or podman-compose is required" >&2',
     '  exit 1',
     'fi',
-    'if [ "$compose_cmd" = "podman-compose" ] && command -v podman >/dev/null 2>&1; then',
-    `  podman unshare chown 1000:1000 ${keyPath}`,
-    `  podman unshare chmod 600 ${keyPath}`,
-    'fi',
+    ...podmanRootlessPrivateFileCommands(privateMountPaths, runtime),
     "cat > tunnel.env <<'EOF'",
     stringsTrimWithNewline(envContent),
     'EOF',
@@ -216,6 +236,35 @@ function buildInstallCommands(
     'EOF',
     '$compose_cmd --env-file tunnel.env up -d',
   ].join('\n');
+}
+
+function restorePodmanRootlessOwnershipCommands(paths: string[]): string[] {
+  if (paths.length === 0) {
+    return [];
+  }
+  return [
+    'if command -v podman >/dev/null 2>&1; then',
+    `  for path in ${paths.map(shellQuote).join(' ')}; do`,
+    '    if [ -e "$path" ]; then',
+    '      podman unshare chown 0:0 "$path" 2>/dev/null || true',
+    '    fi',
+    '  done',
+    'fi',
+  ];
+}
+
+function podmanRootlessPrivateFileCommands(paths: string[], runtime: GatewayRuntimeInstall): string[] {
+  if (paths.length === 0) {
+    return [];
+  }
+  return [
+    'if [ "$compose_cmd" = "podman-compose" ] && command -v podman >/dev/null 2>&1; then',
+    ...paths.flatMap((path) => [
+      `  podman unshare chown ${runtime.containerUid}:${runtime.containerGid} ${path}`,
+      `  podman unshare chmod 600 ${path}`,
+    ]),
+    'fi',
+  ];
 }
 
 function gatewayInstallDirectory(gatewayID: string, serviceName: string): string {

--- a/client/src/components/gateway/gatewayTunnelInstall.ts
+++ b/client/src/components/gateway/gatewayTunnelInstall.ts
@@ -161,6 +161,7 @@ function buildDockerCompose(runtime: GatewayRuntimeInstall, _localPort: number):
     'services:',
     `  ${runtime.serviceName}:`,
     `    image: ${runtime.image}`,
+    '    user: "0:0"',
     '    restart: unless-stopped',
     '    env_file:',
     '      - tunnel.env',

--- a/gateways/db-proxy/Dockerfile
+++ b/gateways/db-proxy/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=tunnel-builder /out/tunnel-agent /usr/local/bin/tunnel-agent
 COPY gateways/db-proxy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-USER root
+USER dbproxy
 
 ENV DB_LISTEN_PORT=5432
 

--- a/gateways/db-proxy/Dockerfile
+++ b/gateways/db-proxy/Dockerfile
@@ -48,7 +48,7 @@ LABEL org.opencontainers.image.source="https://github.com/dnviti/arsenale"
 LABEL org.opencontainers.image.licenses="BUSL-1.1"
 
 RUN apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates && \
+    apk add --no-cache ca-certificates su-exec && \
     addgroup -S dbproxy && adduser -S dbproxy -G dbproxy
 
 COPY --from=proxy-builder /out/db-proxy /usr/local/bin/db-proxy
@@ -58,7 +58,7 @@ COPY --from=tunnel-builder /out/tunnel-agent /usr/local/bin/tunnel-agent
 COPY gateways/db-proxy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-USER dbproxy
+USER root
 
 ENV DB_LISTEN_PORT=5432
 

--- a/gateways/db-proxy/compose.yml
+++ b/gateways/db-proxy/compose.yml
@@ -2,12 +2,18 @@ services:
   db-proxy:
     image: ${DB_PROXY_IMAGE:-ghcr.io/dnviti/arsenale/db-proxy:latest}
     container_name: ${DB_PROXY_CONTAINER_NAME:-arsenale-db-proxy}
+    user: "0:0"
     restart: unless-stopped
     read_only: true
     tmpfs:
       - /tmp
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
     security_opt:
       - no-new-privileges:true
     environment:

--- a/gateways/db-proxy/entrypoint.sh
+++ b/gateways/db-proxy/entrypoint.sh
@@ -4,20 +4,20 @@ set -e
 if [ "$(id -u)" = "0" ]; then
   TUNNEL_RUNTIME_DIR="/tmp/arsenale-tunnel"
   mkdir -p "$TUNNEL_RUNTIME_DIR"
-  chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR"
   chmod 700 "$TUNNEL_RUNTIME_DIR"
+  chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR"
 
   if [ -n "${TUNNEL_CLIENT_CERT_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_CERT_FILE" ]; then
     cp "$TUNNEL_CLIENT_CERT_FILE" "$TUNNEL_RUNTIME_DIR/client-cert.pem"
-    chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR/client-cert.pem"
     chmod 644 "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR/client-cert.pem"
     export TUNNEL_CLIENT_CERT_FILE="$TUNNEL_RUNTIME_DIR/client-cert.pem"
   fi
 
   if [ -n "${TUNNEL_CLIENT_KEY_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_KEY_FILE" ]; then
     cp "$TUNNEL_CLIENT_KEY_FILE" "$TUNNEL_RUNTIME_DIR/client-key.pem"
-    chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR/client-key.pem"
     chmod 600 "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR/client-key.pem"
     export TUNNEL_CLIENT_KEY_FILE="$TUNNEL_RUNTIME_DIR/client-key.pem"
   fi
 

--- a/gateways/db-proxy/entrypoint.sh
+++ b/gateways/db-proxy/entrypoint.sh
@@ -1,6 +1,29 @@
 #!/bin/sh
 set -e
 
+if [ "$(id -u)" = "0" ]; then
+  TUNNEL_RUNTIME_DIR="/tmp/arsenale-tunnel"
+  mkdir -p "$TUNNEL_RUNTIME_DIR"
+  chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR"
+  chmod 700 "$TUNNEL_RUNTIME_DIR"
+
+  if [ -n "${TUNNEL_CLIENT_CERT_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_CERT_FILE" ]; then
+    cp "$TUNNEL_CLIENT_CERT_FILE" "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chmod 644 "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    export TUNNEL_CLIENT_CERT_FILE="$TUNNEL_RUNTIME_DIR/client-cert.pem"
+  fi
+
+  if [ -n "${TUNNEL_CLIENT_KEY_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_KEY_FILE" ]; then
+    cp "$TUNNEL_CLIENT_KEY_FILE" "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chown dbproxy:dbproxy "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chmod 600 "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    export TUNNEL_CLIENT_KEY_FILE="$TUNNEL_RUNTIME_DIR/client-key.pem"
+  fi
+
+  exec su-exec dbproxy "$0" "$@"
+fi
+
 export PORT="${DB_LISTEN_PORT:-5432}"
 
 db_proxy_pid=""

--- a/gateways/guacd/Dockerfile
+++ b/gateways/guacd/Dockerfile
@@ -49,6 +49,7 @@ RUN apk add --no-cache \
     guacamole-server-libs \
     netcat-openbsd \
     shadow \
+    su-exec \
     && mkdir -p /home/guacd \
     && chown guacd:guacd /home/guacd \
     && usermod -d /home/guacd guacd \
@@ -65,7 +66,7 @@ COPY --from=tunnel-builder /out/tunnel-agent /usr/local/bin/tunnel-agent
 COPY gateways/guacd/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-USER guacd
+USER root
 
 EXPOSE 4822
 

--- a/gateways/guacd/Dockerfile
+++ b/gateways/guacd/Dockerfile
@@ -34,8 +34,6 @@ RUN GOWORK=off CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64}
 # ── guacd runtime + tunnel agent ─────────────────────────────────────────────
 FROM docker.io/library/alpine:3.21
 
-USER root
-
 LABEL org.opencontainers.image.title="Arsenale guacd"
 LABEL org.opencontainers.image.description="guacd with embedded zero-trust tunnel agent"
 LABEL org.opencontainers.image.source="https://github.com/dnviti/arsenale"
@@ -66,7 +64,7 @@ COPY --from=tunnel-builder /out/tunnel-agent /usr/local/bin/tunnel-agent
 COPY gateways/guacd/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-USER root
+USER guacd
 
 EXPOSE 4822
 

--- a/gateways/guacd/compose.yml
+++ b/gateways/guacd/compose.yml
@@ -2,12 +2,18 @@ services:
   guacd:
     image: ${GUACD_IMAGE:-ghcr.io/dnviti/arsenale/guacd:latest}
     container_name: ${GUACD_CONTAINER_NAME:-arsenale-guacd}
+    user: "0:0"
     restart: unless-stopped
     read_only: true
     tmpfs:
       - /tmp
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
     security_opt:
       - no-new-privileges:true
     environment:

--- a/gateways/guacd/entrypoint.sh
+++ b/gateways/guacd/entrypoint.sh
@@ -5,34 +5,34 @@ if [ "$(id -u)" = "0" ]; then
   TUNNEL_RUNTIME_DIR="/tmp/arsenale-tunnel"
   TLS_RUNTIME_DIR="/tmp/guacd-tls"
   mkdir -p "$TUNNEL_RUNTIME_DIR" "$TLS_RUNTIME_DIR"
-  chown guacd:guacd "$TUNNEL_RUNTIME_DIR" "$TLS_RUNTIME_DIR"
   chmod 700 "$TUNNEL_RUNTIME_DIR" "$TLS_RUNTIME_DIR"
+  chown guacd:guacd "$TUNNEL_RUNTIME_DIR" "$TLS_RUNTIME_DIR"
 
   if [ -n "${TUNNEL_CLIENT_CERT_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_CERT_FILE" ]; then
     cp "$TUNNEL_CLIENT_CERT_FILE" "$TUNNEL_RUNTIME_DIR/client-cert.pem"
-    chown guacd:guacd "$TUNNEL_RUNTIME_DIR/client-cert.pem"
     chmod 644 "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chown guacd:guacd "$TUNNEL_RUNTIME_DIR/client-cert.pem"
     export TUNNEL_CLIENT_CERT_FILE="$TUNNEL_RUNTIME_DIR/client-cert.pem"
   fi
 
   if [ -n "${TUNNEL_CLIENT_KEY_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_KEY_FILE" ]; then
     cp "$TUNNEL_CLIENT_KEY_FILE" "$TUNNEL_RUNTIME_DIR/client-key.pem"
-    chown guacd:guacd "$TUNNEL_RUNTIME_DIR/client-key.pem"
     chmod 600 "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chown guacd:guacd "$TUNNEL_RUNTIME_DIR/client-key.pem"
     export TUNNEL_CLIENT_KEY_FILE="$TUNNEL_RUNTIME_DIR/client-key.pem"
   fi
 
   if [ -n "${GUACD_SSL_CERT:-}" ] && [ -f "$GUACD_SSL_CERT" ]; then
     cp "$GUACD_SSL_CERT" "$TLS_RUNTIME_DIR/server-cert.pem"
-    chown guacd:guacd "$TLS_RUNTIME_DIR/server-cert.pem"
     chmod 644 "$TLS_RUNTIME_DIR/server-cert.pem"
+    chown guacd:guacd "$TLS_RUNTIME_DIR/server-cert.pem"
     export GUACD_SSL_CERT="$TLS_RUNTIME_DIR/server-cert.pem"
   fi
 
   if [ -n "${GUACD_SSL_KEY:-}" ] && [ -f "$GUACD_SSL_KEY" ]; then
     cp "$GUACD_SSL_KEY" "$TLS_RUNTIME_DIR/server-key.pem"
-    chown guacd:guacd "$TLS_RUNTIME_DIR/server-key.pem"
     chmod 600 "$TLS_RUNTIME_DIR/server-key.pem"
+    chown guacd:guacd "$TLS_RUNTIME_DIR/server-key.pem"
     export GUACD_SSL_KEY="$TLS_RUNTIME_DIR/server-key.pem"
   fi
 

--- a/gateways/guacd/entrypoint.sh
+++ b/gateways/guacd/entrypoint.sh
@@ -1,6 +1,44 @@
 #!/bin/sh
 set -e
 
+if [ "$(id -u)" = "0" ]; then
+  TUNNEL_RUNTIME_DIR="/tmp/arsenale-tunnel"
+  TLS_RUNTIME_DIR="/tmp/guacd-tls"
+  mkdir -p "$TUNNEL_RUNTIME_DIR" "$TLS_RUNTIME_DIR"
+  chown guacd:guacd "$TUNNEL_RUNTIME_DIR" "$TLS_RUNTIME_DIR"
+  chmod 700 "$TUNNEL_RUNTIME_DIR" "$TLS_RUNTIME_DIR"
+
+  if [ -n "${TUNNEL_CLIENT_CERT_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_CERT_FILE" ]; then
+    cp "$TUNNEL_CLIENT_CERT_FILE" "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chown guacd:guacd "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chmod 644 "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    export TUNNEL_CLIENT_CERT_FILE="$TUNNEL_RUNTIME_DIR/client-cert.pem"
+  fi
+
+  if [ -n "${TUNNEL_CLIENT_KEY_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_KEY_FILE" ]; then
+    cp "$TUNNEL_CLIENT_KEY_FILE" "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chown guacd:guacd "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chmod 600 "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    export TUNNEL_CLIENT_KEY_FILE="$TUNNEL_RUNTIME_DIR/client-key.pem"
+  fi
+
+  if [ -n "${GUACD_SSL_CERT:-}" ] && [ -f "$GUACD_SSL_CERT" ]; then
+    cp "$GUACD_SSL_CERT" "$TLS_RUNTIME_DIR/server-cert.pem"
+    chown guacd:guacd "$TLS_RUNTIME_DIR/server-cert.pem"
+    chmod 644 "$TLS_RUNTIME_DIR/server-cert.pem"
+    export GUACD_SSL_CERT="$TLS_RUNTIME_DIR/server-cert.pem"
+  fi
+
+  if [ -n "${GUACD_SSL_KEY:-}" ] && [ -f "$GUACD_SSL_KEY" ]; then
+    cp "$GUACD_SSL_KEY" "$TLS_RUNTIME_DIR/server-key.pem"
+    chown guacd:guacd "$TLS_RUNTIME_DIR/server-key.pem"
+    chmod 600 "$TLS_RUNTIME_DIR/server-key.pem"
+    export GUACD_SSL_KEY="$TLS_RUNTIME_DIR/server-key.pem"
+  fi
+
+  exec su-exec guacd "$0" "$@"
+fi
+
 requested_home="${HOME:-/home/guacd}"
 requested_config_home="${XDG_CONFIG_HOME:-$requested_home/.config}"
 

--- a/gateways/ssh-gateway/Dockerfile
+++ b/gateways/ssh-gateway/Dockerfile
@@ -60,7 +60,7 @@ COPY --from=grpc-builder /key-mgmt-server /usr/local/bin/key-mgmt-server
 # Embed pre-built tunnel agent
 COPY --from=tunnel-builder /out/tunnel-agent /usr/local/bin/tunnel-agent
 
-USER root
+USER tunnel
 
 EXPOSE 2222 9022
 

--- a/gateways/ssh-gateway/Dockerfile
+++ b/gateways/ssh-gateway/Dockerfile
@@ -43,7 +43,7 @@ LABEL org.opencontainers.image.description="Lightweight SSH tunnel for TCP port 
 LABEL org.opencontainers.image.source="https://github.com/dnviti/arsenale"
 LABEL org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache openssh-server netcat-openbsd busybox-extras \
+RUN apk add --no-cache openssh-server netcat-openbsd busybox-extras su-exec \
     && adduser -D -s /sbin/nologin tunnel \
     && sed -i 's/^tunnel:!/tunnel:*/' /etc/shadow \
     && mkdir -p /config
@@ -60,7 +60,7 @@ COPY --from=grpc-builder /key-mgmt-server /usr/local/bin/key-mgmt-server
 # Embed pre-built tunnel agent
 COPY --from=tunnel-builder /out/tunnel-agent /usr/local/bin/tunnel-agent
 
-USER tunnel
+USER root
 
 EXPOSE 2222 9022
 

--- a/gateways/ssh-gateway/compose.yml
+++ b/gateways/ssh-gateway/compose.yml
@@ -2,12 +2,18 @@ services:
   ssh-gateway:
     image: ${SSH_GATEWAY_IMAGE:-ghcr.io/dnviti/arsenale/ssh-gateway:latest}
     container_name: ${SSH_GATEWAY_CONTAINER_NAME:-arsenale-ssh-gateway}
+    user: "0:0"
     restart: unless-stopped
     read_only: true
     tmpfs:
       - /tmp
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
     security_opt:
       - no-new-privileges:true
     environment:

--- a/gateways/ssh-gateway/entrypoint.sh
+++ b/gateways/ssh-gateway/entrypoint.sh
@@ -4,20 +4,20 @@ set -e
 if [ "$(id -u)" = "0" ]; then
   TUNNEL_RUNTIME_DIR="/tmp/arsenale-tunnel"
   mkdir -p "$TUNNEL_RUNTIME_DIR"
-  chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR"
   chmod 700 "$TUNNEL_RUNTIME_DIR"
+  chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR"
 
   if [ -n "${TUNNEL_CLIENT_CERT_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_CERT_FILE" ]; then
     cp "$TUNNEL_CLIENT_CERT_FILE" "$TUNNEL_RUNTIME_DIR/client-cert.pem"
-    chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR/client-cert.pem"
     chmod 644 "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR/client-cert.pem"
     export TUNNEL_CLIENT_CERT_FILE="$TUNNEL_RUNTIME_DIR/client-cert.pem"
   fi
 
   if [ -n "${TUNNEL_CLIENT_KEY_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_KEY_FILE" ]; then
     cp "$TUNNEL_CLIENT_KEY_FILE" "$TUNNEL_RUNTIME_DIR/client-key.pem"
-    chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR/client-key.pem"
     chmod 600 "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR/client-key.pem"
     export TUNNEL_CLIENT_KEY_FILE="$TUNNEL_RUNTIME_DIR/client-key.pem"
   fi
 

--- a/gateways/ssh-gateway/entrypoint.sh
+++ b/gateways/ssh-gateway/entrypoint.sh
@@ -1,6 +1,29 @@
 #!/bin/sh
 set -e
 
+if [ "$(id -u)" = "0" ]; then
+  TUNNEL_RUNTIME_DIR="/tmp/arsenale-tunnel"
+  mkdir -p "$TUNNEL_RUNTIME_DIR"
+  chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR"
+  chmod 700 "$TUNNEL_RUNTIME_DIR"
+
+  if [ -n "${TUNNEL_CLIENT_CERT_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_CERT_FILE" ]; then
+    cp "$TUNNEL_CLIENT_CERT_FILE" "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    chmod 644 "$TUNNEL_RUNTIME_DIR/client-cert.pem"
+    export TUNNEL_CLIENT_CERT_FILE="$TUNNEL_RUNTIME_DIR/client-cert.pem"
+  fi
+
+  if [ -n "${TUNNEL_CLIENT_KEY_FILE:-}" ] && [ -f "$TUNNEL_CLIENT_KEY_FILE" ]; then
+    cp "$TUNNEL_CLIENT_KEY_FILE" "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chown tunnel:tunnel "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    chmod 600 "$TUNNEL_RUNTIME_DIR/client-key.pem"
+    export TUNNEL_CLIENT_KEY_FILE="$TUNNEL_RUNTIME_DIR/client-key.pem"
+  fi
+
+  exec su-exec tunnel "$0" "$@"
+fi
+
 # Set up authorized_keys in /tmp (writable tmpfs) for read_only containers
 AUTH_KEYS_DIR="/tmp/.ssh"
 AUTH_KEYS_FILE="${AUTH_KEYS_DIR}/authorized_keys"

--- a/tools/arsenale-cli/cmd/gateway_test.go
+++ b/tools/arsenale-cli/cmd/gateway_test.go
@@ -173,13 +173,18 @@ func TestWriteTunnelTokenBundle(t *testing.T) {
 		t.Fatalf("unexpected env path %q", envPath)
 	}
 
-	for _, path := range []string{
-		filepath.Join(tempDir, "certs", "tunnel-client-cert.pem"),
-		filepath.Join(tempDir, "certs", "tunnel-client-key.pem"),
-		filepath.Join(tempDir, "tunnel.env"),
-	} {
-		if _, err := os.Stat(path); err != nil {
+	expectedModes := map[string]os.FileMode{
+		filepath.Join(tempDir, "certs", "tunnel-client-cert.pem"): 0644,
+		filepath.Join(tempDir, "certs", "tunnel-client-key.pem"):  0600,
+		filepath.Join(tempDir, "tunnel.env"):                      0600,
+	}
+	for path, wantMode := range expectedModes {
+		info, err := os.Stat(path)
+		if err != nil {
 			t.Fatalf("expected %s to exist: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != wantMode {
+			t.Fatalf("%s mode = %o, want %o", path, got, wantMode)
 		}
 	}
 }

--- a/tools/arsenale-cli/cmd/gateway_tunnel_tokens.go
+++ b/tools/arsenale-cli/cmd/gateway_tunnel_tokens.go
@@ -114,16 +114,25 @@ func writeTunnelTokenBundle(bundleDir string, bundle tunnelTokenBundle, serverUR
 	}
 	certPath := filepath.Join(certsDir, "tunnel-client-cert.pem")
 	keyPath := filepath.Join(certsDir, "tunnel-client-key.pem")
-	if err := os.WriteFile(certPath, []byte(strings.TrimSpace(bundle.TunnelClientCert)+"\n"), 0600); err != nil {
+	if err := os.WriteFile(certPath, []byte(strings.TrimSpace(bundle.TunnelClientCert)+"\n"), 0644); err != nil {
 		return "", fmt.Errorf("write tunnel client cert: %w", err)
+	}
+	if err := os.Chmod(certPath, 0644); err != nil {
+		return "", fmt.Errorf("chmod tunnel client cert: %w", err)
 	}
 	if err := os.WriteFile(keyPath, []byte(strings.TrimSpace(bundle.TunnelClientKey)+"\n"), 0600); err != nil {
 		return "", fmt.Errorf("write tunnel client key: %w", err)
+	}
+	if err := os.Chmod(keyPath, 0600); err != nil {
+		return "", fmt.Errorf("chmod tunnel client key: %w", err)
 	}
 	envPath := filepath.Join(bundleDir, "tunnel.env")
 	envContent := tunnelTokenEnvContent(bundle, serverURL, "./certs/tunnel-client-cert.pem", "./certs/tunnel-client-key.pem")
 	if err := os.WriteFile(envPath, []byte(envContent), 0600); err != nil {
 		return "", fmt.Errorf("write tunnel env file: %w", err)
+	}
+	if err := os.Chmod(envPath, 0600); err != nil {
+		return "", fmt.Errorf("chmod tunnel env file: %w", err)
 	}
 	return envPath, nil
 }


### PR DESCRIPTION
## Summary
- Materialize mounted tunnel cert/key files inside SSH, GUACD, and DB proxy containers before dropping privileges.
- Generate install bundles with per-runtime rootless Podman ownership handling, including GUACD TLS keys.
- Write CLI tunnel client cert bundles as public certs plus private keys/env files with strict modes.

## Verification
- go test ./tools/arsenale-cli/...
- npm run test -w client -- gatewayTunnelInstall.test.ts GatewayDialog.test.tsx
- npm run typecheck -w client
- sh -n gateways/ssh-gateway/entrypoint.sh gateways/guacd/entrypoint.sh gateways/db-proxy/entrypoint.sh
- podman build -f gateways/ssh-gateway/Dockerfile -t localhost/arsenale-ssh-gateway-secret-test .
- podman build -f gateways/guacd/Dockerfile -t localhost/arsenale-guacd-secret-test .
- podman build -f gateways/db-proxy/Dockerfile -t localhost/arsenale-db-proxy-secret-test .
- container smoke for SSH, GUACD, and DB proxy mounted-secret startup
- npm run verify