### PR TITLE
fix(deploy): keep internal broker/query ports loopback-bound

### DIFF
--- a/deployment/ansible/roles/deploy/templates/compose.yml.j2
+++ b/deployment/ansible/roles/deploy/templates/compose.yml.j2
@@ -323,7 +323,7 @@ services:
       RUNTIME_EGRESS_PRINCIPAL_SIGNING_KEY_FILE: /run/secrets/runtime_egress_principal_signing_key
 {% endif %}
     ports:
-      - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_control_plane_api_port | default(18080) }}:8080"
+      - "127.0.0.1:{{ arsenale_control_plane_api_port | default(18080) }}:8080"
       - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_ssh_port }}:2222"
     depends_on:
       postgres:
@@ -378,7 +378,7 @@ services:
       TUNNEL_TCP_PROXY_BIND_HOST: "0.0.0.0"
       TUNNEL_TCP_PROXY_ADVERTISE_HOST: "tunnel-broker"
     ports:
-      - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_tunnel_broker_port | default(18092) }}:8092"
+      - "127.0.0.1:{{ arsenale_tunnel_broker_port | default(18092) }}:8092"
     depends_on:
       postgres:
         condition: {{ _compose_dependency_condition }}
@@ -420,7 +420,7 @@ services:
       DATABASE_URL_FILE: /run/secrets/database_url
       DATABASE_SSL_ROOT_CERT: /certs/postgres/ca.pem
     ports:
-      - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_query_runner_port | default(18093) }}:8093"
+      - "127.0.0.1:{{ arsenale_query_runner_port | default(18093) }}:8093"
     depends_on:
       postgres:
         condition: {{ _compose_dependency_condition }}
@@ -467,7 +467,7 @@ services:
       GUACD_SSL: "true"
       GUACD_CA_CERT: /certs/ca/ca.pem
     ports:
-      - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_desktop_broker_port | default(18091) }}:8091"
+      - "127.0.0.1:{{ arsenale_desktop_broker_port | default(18091) }}:8091"
     depends_on:
       postgres:
         condition: {{ _compose_dependency_condition }}
@@ -514,7 +514,7 @@ services:
       DATABASE_SSL_ROOT_CERT: /certs/postgres/ca.pem
       GUACAMOLE_SECRET_FILE: /run/secrets/guacamole_secret
     ports:
-      - "{{ arsenale_service_bind_host | default('0.0.0.0') }}:{{ arsenale_terminal_broker_port | default(18090) }}:8090"
+      - "127.0.0.1:{{ arsenale_terminal_broker_port | default(18090) }}:8090"
     depends_on:
       postgres:
         condition: {{ _compose_dependency_condition }}

--- a/deployment/ansible/tests/test_standalone_installer.py
+++ b/deployment/ansible/tests/test_standalone_installer.py
@@ -254,6 +254,11 @@ class StandaloneInstallerTemplateTest(unittest.TestCase):
             "${GATEWAY_ROUTING_MODE:-gateway-mandatory}",
         )
         self.assertIn("0.0.0.0:2222:2222", services["control-plane-api"]["ports"])
+        self.assertIn("127.0.0.1:18080:8080", services["control-plane-api"]["ports"])
+        self.assertEqual(services["terminal-broker"]["ports"], ["127.0.0.1:18090:8090"])
+        self.assertEqual(services["desktop-broker"]["ports"], ["127.0.0.1:18091:8091"])
+        self.assertEqual(services["tunnel-broker"]["ports"], ["127.0.0.1:18092:8092"])
+        self.assertEqual(services["query-runner"]["ports"], ["127.0.0.1:18093:8093"])
         self.assertNotIn("ports", services["ssh-gateway"])
 
         postgres_volumes = services["postgres"]["volumes"]


### PR DESCRIPTION
### Motivation
- A recent template change caused production renders with bundled `shared-files-s3` to lose the later localhost-bound service definitions, leaving internal `/v1` broker and query endpoints published on all interfaces (`0.0.0.0`) and exposing unauthenticated internal APIs.
- The change here is intended to restore the accidental localhost-only protection for those internal services so they are not reachable from non-local network interfaces by default.

### Description
- Updated `deployment/ansible/roles/deploy/templates/compose.yml.j2` to publish the control-plane API HTTP port on `127.0.0.1:{{ arsenale_control_plane_api_port }}:8080` instead of using `arsenale_service_bind_host` for that mapping.
- Updated `deployment/ansible/roles/deploy/templates/compose.yml.j2` to publish `terminal-broker`, `desktop-broker`, `tunnel-broker`, and `query-runner` ports on `127.0.0.1` instead of the default service bind host.
- Kept the SSH proxy published mapping unchanged (still respects `arsenale_service_bind_host`) to preserve intended external SSH behavior.
- Tightened `deployment/ansible/tests/test_standalone_installer.py` assertions to assert the loopback bindings for the hardened services.

### Testing
- Attempted to run the updated installer template unit test with `python -m unittest deployment.ansible.tests.test_standalone_installer`, which failed to execute locally due to a missing runtime dependency (`ModuleNotFoundError: No module named 'yaml'`) in this environment, so the test could not be completed here.
- The change is minimal and limited to compose templating and its test assertions; CI or a dev environment with `PyYAML` installed should render the template and validate the updated assertions (recommended smoke path: render the compose template with the installer service selection that previously exposed ports and confirm the published ports are loopback-bound).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15687372788326bbc3ba42e43e9c71)