### PR TITLE
fix(tunnelbroker): bound and validate tcp proxy fallback ports

### DIFF
--- a/backend/internal/tunnelbroker/broker_handlers.go
+++ b/backend/internal/tunnelbroker/broker_handlers.go
@@ -96,7 +96,7 @@ func (b *Broker) HandleCreateTCPProxy(w http.ResponseWriter, r *http.Request) {
 		app.ErrorJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if strings.TrimSpace(req.GatewayID) == "" || strings.TrimSpace(req.TargetHost) == "" || len(targetPortCandidates(req.TargetPort, req.TargetPorts)) == 0 {
+	if strings.TrimSpace(req.GatewayID) == "" || strings.TrimSpace(req.TargetHost) == "" || !isValidTargetPortRequest(req.TargetPort, req.TargetPorts) {
 		app.ErrorJSON(w, http.StatusBadRequest, "gatewayId, targetHost and targetPort are required")
 		return
 	}

--- a/backend/internal/tunnelbroker/broker_streams.go
+++ b/backend/internal/tunnelbroker/broker_streams.go
@@ -133,10 +133,16 @@ func (b *Broker) createTCPProxy(req contracts.TunnelProxyRequest) (contracts.Tun
 }
 
 func targetPortCandidates(primary int, additional []int) []int {
+	const maxTargetPortCandidates = 2
+	const maxPortNumber = 65535
+
 	seen := map[int]struct{}{}
 	ports := make([]int, 0, len(additional)+1)
 	for _, port := range append([]int{primary}, additional...) {
-		if port <= 0 {
+		if len(ports) == maxTargetPortCandidates {
+			break
+		}
+		if port <= 0 || port > maxPortNumber {
 			continue
 		}
 		if _, ok := seen[port]; ok {
@@ -146,6 +152,13 @@ func targetPortCandidates(primary int, additional []int) []int {
 		ports = append(ports, port)
 	}
 	return ports
+}
+
+func isValidTargetPortRequest(primary int, additional []int) bool {
+	if len(additional) > 1 {
+		return false
+	}
+	return len(targetPortCandidates(primary, additional)) > 0
 }
 
 func (b *Broker) sendFrame(conn *tunnelConnection, frameType msgType, streamID uint16, payload []byte) error {

--- a/backend/internal/tunnelbroker/broker_streams_test.go
+++ b/backend/internal/tunnelbroker/broker_streams_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestTargetPortCandidatesDeduplicateAndDropInvalidPorts(t *testing.T) {
-	got := targetPortCandidates(14822, []int{4822, 14822, 0, -1})
+	got := targetPortCandidates(14822, []int{4822, 14822, 0, -1, 70000})
 	want := []int{14822, 4822}
 	if len(got) != len(want) {
 		t.Fatalf("candidate count = %d, want %d: %#v", len(got), len(want), got)
@@ -15,6 +15,42 @@ func TestTargetPortCandidatesDeduplicateAndDropInvalidPorts(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("candidate %d = %d, want %d: %#v", i, got[i], want[i], got)
 		}
+	}
+}
+
+func TestTargetPortCandidatesLimitFallbackAttempts(t *testing.T) {
+	got := targetPortCandidates(14822, []int{4822, 5822, 6822})
+	want := []int{14822, 4822}
+	if len(got) != len(want) {
+		t.Fatalf("candidate count = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d = %d, want %d: %#v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestIsValidTargetPortRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		primary    int
+		additional []int
+		want       bool
+	}{
+		{name: "single valid primary", primary: 22, want: true},
+		{name: "valid fallback", primary: 22, additional: []int{2222}, want: true},
+		{name: "too many fallbacks", primary: 22, additional: []int{2222, 2223}, want: false},
+		{name: "out of range primary", primary: 70000, want: false},
+		{name: "all invalid", primary: 0, additional: []int{70000}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidTargetPortRequest(tt.primary, tt.additional); got != tt.want {
+				t.Fatalf("isValidTargetPortRequest(%d, %#v) = %t, want %t", tt.primary, tt.additional, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Motivation
- An unauthenticated `POST /v1/tcp-proxies` allowed an attacker-controlled `targetPorts` array with unbounded length, enabling repeated tunnel open attempts and potential DoS of the broker.
- The broker previously accepted any positive ports and iterated every candidate without a maximum or upper-range check, and the production compose can expose the broker to the network by default. 
- Legitimate use only requires a configured port and at most one runtime fallback, so requests must be constrained and validated server-side.

### Description
- Replace the permissive check in the create handler with `isValidTargetPortRequest(...)` and require that validation in `HandleCreateTCPProxy`. 
- Harden `targetPortCandidates(...)` to cap runtime candidates to two total (primary + one fallback) and to ignore ports outside the `1..65535` range. 
- Add `isValidTargetPortRequest(...)` which rejects requests that provide more than one fallback and ensures at least one valid candidate remains after normalization. 
- Add and update unit tests in `backend/internal/tunnelbroker/broker_streams_test.go` to cover out-of-range filtering, candidate cap behavior, and request validation boundaries.

### Testing
- Ran unit tests with `go test ./backend/internal/tunnelbroker -count=1` and they completed successfully. 
- New and updated tests in `backend/internal/tunnelbroker` pass as part of that run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1567b632948326857ec354a13da12d)