### PR TITLE
docs: one-command installer, QUIC tunnel transport, gateway type catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Gateway creation now returns a zero-trust tunnel enrollment panel with the one-time tunnel token, client certificate, client key, `tunnel.env`, `docker-compose.yml`, and remote install commands.
+- One-command platform installer: `tools/installer/install-platform.sh` (`curl … | ARSENALE_DOMAIN=… bash`) installs the full production stack on a Linux host without cloning the repo, downloading a checksummed `arsenale-installer_<version>.tar.gz` bundle published with each release and running the existing Ansible installer.
+- QUIC reverse-tunnel transport (opt-in via `TUNNEL_TRANSPORT=quic|auto`): the tunnel broker terminates QUIC on a UDP port (default `:8092`) with a CA-signed server certificate, and the agent prefers QUIC with automatic WebSocket fallback in `auto` mode. Provisioned by the installer behind `arsenale_tunnel_quic_enabled`.
+- Gateway type catalog: `GET /api/gateways/types` and the `arsenale gateway types` CLI command expose human-readable metadata (display name, summary, protocols, deployment model/modes, default port, image) for each gateway type, sourced from a single `gatewayruntime` definition shared by backend, CLI, and web UI.
 
 ### Changed
 - Release metadata, CLI version output, browser extension manifest, and package manifests now target `1.8.4`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -389,6 +389,7 @@ Operational domains under `routes_operations.go` include:
 
 Notable gateway subpaths:
 
+- `GET /api/gateways/types` returns the human-readable gateway type catalog as `{"types":[...]}`. Each entry carries `type`, `displayName`, `summary`, `description`, `protocols`, `managed`, `deploymentModel`, `deploymentModes`, `defaultPort`, `requiresCredentials`, and (for managed types) `image`. The catalog is the single source of truth shared by the backend (`gatewayruntime`), the web UI, and the CLI's `arsenale gateway types` command (which reads it locally, no login required). Gateway-create validation errors reference this endpoint for the list of valid types.
 - `GET /api/gateways` now returns derived `operationalStatus`, `operationalReason`, `healthyInstances`, and `egressPolicy` fields alongside the legacy probe fields so clients can render managed and tunnel-backed gateway health consistently.
 - `/api/gateways/{id}/deploy`
 - `/api/gateways/{id}/scale`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,7 +36,8 @@ source-files:
 
 Arsenale now has one installer-driven deployment story for both development and production:
 
