### PR TITLE
fix(setup): serialize one-time setup completion to prevent owner-account race

### DIFF
--- a/backend/internal/setup/complete.go
+++ b/backend/internal/setup/complete.go
@@ -253,6 +253,19 @@ func (s Service) createSetupAdmin(
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Serialize one-time setup completion attempts for this database.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, int64(84572133)); err != nil {
+		return "", fmt.Errorf("acquire setup lock: %w", err)
+	}
+
+	setupRequired, err := isSetupRequiredTx(ctx, tx)
+	if err != nil {
+		return "", err
+	}
+	if !setupRequired {
+		return "", &requestError{status: http.StatusConflict, message: "Setup has already been completed"}
+	}
+
 	userID := uuid.NewString()
 	if _, err := tx.Exec(ctx, `
 INSERT INTO "User" (
@@ -323,6 +336,23 @@ INSERT INTO "User" (
 		return "", fmt.Errorf("commit setup transaction: %w", err)
 	}
 	return userID, nil
+}
+
+func isSetupRequiredTx(ctx context.Context, tx pgx.Tx) (bool, error) {
+	var setupValue string
+	err := tx.QueryRow(ctx, `SELECT value FROM "AppConfig" WHERE key = 'setupCompleted'`).Scan(&setupValue)
+	if err == nil && strings.EqualFold(strings.TrimSpace(setupValue), "true") {
+		return false, nil
+	}
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return false, fmt.Errorf("read setup completed flag in transaction: %w", err)
+	}
+
+	var hasUsers bool
+	if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM "User" LIMIT 1)`).Scan(&hasUsers); err != nil {
+		return false, fmt.Errorf("read setup users in transaction: %w", err)
+	}
+	return !hasUsers, nil
 }
 
 func upsertAppConfig(ctx context.Context, tx pgx.Tx, key, value string) error {


### PR DESCRIPTION
### Motivation
- The unauthenticated first-run `POST /api/setup/complete` flow could be raced: parallel callers could all observe zero users and each create an OWNER account and tenant. 
- The root cause was a non-atomic pre-check performed outside the DB transaction and expensive async work before entering the transaction, leaving a large race window.

### Description
- Added a transaction-scoped PostgreSQL advisory lock using `pg_advisory_xact_lock` in `createSetupAdmin` to serialize concurrent setup completion attempts. 
- Added an in-transaction re-check `isSetupRequiredTx` that validates `setupCompleted` and user existence inside the same transaction and returns a `409` (`requestError`) when setup is already completed. 
- Kept the existing atomic creation of the initial admin user, AppConfig upserts, audit log insertion, and commit behavior unchanged except for the added lock and recheck. 
- Modified file: `backend/internal/setup/complete.go`.

### Testing
- Ran `go test ./backend/internal/setup/...` which reported no test files for the package (smoke check completed). 
- Ran `go test ./backend/cmd/control-plane-api/...` which succeeded (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a156cc4e90c8326a2615c3402e4a943)