### PR TITLE
Harden terminal-broker default network exposure

### DIFF
--- a/deployment/ansible/README.md
+++ b/deployment/ansible/README.md
@@ -994,6 +994,7 @@ All non-secret configuration is in `inventory/group_vars/all/vars.yml`.
 | `arsenale_agent_orchestrator_port` | `18085` | Agent orchestrator |
 | `arsenale_memory_service_port` | `18086` | Memory service |
 | `arsenale_terminal_broker_port` | `18090` | Terminal broker |
+| `arsenale_terminal_broker_bind_host` | `127.0.0.1` | Terminal broker bind address |
 | `arsenale_desktop_broker_port` | `18091` | Desktop broker |
 | `arsenale_tunnel_broker_port` | `18092` | Tunnel broker |
 | `arsenale_query_runner_port` | `18093` | Query runner |

--- a/deployment/ansible/inventory/group_vars/all/vars.yml
+++ b/deployment/ansible/inventory/group_vars/all/vars.yml
@@ -12,6 +12,7 @@ arsenale_tool_gateway_port: 18084
 arsenale_agent_orchestrator_port: 18085
 arsenale_memory_service_port: 18086
 arsenale_terminal_broker_port: 18090
+arsenale_terminal_broker_bind_host: 127.0.0.1
 arsenale_desktop_broker_port: 18091
 arsenale_tunnel_broker_port: 18092
 arsenale_query_runner_port: 18093

--- a/deployment/ansible/roles/deploy/templates/compose.yml.j2
+++ b/deployment/ansible/roles/deploy/templates/compose.yml.j2
@@ -514,7 +514,7 @@ services:
       DATABASE_SSL_ROOT_CERT: /certs/postgres/ca.pem
       GUACAMOLE_SECRET_FILE: /run/secrets/guacamole_secret
     ports:
-      - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_terminal_broker_port | default(18090) }}:8090"
+      - "{{ arsenale_terminal_broker_bind_host | default('127.0.0.1') }}:{{ arsenale_terminal_broker_port | default(18090) }}:8090"
     depends_on:
       postgres:
         condition: {{ _compose_dependency_condition }}


### PR DESCRIPTION
### Motivation
- Close a critical production exposure where the terminal-broker was host-published by default and exposed unauthenticated grant-issuance endpoints to external networks. 
- Make the safe (loopback-only) bind behavior the default for typical installs while preserving operator ability to opt into other bindings.

### Description
- Change the terminal-broker service port mapping in `deployment/ansible/roles/deploy/templates/compose.yml.j2` to use a new per-service bind variable and default it to `127.0.0.1` instead of inheriting `arsenale_service_bind_host`.
- Add `arsenale_terminal_broker_bind_host: 127.0.0.1` to `deployment/ansible/inventory/group_vars/all/vars.yml` so the installer has a secure default.
- Document the new `arsenale_terminal_broker_bind_host` variable in `deployment/ansible/README.md` under internal service ports.
- Preserve operator override semantics by leaving the new variable configurable so public binding can be enabled intentionally.

### Testing
- Attempted to run the installer tests with `pytest -q deployment/ansible/tests/test_standalone_installer.py`, which failed during collection due to the environment missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`).
- Verified the template and inventory updates via local file inspection to confirm the new default mapping and README entry were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15779424ec8326a001bdcf8abbadd6)