-- `Makefile` is the human entry point,
+- `Makefile` is the human entry point (from a cloned repo),
+- `tools/installer/install-platform.sh` is the one-command bootstrap that runs the same installer on a production host **without cloning** — `curl -fsSL .../install-platform.sh | ARSENALE_DOMAIN=example.com bash`. See [`docs/installer.md`](installer.md#one-command-install-no-repo-clone),
 - `deployment/ansible/playbooks/install.yml` is the interactive installer entrypoint,
 - `deployment/ansible/playbooks/dev_refresh.yml` is the targeted dev-service refresh entrypoint,
 - `deployment/ansible/playbooks/status.yml` reads encrypted installer status,

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -217,6 +217,30 @@ Leave `LDAP_ENABLED=false` to disable. Compatible with FreeIPA, OpenLDAP, 389 Di
 | `SSH_AUTHORIZED_KEYS` | — | Authorized public keys (newline-separated) |
 | `GATEWAY_API_TOKEN` | — | Shared secret for gateway API sidecar |
 
+### Reverse Tunnel Transport (WebSocket / QUIC)
+
+Reverse-tunnel gateways connect outbound to the tunnel broker. The transport is
+WebSocket by default; QUIC is an opt-in native-stream transport. QUIC is
+provisioned by the installer behind `arsenale_tunnel_quic_enabled` (Ansible), and
+the broker stays WebSocket-only until a QUIC server certificate is configured.
+
+**Tunnel broker:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TUNNEL_QUIC_LISTEN_ADDR` | `:8092` | UDP `host:port` the QUIC tunnel listener binds. Mirrors the HTTP control port. Startup aborts if the bind fails. |
+| `TUNNEL_QUIC_SERVER_CERT` / `TUNNEL_QUIC_SERVER_CERT_FILE` | — | PEM server certificate enabling the QUIC listener. With no cert the broker is WebSocket-only. |
+| `TUNNEL_QUIC_SERVER_KEY` / `TUNNEL_QUIC_SERVER_KEY_FILE` | — | PEM private key for the QUIC server certificate. |
+
+**Tunnel agent (gateway side):**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TUNNEL_TRANSPORT` | `wss` | Transport selection: `wss` (WebSocket), `quic` (QUIC only), or `auto` (prefer QUIC, fall back to WebSocket when QUIC cannot be established, e.g. UDP-blocked networks). |
+| `TUNNEL_QUIC_SERVER_ADDR` | — | Broker QUIC `host:port` (required when `TUNNEL_TRANSPORT` is `quic` or `auto`). |
+| `TUNNEL_QUIC_SERVER_NAME` | — | Optional TLS SNI / server-cert name override when it differs from the dial host. |
+| `TUNNEL_CA_CERT` / `TUNNEL_CA_CERT_FILE` | — | CA that signed the broker's QUIC server certificate, used by the agent to verify it. |
+
 ### Gateway Runtime Egress
 
 | Variable | Default | Description |

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -57,6 +57,33 @@ Underlying playbooks:
 | `make dev <selector>` | `playbooks/dev_refresh.yml` | Targeted dev image rebuild and service refresh |
 | `make dev-down` | `playbooks/deploy.yml -e arsenale_env=development -e arsenale_state=absent` | Dev teardown |
 
+### One-Command Install (no repo clone)
+
+For a production host you do not need to clone the repository. The bootstrap
+[`tools/installer/install-platform.sh`](../tools/installer/install-platform.sh)
+wraps the same `playbooks/install.yml` flow:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dnviti/arsenale/main/tools/installer/install-platform.sh \
+  | ARSENALE_DOMAIN=example.com bash
+```
+
+It auto-installs prerequisites (Ansible, Podman, OpenSSL, Git), verifies
+passwordless SSH-to-localhost and `sudo` (the production play uses `connection:
+ssh` + `become`), downloads and SHA256-verifies the `arsenale-installer_<version>.tar.gz`
+bundle published with each release, generates and encrypts secrets, and runs the
+installer non-interactively (`installer_mode=production`, `installer_backend=podman`),
+pulling prebuilt images from `ghcr.io/dnviti/arsenale`. Re-runs upgrade in place
+without rotating live secrets.
+
+Configure it via environment variables — `ARSENALE_DOMAIN`,
+`ARSENALE_INSTALL_PASSWORD`, `ARSENALE_VAULT_PASSWORD`, `ARSENALE_CAPABILITIES`,
+`ARSENALE_VERSION`, `ARSENALE_SECRETS_FILE` (a filled `SECRETS.env` for OAuth/SMTP/S3),
+`ARSENALE_HOST` / `ARSENALE_DEPLOY_USER` (target a remote host over SSH),
+`ARSENALE_NONINTERACTIVE=1`, `ARSENALE_SKIP_PREREQS=1`. The extracted bundle ships a
+trimmed `Makefile`, so post-install `make status` / `backup` / `rotate` / `deploy`
+work from the install directory (default `/opt/arsenale/installer`) without the repo.
+
 ## Modes
 
 ### Development Mode


### PR DESCRIPTION
Updates the reference documentation for the three features shipped in the re-released 1.8.4 (merged in #646) that were not yet covered outside the feature-specific guides.

- **installer.md** / **deployment.md** — document the one-command \`tools/installer/install-platform.sh\` bootstrap (curl | bash, no repo clone) and its env-var surface.
- **environment.md** — add the reverse-tunnel transport variables: broker (\`TUNNEL_QUIC_LISTEN_ADDR\`, \`TUNNEL_QUIC_SERVER_CERT/_KEY\`) and agent (\`TUNNEL_TRANSPORT\` = wss|quic|auto, \`TUNNEL_QUIC_SERVER_ADDR/_NAME\`, \`TUNNEL_CA_CERT\`).
- **api-reference.md** — document \`GET /api/gateways/types\` and the \`arsenale gateway types\` CLI command (the shared gateway type catalog).
- **CHANGELOG.md** — add these to the 1.8.4 entry.

Verified env-var names, transport values, and the endpoint/CLI against source (\`tunnel-broker/main.go\`, \`tunnel-agent/config.go\`, \`gatewayruntime\`, \`gateway_types.go\`). Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)