### PR TITLE
Harden query-runner compose exposure

### DIFF
--- a/deployment/ansible/roles/deploy/templates/compose.yml.j2
+++ b/deployment/ansible/roles/deploy/templates/compose.yml.j2
@@ -419,8 +419,6 @@ services:
       ARSENALE_VERSION: "{{ arsenale_image_tag }}"
       DATABASE_URL_FILE: /run/secrets/database_url
       DATABASE_SSL_ROOT_CERT: /certs/postgres/ca.pem
-    ports:
-      - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_query_runner_port | default(18093) }}:8093"
     depends_on:
       postgres:
         condition: {{ _compose_dependency_condition }}


### PR DESCRIPTION
### Motivation
- The production Podman Compose template published the `query-runner` service on host port `18093` (bound via `arsenale_service_bind_host` defaulting to `0.0.0.0`), which exposed an unauthenticated internal SQL execution API to external networks and allowed arbitrary SQL against the application database.

### Description
- Removed the host `ports` mapping for the `query-runner` service in `deployment/ansible/roles/deploy/templates/compose.yml.j2` so the service is no longer published on host interfaces and remains reachable only via internal compose networks, while keeping its environment, secrets, healthcheck, and internal networking intact.

### Testing
- Ran `go test ./tools/arsenale-cli/...` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15748dccf8832686f12db2fe4e3171)